### PR TITLE
add release-plz workflow for automated release management

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,67 @@
+name: Release-plz
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  # Wait for CI to pass before running release-plz
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    # Only run on main branch pushes (not PRs to main)
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Prevent multiple concurrent release-pr jobs
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for changelog generation
+          persist-credentials: false
+          submodules: recursive  # Support submodules if any
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Run release-plz to create/update release PR
+        uses: release-plz/release-plz-action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  # Automatically release when release PR is merged
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    # Only run on main branch pushes
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Prevent concurrent releases
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Run release-plz to create tags and trigger releases
+        uses: release-plz/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Enables automatic version bumping and release PR creation based on conventional commits. The workflow runs on pushes to main and handles both PR creation and actual releases when those PRs are merged.