### PR TITLE
fix(ci): remove conflicting changelog section from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,12 +30,4 @@ changelog_path = "claudecode_rs/CHANGELOG.md"
 git_tag_name = "claudecode-v{{ version }}"
 release = true
 
-[changelog]
-header = """
-# Changelog
-
-All notable changes to this package will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-"""
 


### PR DESCRIPTION
The [changelog] section conflicts with changelog_config pointing to cliff.toml. Release-plz requires using one or the other, not both.