### PR TITLE
fix(ci): properly configure gitignore to avoid release-plz conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-.claude/
+# Claude configuration - ignore most files but keep commit.md
+.claude/settings.json
+.claude/settings.local.json
+.claude/agents/**/*.md
+.claude/commands/**/*.md
 !.claude/commands/commit.md
 
 # Thoughts data directory (created by thoughts init)


### PR DESCRIPTION
Instead of ignoring .claude/ directory and trying to un-ignore files, ignore specific file patterns while keeping commit.md tracked. This resolves the 'uncommitted changes' error in release-plz.