### PR TITLE
Thoughts tool mcp expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "rustc_version",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serial_test",
@@ -3045,6 +3046,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "universal-tool-core 0.2.1",
  "which",
 ]
 

--- a/thoughts_tool/Cargo.toml
+++ b/thoughts_tool/Cargo.toml
@@ -34,6 +34,8 @@ which = "6"
 atomicwrites = "0.4"
 colored = "2"
 regex = "1"
+schemars = "0.8"
+universal-tool-core = { version = "0.2.1", path = "../universal_tool/universal-tool-core", features = ["mcp"] }
 
 # Platform-specific dependencies
 [target.'cfg(unix)'.dependencies]

--- a/thoughts_tool/src/commands/work/mod.rs
+++ b/thoughts_tool/src/commands/work/mod.rs
@@ -1,4 +1,5 @@
 pub mod complete;
 pub mod init;
 pub mod list;
+pub mod open;
 mod utils;

--- a/thoughts_tool/src/commands/work/open.rs
+++ b/thoughts_tool/src/commands/work/open.rs
@@ -1,0 +1,39 @@
+use anyhow::{Result, bail};
+use colored::Colorize;
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use thoughts_tool::workspace::ensure_active_work;
+
+#[derive(Debug, Clone, Copy)]
+pub enum OpenSubdir {
+    Base,
+    Research,
+    Plans,
+    Artifacts,
+}
+
+pub async fn execute(subdir: OpenSubdir) -> Result<()> {
+    let editor = env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let aw = ensure_active_work()?;
+
+    let target: PathBuf = match subdir {
+        OpenSubdir::Base => aw.base.clone(),
+        OpenSubdir::Research => aw.research.clone(),
+        OpenSubdir::Plans => aw.plans.clone(),
+        OpenSubdir::Artifacts => aw.artifacts.clone(),
+    };
+
+    if !target.exists() {
+        bail!("Target directory does not exist: {}", target.display());
+    }
+
+    let status = Command::new(&editor).arg(&target).status()?;
+    if !status.success() {
+        bail!("Editor exited with error");
+    }
+
+    println!("{} Opened {}", "✓".green(), target.display());
+    Ok(())
+}

--- a/thoughts_tool/src/lib.rs
+++ b/thoughts_tool/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod error;
 pub mod git;
+pub mod mcp;
 pub mod mount;
 pub mod platform;
 pub mod utils;
+pub mod workspace;
 
 pub use config::{Config, Mount, SyncStrategy};
 pub use config::{

--- a/thoughts_tool/src/mcp/mod.rs
+++ b/thoughts_tool/src/mcp/mod.rs
@@ -1,0 +1,205 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use universal_tool_core::mcp::ServiceExt;
+use universal_tool_core::prelude::*;
+
+use crate::config::RepoConfigManager;
+use crate::config::extract_org_repo_from_url;
+use crate::utils::validation::validate_simple_filename;
+use crate::workspace::{ActiveWork, ensure_active_work};
+
+// Type definitions
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentType {
+    Research,
+    Plan,
+    Artifact,
+}
+
+impl DocumentType {
+    fn subdir<'a>(&self, aw: &'a ActiveWork) -> &'a std::path::PathBuf {
+        match self {
+            DocumentType::Research => &aw.research,
+            DocumentType::Plan => &aw.plans,
+            DocumentType::Artifact => &aw.artifacts,
+        }
+    }
+
+    fn subdir_name(&self) -> &'static str {
+        match self {
+            DocumentType::Research => "research",
+            DocumentType::Plan => "plans",
+            DocumentType::Artifact => "artifacts",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DocumentInfo {
+    pub path: String,
+    pub doc_type: String,
+    pub size: u64,
+    pub modified: String,
+}
+
+// Tool implementation
+
+#[derive(Clone, Default)]
+pub struct ThoughtsMcpTools;
+
+#[universal_tool_router(mcp(name = "thoughts_tool", version = "0.3.0"))]
+impl ThoughtsMcpTools {
+    /// Write markdown to active work directory (research/plans/artifacts)
+    #[universal_tool(
+        description = "Write markdown to the active work directory",
+        mcp(destructive = false)
+    )]
+    pub async fn write_document(
+        &self,
+        doc_type: DocumentType,
+        filename: String,
+        content: String,
+    ) -> Result<String, ToolError> {
+        // Validate filename
+        validate_simple_filename(&filename).map_err(|e| ToolError::invalid_input(e.to_string()))?;
+
+        // Ensure active work exists
+        let aw =
+            ensure_active_work().map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?;
+
+        // Determine target path
+        let dir = doc_type.subdir(&aw);
+        let target = dir.join(&filename);
+
+        // Atomic write
+        let af =
+            atomicwrites::AtomicFile::new(&target, atomicwrites::OverwriteBehavior::AllowOverwrite);
+        af.write(|f| std::io::Write::write_all(f, content.as_bytes()))
+            .map_err(|e| {
+                ToolError::new(ErrorCode::IoError, format!("Failed to write file: {}", e))
+            })?;
+
+        // Return repo-relative path
+        let repo_rel = format!(
+            "thoughts/active/{}/{}/{}",
+            aw.dir_name,
+            doc_type.subdir_name(),
+            filename
+        );
+        Ok(repo_rel)
+    }
+
+    /// List files in current active work directory
+    #[universal_tool(
+        description = "List files in the current active work directory",
+        mcp(read_only = true, idempotent = true)
+    )]
+    pub async fn list_active_documents(
+        &self,
+        subdir: Option<DocumentType>,
+    ) -> Result<Vec<DocumentInfo>, ToolError> {
+        let aw =
+            ensure_active_work().map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?;
+
+        // Determine which subdirs to scan
+        let sets: Vec<(String, std::path::PathBuf)> = match subdir {
+            Some(d) => vec![(d.subdir_name().to_string(), d.subdir(&aw).clone())],
+            None => vec![
+                ("research".to_string(), aw.research.clone()),
+                ("plans".to_string(), aw.plans.clone()),
+                ("artifacts".to_string(), aw.artifacts.clone()),
+            ],
+        };
+
+        let mut out = Vec::new();
+        for (name, dir) in sets {
+            if !dir.exists() {
+                continue;
+            }
+            for entry in fs::read_dir(&dir).map_err(|e| {
+                ToolError::new(
+                    ErrorCode::IoError,
+                    format!("Failed to read dir {}: {}", dir.display(), e),
+                )
+            })? {
+                let entry = entry.map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?;
+                let meta = entry
+                    .metadata()
+                    .map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?;
+                if meta.is_file() {
+                    let modified = meta
+                        .modified()
+                        .ok()
+                        .and_then(|t| chrono::DateTime::<chrono::Utc>::from(t).into())
+                        .unwrap_or_else(chrono::Utc::now);
+                    let file_name = entry.file_name().to_string_lossy().to_string();
+                    out.push(DocumentInfo {
+                        path: format!("thoughts/active/{}/{}/{}", aw.dir_name, name, file_name),
+                        doc_type: name.clone(),
+                        size: meta.len(),
+                        modified: modified.to_rfc3339(),
+                    });
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// List reference repository directory paths
+    #[universal_tool(
+        description = "List reference repository directory paths (references/org/repo)",
+        mcp(read_only = true, idempotent = true)
+    )]
+    pub async fn list_references(&self) -> Result<Vec<String>, ToolError> {
+        let control_root = crate::git::utils::get_control_repo_root(
+            &std::env::current_dir()
+                .map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?,
+        )
+        .map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?;
+        let mgr = RepoConfigManager::new(control_root);
+        let ds = mgr
+            .load_desired_state()
+            .map_err(|e| ToolError::new(ErrorCode::IoError, e.to_string()))?
+            .ok_or_else(|| {
+                ToolError::new(
+                    universal_tool_core::error::ErrorCode::NotFound,
+                    "No repository configuration found",
+                )
+            })?;
+
+        let mut out = Vec::new();
+        for url in &ds.references {
+            match extract_org_repo_from_url(url) {
+                Ok((org, repo)) => {
+                    out.push(format!("{}/{}/{}", ds.mount_dirs.references, org, repo));
+                }
+                Err(_) => {
+                    // Best-effort fallback for unparseable URLs
+                    out.push(format!("{}/{}", ds.mount_dirs.references, url));
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+// MCP server wrapper
+pub struct ThoughtsMcpServer {
+    tools: std::sync::Arc<ThoughtsMcpTools>,
+}
+universal_tool_core::implement_mcp_server!(ThoughtsMcpServer, tools);
+
+/// Serve MCP over stdio (called from main)
+pub async fn serve_stdio() -> Result<(), Box<dyn std::error::Error>> {
+    let server = ThoughtsMcpServer {
+        tools: std::sync::Arc::new(ThoughtsMcpTools),
+    };
+    let transport = universal_tool_core::mcp::stdio();
+    let svc = server.serve(transport).await?;
+    svc.waiting().await?;
+    Ok(())
+}

--- a/thoughts_tool/src/utils/mod.rs
+++ b/thoughts_tool/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod git;
 pub mod logging;
 pub mod paths;
+pub mod validation;

--- a/thoughts_tool/src/utils/validation.rs
+++ b/thoughts_tool/src/utils/validation.rs
@@ -1,0 +1,70 @@
+use anyhow::{Result, bail};
+use std::path::{Component, Path};
+
+/// Validate a simple filename: no directories, no traversal, not absolute.
+/// Allows [A-Za-z0-9._-] only, must not be empty.
+pub fn validate_simple_filename(filename: &str) -> Result<()> {
+    if filename.trim().is_empty() {
+        bail!("Filename cannot be empty");
+    }
+
+    // Parse as path and check components
+    let p = Path::new(filename);
+    let mut comps = p.components();
+
+    // Reject absolute paths
+    if matches!(
+        comps.next(),
+        Some(Component::RootDir | Component::Prefix(_))
+    ) {
+        bail!("Absolute paths are not allowed");
+    }
+
+    // Must be single component (no directories)
+    if p.components().count() != 1 {
+        bail!("Filename must not contain directories");
+    }
+
+    // Reject special names
+    if filename == "." || filename == ".." {
+        bail!("Invalid filename");
+    }
+
+    // Restrict to safe character set
+    let ok = filename
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if !ok {
+        bail!("Filename contains invalid characters (allowed: A-Z a-z 0-9 . _ -)");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_simple_filename_ok() {
+        for f in ["a.md", "plan-01.md", "notes_v2.md", "R1.TOC"] {
+            assert!(validate_simple_filename(f).is_ok(), "{f}");
+        }
+    }
+
+    #[test]
+    fn test_validate_simple_filename_bad() {
+        for f in [
+            "../x.md",
+            "/abs.md",
+            "a/b.md",
+            " ",
+            "",
+            ".",
+            "..",
+            "name with space.md",
+        ] {
+            assert!(validate_simple_filename(f).is_err(), "{f}");
+        }
+    }
+}

--- a/thoughts_tool/src/workspace/mod.rs
+++ b/thoughts_tool/src/workspace/mod.rs
@@ -1,0 +1,126 @@
+use anyhow::{Context, Result};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use chrono::Datelike;
+use serde_json::json;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::config::{Mount, RepoConfigManager};
+use crate::git::utils::{
+    find_repo_root, get_control_repo_root, get_current_branch, get_remote_url,
+};
+use crate::mount::MountResolver;
+
+/// Paths for the current active work directory
+#[derive(Debug, Clone)]
+pub struct ActiveWork {
+    pub dir_name: String,
+    pub base: PathBuf,
+    pub research: PathBuf,
+    pub plans: PathBuf,
+    pub artifacts: PathBuf,
+}
+
+/// Resolve thoughts root via configured thoughts_mount
+fn resolve_thoughts_root() -> Result<PathBuf> {
+    let control_root = get_control_repo_root(&std::env::current_dir()?)?;
+    let mgr = RepoConfigManager::new(control_root);
+    let ds = mgr.load_desired_state()?.ok_or_else(|| {
+        anyhow::anyhow!("No repository configuration found. Run 'thoughts init'.")
+    })?;
+
+    let tm = ds.thoughts_mount.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No thoughts_mount configured in repository configuration.\n\
+             Add thoughts_mount to .thoughts/config.json and run 'thoughts mount update'."
+        )
+    })?;
+
+    let resolver = MountResolver::new()?;
+    let mount = Mount::Git {
+        url: tm.remote.clone(),
+        subpath: tm.subpath.clone(),
+        sync: tm.sync,
+    };
+
+    resolver
+        .resolve_mount(&mount)
+        .context("Thoughts mount not cloned. Run 'thoughts sync' or 'thoughts mount update' first.")
+}
+
+/// Compute work directory name: ISO week for main/master, branch name otherwise
+fn current_work_dir_name() -> Result<String> {
+    let code_root = find_repo_root(&std::env::current_dir()?)?;
+    let branch = get_current_branch(&code_root)?;
+    if branch == "main" || branch == "master" {
+        let now = chrono::Utc::now().date_naive();
+        let iso = now.iso_week();
+        Ok(format!("{}-W{:02}", iso.year(), iso.week()))
+    } else {
+        Ok(branch)
+    }
+}
+
+/// Ensure active work directory exists with subdirs and manifest
+pub fn ensure_active_work() -> Result<ActiveWork> {
+    let thoughts_root = resolve_thoughts_root()?;
+    let dir_name = current_work_dir_name()?;
+    let base = thoughts_root.join("active").join(&dir_name);
+
+    // Create structure if missing
+    if !base.exists() {
+        fs::create_dir_all(&base).context("Failed to create base work directory")?;
+        fs::create_dir_all(base.join("research")).context("Failed to create research directory")?;
+        fs::create_dir_all(base.join("plans")).context("Failed to create plans directory")?;
+        fs::create_dir_all(base.join("artifacts"))
+            .context("Failed to create artifacts directory")?;
+
+        // Create manifest.json atomically
+        let code_root = find_repo_root(&std::env::current_dir()?)?;
+        let source_repo = get_remote_url(&code_root).unwrap_or_else(|_| "unknown".to_string());
+        let manifest = json!({
+            "source_repo": source_repo,
+            "branch_or_week": dir_name,
+            "started_at": chrono::Utc::now().to_rfc3339(),
+        });
+
+        let manifest_path = base.join("manifest.json");
+        AtomicFile::new(&manifest_path, OverwriteBehavior::AllowOverwrite)
+            .write(|f| f.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes()))
+            .with_context(|| format!("Failed to write manifest at {}", manifest_path.display()))?;
+    } else {
+        // Ensure subdirs exist even if base exists
+        for sub in ["research", "plans", "artifacts"] {
+            let subdir = base.join(sub);
+            if !subdir.exists() {
+                fs::create_dir_all(&subdir)
+                    .with_context(|| format!("Failed to ensure {} directory", sub))?;
+            }
+        }
+        // Ensure manifest exists
+        let manifest_path = base.join("manifest.json");
+        if !manifest_path.exists() {
+            let code_root = find_repo_root(&std::env::current_dir()?)?;
+            let source_repo = get_remote_url(&code_root).unwrap_or_else(|_| "unknown".to_string());
+            let manifest = json!({
+                "source_repo": source_repo,
+                "branch_or_week": dir_name,
+                "started_at": chrono::Utc::now().to_rfc3339(),
+            });
+            AtomicFile::new(&manifest_path, OverwriteBehavior::AllowOverwrite)
+                .write(|f| f.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes()))
+                .with_context(|| {
+                    format!("Failed to write manifest at {}", manifest_path.display())
+                })?;
+        }
+    }
+
+    Ok(ActiveWork {
+        dir_name: dir_name.clone(),
+        base: base.clone(),
+        research: base.join("research"),
+        plans: base.join("plans"),
+        artifacts: base.join("artifacts"),
+    })
+}

--- a/universal_tool/examples/01-cli-simple/Cargo.lock
+++ b/universal_tool/examples/01-cli-simple/Cargo.lock
@@ -911,7 +911,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atty",
  "clap",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/universal_tool/examples/02-cli-advanced-params/Cargo.lock
+++ b/universal_tool/examples/02-cli-advanced-params/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atty",
  "clap",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/universal_tool/examples/03-rest-simple/Cargo.lock
+++ b/universal_tool/examples/03-rest-simple/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "schemars",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/universal_tool/examples/04-rest-idiomatic/Cargo.lock
+++ b/universal_tool/examples/04-rest-idiomatic/Cargo.lock
@@ -1036,7 +1036,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "schemars",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/universal_tool/examples/05-mcp-basic/Cargo.lock
+++ b/universal_tool/examples/05-mcp-basic/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "rmcp",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/universal_tool/examples/06-kitchen-sink/Cargo.lock
+++ b/universal_tool/examples/06-kitchen-sink/Cargo.lock
@@ -1675,7 +1675,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "universal-tool-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "atty",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "universal-tool-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",


### PR DESCRIPTION
## What problem(s) was I solving?

This PR addresses several key issues:

1. **AI Assistant Integration**: No programmatic way for AI assistants (like Claude Desktop) to interact with thoughts_tool functionality - needed MCP server integration to enable AI-driven documentation and workspace management.

2. **Code Duplication**: Workspace management logic (resolving thoughts root, computing work directory names, ensuring directory structure) was being duplicated between different commands. This led to maintenance burden and potential inconsistencies.

3. **Architectural Flaw**: The binary (`src/main.rs`) was declaring its own copies of modules (`config`, `error`, `git`, etc.) instead of re-exporting from the library. This violated Rust best practices for CLI+library projects and caused duplicate compilation.

4. **Missing Developer Convenience**: No quick way to open the active work directory in an editor - developers had to manually navigate or remember paths.

## What user-facing changes did I ship?

1. **MCP Server Mode**: New `thoughts mcp` command runs thoughts_tool as an MCP server for integration with AI assistants. Provides three tools:
   - `write_document` - Write markdown files to active work directory (research/plans/artifacts)
   - `list_active_documents` - List files in active work with optional subdirectory filtering
   - `list_references` - Get paths to reference repositories

2. **Quick Editor Access**: New `thoughts work open` command opens the active work directory in `$EDITOR`, with optional `--subdir` flag to target specific subdirectories (research, plans, or artifacts).

3. **Enhanced Safety**: All file writes through MCP now validate filenames to prevent path traversal attacks and restrict to safe character sets.

## How I implemented it

### MCP Server Integration
- Added `src/mcp/mod.rs` with `ThoughtsMcpTools` implementation using `universal-tool-core` framework
- Each MCP tool returns structured data (repo-relative paths, file metadata with timestamps)
- Atomic file writes using `atomicwrites` crate to prevent partial writes
- Integrated stdio transport for MCP protocol communication

### Workspace Module Extraction
- Created `src/workspace/mod.rs` with `ensure_active_work()` function and `ActiveWork` struct
- Centralized logic for:
  - Resolving thoughts root from repository configuration
  - Computing work directory names (ISO week for main/master, branch name otherwise)
  - Creating directory structure (research/, plans/, artifacts/)
  - Managing manifest.json with repository metadata
- Now shared between MCP tools and existing CLI commands

### Filename Validation
- Added `src/utils/validation.rs` with `validate_simple_filename()` function
- Rejects absolute paths, directory traversal, and unsafe characters
- Restricts to alphanumeric characters plus `.`, `_`, `-`
- Comprehensive test coverage for edge cases

### Binary/Library Architecture Fix
- Removed duplicate module declarations from `src/main.rs`
- Added `pub use thoughts_tool::{config, error, git, mount, platform, utils};` to re-export library modules
- Moved all shared logic to library crate for reuse
- Follows Rust best practices for dual CLI+library crates

### Work Open Command
- Added `src/commands/work/open.rs` with `OpenSubdir` enum for type-safe subdir selection
- Uses `$EDITOR` environment variable (falls back to `vi`)
- Integrates with existing workspace utilities

### Dependencies
- Added `schemars` for JSON schema generation (required by MCP)
- Added `universal-tool-core` with `mcp` feature for MCP server framework

## How to verify it

- [x] Code formatting check passes (`cargo fmt --check`)
- [x] Clippy lints pass with no warnings
- [x] All 60 unit tests pass
- [x] Builds successfully with all features
- [x] Manual: Configure MCP server in Claude Desktop and verify all three tools work
- [x] Manual: Run `thoughts work open` and verify editor opens to correct directory
- [x] Manual: Run `thoughts work open --subdir research` and verify subdirectory targeting
- [x] Manual: Test MCP `write_document` with various filenames including invalid ones
- [x] Manual: Verify atomic writes don't leave partial files on error

## Changelog

Added MCP server integration with workspace utilities and work open command. Fixed binary/library architecture by re-exporting modules. Enhanced filename validation for safe file operations.