### PR TITLE
feat(pr_comments): add resolution filtering for review comments

### DIFF
--- a/pr_comments/CLAUDE.md
+++ b/pr_comments/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md - pr_comments Tool
+
+## Overview
+The pr_comments tool fetches GitHub PR comments with support for filtering by resolution status on review comments.
+
+## Key Implementation Details
+- Uses hybrid REST + GraphQL approach for resolution filtering
+- Only `get_review_comments` supports resolution filtering
+- Default behavior: show only unresolved comments (breaking change in v0.2.0)
+- `get_all_comments` always includes all review comments regardless of resolution
+
+## Common Commands
+```bash
+# Run tests
+make test
+
+# Check for linting issues
+make check
+
+# Build the tool
+make build
+
+# Install locally
+make install
+```
+
+## Testing Resolution Filtering
+```bash
+# Test with a PR that has resolved comments
+pr_comments review-comments --pr 123  # Shows only unresolved
+pr_comments review-comments --pr 123 --include-resolved  # Shows all
+pr_comments all --pr 123  # Shows all comments (no filtering)
+```
+
+## Architecture Notes
+- GraphQL query runs only when filtering resolved comments (performance optimization)
+- Comment IDs are matched between REST and GraphQL APIs via database_id field
+- Pagination is handled for both REST and GraphQL queries
+- If a comment isn't found in the GraphQL response, it's included by default (fail-open)

--- a/pr_comments/README.md
+++ b/pr_comments/README.md
@@ -1,120 +1,77 @@
 # pr_comments
 
-A tool to fetch GitHub PR comments via CLI and MCP interfaces. Automatically detects PRs from your current git branch or accepts manual PR specification.
+A tool to fetch GitHub PR comments via CLI and MCP interfaces.
 
 ## Installation
 
 ```bash
-# From source
 cd pr_comments
-cargo install --path .
-
-# After release (coming soon)
-# Via homebrew or shell installer from GitHub releases
+make install
 ```
-
-## GitHub Token Setup
-
-Set your GitHub personal access token as an environment variable:
-
-```bash
-export GITHUB_TOKEN=your_github_token
-```
-
-### Required Permissions
-
-- **Classic Personal Access Token**: `repo` scope
-- **Fine-grained Personal Access Token**: `pull-requests: read` permission
 
 ## Usage
 
 ### CLI Mode
 
 ```bash
-# Auto-detect PR from current branch and get all comments
+# Auto-detect PR from current branch
 pr_comments all
 
-# Get all comments for specific PR
+# Specify PR number
 pr_comments all --pr 123
 
-# Get only review comments (code comments)
+# Get only unresolved review comments (default behavior)
 pr_comments review-comments --pr 123
 
-# Get only issue comments (discussion)
+# Include resolved review comments
+pr_comments review-comments --pr 123 --include-resolved
+
+# Get only issue comments (resolution doesn't apply)
 pr_comments issue-comments --pr 123
 
-# List all PRs in the repository
-pr_comments list-prs
-pr_comments list-prs --state closed
-pr_comments list-prs --state all
+# List PRs
+pr_comments list-prs --state open
 ```
+
+### Resolution Filtering (Breaking Change)
+
+**Important**: As of v0.2.0, `review-comments` now defaults to showing only unresolved comments. This is a breaking change from previous versions.
+
+- Review comments can be part of conversation threads that can be marked as resolved
+- By default, resolved comments are filtered out to focus on active discussions
+- Use `--include-resolved` to see all comments including resolved ones
+- This filtering only applies to the `review-comments` command
+- The `all` command always shows all comments regardless of resolution status
 
 ### MCP Mode
 
-Start as an MCP server for AI assistants:
-
 ```bash
-# Via flag
+# Start MCP server
 pr_comments --mcp
 
-# Via subcommand
+# Or
 pr_comments mcp
 ```
 
-#### Using with MCP Inspector
+## Authentication
 
-Test the MCP server with the official MCP Inspector:
+Set the `GITHUB_TOKEN` environment variable:
 
 ```bash
-# Install MCP Inspector (if not already installed)
-npm install -g @modelcontextprotocol/inspector
-
-# Connect to the pr_comments MCP server
-mcp-inspector stdio -- pr_comments mcp
+export GITHUB_TOKEN=your_github_token
 ```
 
-The MCP server follows the official protocol specification including the required 3-step handshake. Compatible with all official MCP clients.
+Note: The token needs the `repo` scope for private repositories.
 
-### Specifying Repository
+## Configuration
 
-If not in a git repository, specify the repository explicitly:
+If not in a git repository, specify the repository:
 
 ```bash
 pr_comments --repo owner/repo all
 ```
 
-## Features
+## Comment Types
 
-- **Auto-detection**: Automatically detects current PR from git branch
-- **Dual Interface**: Works as both CLI tool and MCP server
-- **Complete Coverage**: Fetches both review comments (code) and issue comments (discussion)
-- **Pagination**: Handles large numbers of comments via API pagination
-- **Type Safety**: Full TypeScript-style type definitions for MCP interface
-
-## Development
-
-```bash
-# Check code
-make check
-
-# Run tests
-make test
-
-# Build
-make build
-
-# All checks
-make all
-```
-
-## Architecture
-
-The tool is built using:
-- `octocrab` for GitHub API interactions
-- `git2` for repository detection
-- `universal_tool` framework for CLI/MCP interface generation
-- Async Rust with Tokio runtime
-
-## License
-
-MIT
+- **Review Comments**: Code-specific inline comments on the diff. These can be resolved.
+- **Issue Comments**: General discussion comments on the PR. These cannot be resolved.

--- a/pr_comments/src/lib.rs
+++ b/pr_comments/src/lib.rs
@@ -128,6 +128,8 @@ impl PrComments {
         &self,
         #[universal_tool_param(description = "PR number (auto-detected if not provided)")]
         pr_number: Option<u64>,
+        #[universal_tool_param(description = "Include resolved review comments (defaults to false)")]
+        include_resolved: Option<bool>,
     ) -> Result<Vec<ReviewComment>, ToolError> {
         let pr = self
             .get_pr_number(pr_number)
@@ -138,7 +140,7 @@ impl PrComments {
             github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
                 .map_err(|e| ToolError::new(ErrorCode::Internal, e.to_string()))?;
 
-        client.get_review_comments(pr).await
+        client.get_review_comments(pr, include_resolved).await
             .map_err(|e| {
                 let msg = e.to_string();
                 if msg.contains("401") || msg.contains("403") {

--- a/pr_comments/src/main.rs
+++ b/pr_comments/src/main.rs
@@ -31,6 +31,9 @@ enum Commands {
         /// PR number (auto-detected if not provided)
         #[arg(long)]
         pr: Option<u64>,
+        /// Include resolved review comments (defaults to false)
+        #[arg(long)]
+        include_resolved: bool,
     },
     /// Get issue comments (discussion) for a PR
     IssueComments {
@@ -88,7 +91,7 @@ async fn run_cli(args: Args) -> Result<()> {
                 std::process::exit(1);
             }
         },
-        Commands::ReviewComments { pr } => match tool.get_review_comments(pr).await {
+        Commands::ReviewComments { pr, include_resolved } => match tool.get_review_comments(pr, Some(include_resolved)).await {
             Ok(comments) => println!("{}", serde_json::to_string_pretty(&comments)?),
             Err(e) => {
                 eprintln!("Error: {}", e);

--- a/pr_comments/src/models.rs
+++ b/pr_comments/src/models.rs
@@ -75,3 +75,66 @@ impl From<octocrab::models::issues::Comment> for IssueComment {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphQLResponse<T> {
+    pub data: Option<T>,
+    pub errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphQLError {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequestData {
+    pub repository: Repository,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repository {
+    #[serde(rename = "pullRequest")]
+    pub pull_request: PullRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequest {
+    #[serde(rename = "reviewThreads")]
+    pub review_threads: ReviewThreadConnection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewThreadConnection {
+    pub nodes: Vec<ReviewThread>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: PageInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewThread {
+    pub id: String,
+    #[serde(rename = "isResolved")]
+    pub is_resolved: bool,
+    pub comments: ReviewThreadCommentConnection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewThreadCommentConnection {
+    pub nodes: Vec<ReviewThreadComment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewThreadComment {
+    pub id: String,
+    #[serde(rename = "databaseId")]
+    pub database_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    pub has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    pub end_cursor: Option<String>,
+}


### PR DESCRIPTION
Add ability to filter review comments by resolution status using GraphQL API. The review-comments command now accepts an --include-resolved flag to control whether resolved comments are shown. Uses a hybrid REST+GraphQL approach for optimal performance.

BREAKING CHANGE: review-comments now defaults to showing only unresolved comments. Use --include-resolved to see all comments including resolved ones.