### PR TITLE
gpt5_reasoner: handle nested code fences in LLM output parsing + some other stuff

### DIFF
--- a/gpt5_reasoner/src/lib.rs
+++ b/gpt5_reasoner/src/lib.rs
@@ -264,10 +264,7 @@ pub async fn gpt5_reasoner_impl(
                 let is_template_error = matches!(e, ReasonerError::Template(_));
 
                 if is_template_error && attempt < TEMPLATE_RETRIES {
-                    tracing::warn!(
-                        "Template validation failed: {}; retrying optimizer call",
-                        e
-                    );
+                    tracing::warn!("Template validation failed: {}; retrying optimizer call", e);
                     continue;
                 }
 
@@ -513,7 +510,8 @@ mod retry_tests {
     #[test]
     fn test_yaml_error_is_not_template_error() {
         // Create a YAML error by parsing invalid YAML
-        let yaml_result: Result<serde_yaml::Value, _> = serde_yaml::from_str("invalid: yaml: syntax");
+        let yaml_result: Result<serde_yaml::Value, _> =
+            serde_yaml::from_str("invalid: yaml: syntax");
         assert!(yaml_result.is_err());
 
         let yaml_err = ReasonerError::Yaml(yaml_result.unwrap_err());

--- a/gpt5_reasoner/src/lib.rs
+++ b/gpt5_reasoner/src/lib.rs
@@ -205,9 +205,16 @@ fn expand_directories_to_filemeta(directories: &[DirectoryMeta]) -> Result<Vec<F
     Ok(out)
 }
 
-// Helper: convert to absolute path string without resolving symlinks
+// Helper: convert to absolute path string, resolving symlinks when file exists
 fn to_abs_string(p: &str) -> String {
     let path = std::path::Path::new(p);
+
+    // Try to canonicalize first (resolves symlinks, requires file to exist)
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical.to_string_lossy().to_string();
+    }
+
+    // Fallback: just make it absolute without resolving symlinks
     if path.is_absolute() {
         path.to_string_lossy().to_string()
     } else {

--- a/gpt5_reasoner/src/lib.rs
+++ b/gpt5_reasoner/src/lib.rs
@@ -282,7 +282,12 @@ pub async fn gpt5_reasoner_impl(
     dedup_files_in_place(&mut files);
     let after = files.len();
     if before != after {
-        tracing::debug!("Deduplicated files post-normalization: {} -> {} ({} removed)", before, after, before - after);
+        tracing::debug!(
+            "Deduplicated files post-normalization: {} -> {} ({} removed)",
+            before,
+            after,
+            before - after
+        );
     }
 
     tracing::info!("Pre-validating {} file(s) before optimizer", files.len());
@@ -961,8 +966,8 @@ mod directory_expansion_tests {
 #[cfg(test)]
 mod pre_validation_tests {
     use super::*;
-    use tempfile::TempDir;
     use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_to_abs_string_makes_relative_absolute() {
@@ -981,8 +986,14 @@ mod pre_validation_tests {
     #[test]
     fn test_normalize_paths_in_place_skips_embedded() {
         let mut files = vec![
-            FileMeta { filename: "plan_structure.md".into(), description: "embedded".into() },
-            FileMeta { filename: "a.rs".into(), description: "code".into() },
+            FileMeta {
+                filename: "plan_structure.md".into(),
+                description: "embedded".into(),
+            },
+            FileMeta {
+                filename: "a.rs".into(),
+                description: "code".into(),
+            },
         ];
         normalize_paths_in_place(&mut files);
         assert_eq!(files[0].filename, "plan_structure.md");
@@ -1002,8 +1013,14 @@ mod pre_validation_tests {
         std::env::set_current_dir(td.path()).unwrap();
 
         let mut files = vec![
-            FileMeta { filename: "dup.rs".into(), description: "rel".into() },
-            FileMeta { filename: abs.clone(), description: "abs".into() },
+            FileMeta {
+                filename: "dup.rs".into(),
+                description: "rel".into(),
+            },
+            FileMeta {
+                filename: abs.clone(),
+                description: "abs".into(),
+            },
         ];
 
         // Need to normalize first for dedup to work correctly
@@ -1013,7 +1030,11 @@ mod pre_validation_tests {
         // Restore original directory
         std::env::set_current_dir(orig_dir).unwrap();
 
-        assert_eq!(files.len(), 1, "duplicates should be removed after normalization");
+        assert_eq!(
+            files.len(),
+            1,
+            "duplicates should be removed after normalization"
+        );
         assert!(files[0].filename.ends_with("dup.rs"));
         assert!(std::path::Path::new(&files[0].filename).is_absolute());
     }

--- a/gpt5_reasoner/src/optimizer/parser.rs
+++ b/gpt5_reasoner/src/optimizer/parser.rs
@@ -22,24 +22,305 @@ pub struct OptimizerOutput {
     pub xml_template: String,
 }
 
+/// Scanning strategy for collecting closing fence candidates
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum CandidateScanMode {
+    /// Collect all closing fences greedily without stopping on inner language-tagged openers.
+    /// Use for XML where inner content may have multiple language-tagged blocks.
+    GreedyCollectAll,
+    /// Stop collecting when encountering a language-tagged opener after finding at least one closer.
+    /// Use for YAML to prevent spanning multiple consecutive blocks.
+    StopOnLangOpenerAfterFirstCloser,
+}
+
+/// Collect all potential closing fence positions for validation.
+///
+/// Returns positions where valid closing fences could be (lines with ≥N backticks and only whitespace after).
+/// Allows up to 3 leading spaces for markdown compatibility.
+///
+/// Mode behavior:
+/// - GreedyCollectAll: Never stops on inner openers, collects all closers up to search_end
+/// - StopOnLangOpenerAfterFirstCloser: Stops when hitting a language-tagged opener after finding a closer
+fn collect_closing_candidates(
+    s: &str,
+    start: usize,
+    fence_len: usize,
+    search_end: usize,
+    mode: CandidateScanMode,
+) -> Vec<usize> {
+    let mut candidates = Vec::new();
+    let mut pos = start;
+    let mut seen_closer = false;
+
+    for line in s[start..search_end].split_inclusive('\n') {
+        let line_start = pos;
+        pos += line.len();
+
+        // Allow up to 3 leading spaces (markdown spec)
+        let trimmed_leading = line.trim_start_matches(' ');
+        let leading_spaces = line.len() - trimmed_leading.len();
+        if leading_spaces > 3 {
+            continue;
+        }
+
+        let trimmed = trimmed_leading.trim_end();
+        if !trimmed.starts_with('`') {
+            continue;
+        }
+
+        let tick_count = trimmed.chars().take_while(|&c| c == '`').count();
+        if tick_count < 3 {
+            continue;
+        }
+
+        let after_ticks = &trimmed[tick_count..];
+        let has_lang_tag = !after_ticks.trim().is_empty();
+
+        if has_lang_tag {
+            // This is an opening fence
+            // In conservative mode, stop collecting if we've already found a closer
+            if mode == CandidateScanMode::StopOnLangOpenerAfterFirstCloser && seen_closer {
+                break;
+            }
+            // In greedy mode, continue collecting - don't stop on inner openers
+        } else if tick_count >= fence_len {
+            // This is a potential closing fence
+            candidates.push(line_start);
+            seen_closer = true;
+        }
+    }
+
+    candidates
+}
+
+/// Extract a fenced code block anchored to a specific label, handling nested fences correctly.
+///
+/// Strategy (based on GPT-5 recommendation):
+/// 1. Find the label and opening fence with N backticks
+/// 2. Collect ALL closing fence candidates (≥N backticks, only whitespace after)
+/// 3. Return the last candidate as a heuristic
+///
+/// For XML blocks, the caller (parse_optimizer_output) will validate candidates contain
+/// required GROUP markers and pick the first valid one.
+fn extract_fenced_block_fence_aware(s: &str, label: &str, lang: &str) -> Option<String> {
+    // 1. Find label anchor
+    let anchor_pos = s.find(label)?;
+    let tail = &s[anchor_pos..];
+
+    // 2. Scan lines for opening fence
+    let mut char_offset = anchor_pos;
+    let mut open_fence_end: Option<usize> = None;
+    let mut fence_len = 0;
+
+    for line in tail.split_inclusive('\n') {
+        char_offset += line.len();
+
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('`') {
+            continue;
+        }
+
+        // Count consecutive backticks
+        let tick_count = trimmed.chars().take_while(|&c| c == '`').count();
+        if tick_count < 3 {
+            continue;
+        }
+
+        // Check for language tag after backticks
+        let after_ticks = trimmed[tick_count..].trim_start();
+        let first_word = after_ticks.split_whitespace().next().unwrap_or("");
+
+        if first_word.eq_ignore_ascii_case(lang) {
+            // Found opening fence
+            open_fence_end = Some(char_offset); // Content starts after this line
+            fence_len = tick_count;
+            break;
+        }
+    }
+
+    let content_start = open_fence_end?;
+
+    // 3. Determine search boundary (stop at next label if present)
+    let next_label_pos = s[content_start..]
+        .find("FILE_GROUPING")
+        .or_else(|| s[content_start..].find("OPTIMIZED_TEMPLATE"))
+        .map(|offset| content_start + offset);
+
+    let search_end = next_label_pos.unwrap_or(s.len());
+
+    // 4. Collect closing fence candidates conservatively (stop on opener after closer)
+    let candidates = collect_closing_candidates(
+        s,
+        content_start,
+        fence_len,
+        search_end,
+        CandidateScanMode::StopOnLangOpenerAfterFirstCloser,
+    );
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // 5. Return FIRST candidate (the closer for the first block, not spanning multiple)
+    let close_start = *candidates.first()?;
+
+    // 6. Extract content between fences
+    let content = &s[content_start..close_start];
+    Some(content.to_string())
+}
+
+/// Count fence occurrences for diagnostic logging
+fn log_fence_stats(raw: &str) {
+    let triple_xml = raw.matches("```xml").count();
+    let quad_xml = raw.matches("````xml").count();
+    let triple_yaml = raw.matches("```yaml").count();
+    let quad_yaml = raw.matches("````yaml").count();
+
+    // Bare triple fences (without language tag) that might be closers or inner fences
+    let bare_triple = raw
+        .lines()
+        .filter(|line| {
+            let t = line.trim();
+            t.starts_with("```")
+                && t.chars().take_while(|&c| c == '`').count() == 3
+                && t[3..].trim().is_empty()
+        })
+        .count();
+
+    tracing::debug!(
+        "Fence stats: yaml(3:{}, 4+:{}), xml(3:{}, 4+:{}), bare_triple_closers:{}",
+        triple_yaml,
+        quad_yaml,
+        triple_xml,
+        quad_xml,
+        bare_triple
+    );
+
+    // Warn if multiple fences detected - indicates potential nesting
+    if triple_xml + quad_xml > 1 || triple_yaml + quad_yaml > 1 {
+        tracing::warn!(
+            "Multiple fenced blocks detected; nested fences may be present (yaml: {}, xml: {})",
+            triple_yaml + quad_yaml,
+            triple_xml + quad_xml
+        );
+    }
+}
+
+/// Extract XML with validation: try each closing fence candidate until we find one
+/// that contains all required GROUP markers.
+fn extract_xml_with_validation(s: &str, label: &str, groups: &FileGrouping) -> Option<String> {
+    // 1. Find label anchor and opening fence
+    let anchor_pos = s.find(label)?;
+    let tail = &s[anchor_pos..];
+
+    let mut char_offset = anchor_pos;
+    let mut open_fence_end: Option<usize> = None;
+    let mut fence_len = 0;
+
+    for line in tail.split_inclusive('\n') {
+        char_offset += line.len();
+
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('`') {
+            continue;
+        }
+
+        let tick_count = trimmed.chars().take_while(|&c| c == '`').count();
+        if tick_count < 3 {
+            continue;
+        }
+
+        let after_ticks = trimmed[tick_count..].trim_start();
+        let first_word = after_ticks.split_whitespace().next().unwrap_or("");
+
+        if first_word.eq_ignore_ascii_case("xml") {
+            open_fence_end = Some(char_offset);
+            fence_len = tick_count;
+            break;
+        }
+    }
+
+    let content_start = open_fence_end?;
+
+    // 2. Determine search boundary
+    let next_label_pos = s[content_start..]
+        .find("FILE_GROUPING")
+        .or_else(|| s[content_start..].find("OPTIMIZED_TEMPLATE"))
+        .map(|offset| content_start + offset);
+
+    let search_end = next_label_pos.unwrap_or(s.len());
+
+    // 3. Collect all candidates greedily (don't stop on inner language-tagged openers)
+    let candidates = collect_closing_candidates(
+        s,
+        content_start,
+        fence_len,
+        search_end,
+        CandidateScanMode::GreedyCollectAll,
+    );
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    tracing::debug!("Found {} XML closing fence candidates", candidates.len());
+
+    // 4. Validate each candidate in order - pick first that has all GROUP markers
+    for (idx, &close_start) in candidates.iter().enumerate() {
+        let xml_candidate = &s[content_start..close_start];
+
+        // Check if all GROUP markers are present
+        let all_markers_present = groups.file_groups.iter().all(|g| {
+            let marker = format!("<!-- GROUP: {} -->", g.name);
+            xml_candidate.contains(&marker)
+        });
+
+        if all_markers_present {
+            tracing::debug!(
+                "Candidate {} (of {}) passed validation (length: {} chars)",
+                idx + 1,
+                candidates.len(),
+                xml_candidate.len()
+            );
+            return Some(xml_candidate.to_string());
+        } else {
+            tracing::debug!(
+                "Candidate {} (of {}) failed validation (length: {} chars)",
+                idx + 1,
+                candidates.len(),
+                xml_candidate.len()
+            );
+        }
+    }
+
+    // 5. Fallback: use last candidate even if it doesn't validate
+    // (will fail later with helpful error message)
+    tracing::warn!("No candidates passed validation; using last candidate as fallback");
+    let close_start = *candidates.last()?;
+    Some(s[content_start..close_start].to_string())
+}
+
 pub fn parse_optimizer_output(raw: &str) -> Result<OptimizerOutput> {
+    // Log fence statistics for debugging
+    log_fence_stats(raw);
+
     // Clean up common formatting issues
     let cleaned = raw
         .replace("**FILE_GROUPING**", "FILE_GROUPING")
         .replace("**OPTIMIZED_TEMPLATE**", "OPTIMIZED_TEMPLATE");
 
-    // 1) Try to extract fenced yaml
-    let yaml = extract_fenced_block(&cleaned, "yaml")
+    // Extract YAML with fence-aware extraction
+    let yaml = extract_fenced_block_fence_aware(&cleaned, "FILE_GROUPING", "yaml")
         .or_else(|| extract_yaml_by_anchor(&cleaned))
         .ok_or_else(|| ReasonerError::Template("Could not find YAML FILE_GROUPING".into()))?;
 
     let groups: FileGrouping = serde_yaml::from_str(&yaml)?;
 
-    // 2) Extract fenced xml
-    let xml = extract_fenced_block(&cleaned, "xml")
+    // Extract XML with validation - tries each candidate until one passes
+    let xml = extract_xml_with_validation(&cleaned, "OPTIMIZED_TEMPLATE", &groups)
         .ok_or_else(|| ReasonerError::Template("Could not find XML OPTIMIZED_TEMPLATE".into()))?;
 
-    // 3) Validate markers for each group
+    // Validate GROUP markers (should pass now, but keep for safety)
     for g in &groups.file_groups {
         let marker = format!("<!-- GROUP: {} -->", g.name);
         if !xml.contains(&marker) {
@@ -65,16 +346,9 @@ pub fn parse_optimizer_output(raw: &str) -> Result<OptimizerOutput> {
     })
 }
 
-fn extract_fenced_block(s: &str, lang: &str) -> Option<String> {
-    let re = Regex::new(&format!(r"(?s)```{}\s*(.*?)```", regex::escape(lang))).ok()?;
-    re.captures(s)
-        .and_then(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string())
-}
-
 fn extract_yaml_by_anchor(s: &str) -> Option<String> {
-    // simple heuristic: capture from "file_groups:" until next fenced block or end
-    let re = Regex::new(r"(?s)(file_groups:\s.*?)(```|$)").ok()?;
+    // simple heuristic: capture from "file_groups:" until next fenced block, label, or end
+    let re = Regex::new(r"(?s)(file_groups:\s.*?)(```|FILE_GROUPING|OPTIMIZED_TEMPLATE|$)").ok()?;
     re.captures(s)
         .and_then(|cap| cap.get(1))
         .map(|m| m.as_str().to_string())
@@ -88,6 +362,7 @@ mod tests {
     fn test_valid_output_with_fenced_blocks() {
         let raw = r#"Here's the optimized output:
 
+FILE_GROUPING
 ```yaml
 file_groups:
   - name: core_logic
@@ -104,6 +379,7 @@ file_groups:
 
 And the template:
 
+OPTIMIZED_TEMPLATE
 ```xml
 <codebase>
   <context>
@@ -126,13 +402,15 @@ That should work!"#;
 
     #[test]
     fn test_missing_group_marker_error() {
-        let raw = r#"```yaml
+        let raw = r#"FILE_GROUPING
+```yaml
 file_groups:
   - name: missing_marker
     files:
       - src/lib.rs
 ```
 
+OPTIMIZED_TEMPLATE
 ```xml
 <codebase>
   <!-- No marker for missing_marker group -->
@@ -150,13 +428,15 @@ file_groups:
 
     #[test]
     fn test_yaml_missing_fields() {
-        let raw = r#"```yaml
+        let raw = r#"FILE_GROUPING
+```yaml
 file_groups:
   - purpose: Missing name field
     files:
       - src/lib.rs
 ```
 
+OPTIMIZED_TEMPLATE
 ```xml
 <codebase>
   <!-- GROUP: something -->
@@ -175,6 +455,8 @@ file_groups:
     #[test]
     fn test_multiple_code_blocks_first_wins() {
         let raw = r#"First attempt:
+
+FILE_GROUPING
 ```yaml
 file_groups:
   - name: first
@@ -189,6 +471,7 @@ file_groups:
 ```
 
 Template:
+OPTIMIZED_TEMPLATE
 ```xml
 <!-- GROUP: first -->
 ```"#;
@@ -202,11 +485,13 @@ Template:
     fn test_fallback_yaml_extraction() {
         let raw = r#"Here's the output without fenced blocks:
 
+FILE_GROUPING
 file_groups:
   - name: fallback_test
     files:
       - test.rs
 
+OPTIMIZED_TEMPLATE
 ```xml
 <codebase>
   <!-- GROUP: fallback_test -->
@@ -238,7 +523,8 @@ file_groups:
 
     #[test]
     fn test_no_xml_found_error() {
-        let raw = r#"```yaml
+        let raw = r#"FILE_GROUPING
+```yaml
 file_groups:
   - name: test
     files: [test.rs]
@@ -256,12 +542,12 @@ But no XML template!"#;
     }
 
     #[test]
-    fn test_extract_fenced_block() {
-        let content = "```rust\nfn main() {}\n```";
-        let result = extract_fenced_block(content, "rust");
+    fn test_extract_fenced_block_fence_aware_simple_case() {
+        let content = "LABEL\n```rust\nfn main() {}\n```";
+        let result = extract_fenced_block_fence_aware(content, "LABEL", "rust");
         assert_eq!(result, Some("fn main() {}\n".to_string()));
 
-        let no_match = extract_fenced_block(content, "python");
+        let no_match = extract_fenced_block_fence_aware(content, "LABEL", "python");
         assert!(no_match.is_none());
     }
 
@@ -315,5 +601,167 @@ file_groups:
         // Should parse successfully despite markdown formatting
         let result = parse_optimizer_output(raw).unwrap();
         assert_eq!(result.groups.file_groups.len(), 1);
+    }
+
+    #[test]
+    fn test_nested_triple_fences_inside_triple_xml() {
+        let raw = r#"
+FILE_GROUPING
+```yaml
+file_groups:
+  - name: test
+    files: [a.rs]
+```
+
+OPTIMIZED_TEMPLATE
+```xml
+<primary_task>
+User prompt with code example:
+
+```
+fn main() {
+    println!("hello");
+}
+```
+
+More content after example...
+</primary_task>
+
+<codebase>
+  <!-- GROUP: test -->
+</codebase>
+```
+"#;
+
+        let result = parse_optimizer_output(raw);
+        assert!(result.is_ok(), "Parser should handle nested triple fences");
+
+        let parsed = result.unwrap();
+        assert!(parsed.xml_template.contains("<!-- GROUP: test -->"));
+        assert!(
+            parsed.xml_template.contains("fn main()"),
+            "Should include content after nested fence"
+        );
+    }
+
+    #[test]
+    fn test_outer_four_backticks_with_inner_triple() {
+        let raw = r#"
+FILE_GROUPING
+````yaml
+file_groups:
+  - name: demo
+    files: [x.rs]
+````
+
+OPTIMIZED_TEMPLATE
+````xml
+<note>
+Inner triple fences are safe:
+```
+code example
+```
+No collision!
+</note>
+<!-- GROUP: demo -->
+````
+"#;
+
+        let result = parse_optimizer_output(raw);
+        assert!(
+            result.is_ok(),
+            "Parser should support 4+ backtick outer fences"
+        );
+
+        let parsed = result.unwrap();
+        assert!(parsed.xml_template.contains("<!-- GROUP: demo -->"));
+        assert!(parsed.xml_template.contains("No collision!"));
+    }
+
+    #[test]
+    fn test_label_anchoring_ignores_earlier_fences() {
+        let raw = r#"
+Here's an example of how to format the output:
+
+```yaml
+# This is NOT the FILE_GROUPING
+example: value
+```
+
+Now here's the actual output:
+
+FILE_GROUPING
+```yaml
+file_groups:
+  - name: real
+    files: [test.rs]
+```
+
+OPTIMIZED_TEMPLATE
+```xml
+<!-- GROUP: real -->
+```
+"#;
+
+        let result = parse_optimizer_output(raw);
+        assert!(
+            result.is_ok(),
+            "Label anchoring should ignore earlier example blocks"
+        );
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.groups.file_groups[0].name, "real");
+        assert!(!parsed.xml_template.contains("example: value"));
+    }
+
+    #[test]
+    fn test_xml_mixed_bare_and_lang_tagged_inner_blocks() {
+        // This test ensures we don't break early when XML contains multiple language-tagged blocks
+        let raw = r#"
+FILE_GROUPING
+```yaml
+file_groups:
+  - name: mix
+    files: [a.rs]
+```
+
+OPTIMIZED_TEMPLATE
+```xml
+<primary_task>
+Example with bare fenced code:
+
+```
+bare fenced code
+```
+
+And a Python example:
+
+```python
+print("hi")
+```
+
+And YAML config:
+
+```yaml
+key: value
+```
+
+All before the marker!
+</primary_task>
+<!-- GROUP: mix -->
+```
+"#;
+
+        let result = parse_optimizer_output(raw);
+        assert!(
+            result.is_ok(),
+            "Parser should not stop at inner language-tagged openers (python, yaml)"
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.xml_template.contains("<!-- GROUP: mix -->"));
+        assert!(parsed.xml_template.contains("bare fenced code"));
+        assert!(parsed.xml_template.contains("print(\"hi\")"));
+        assert!(parsed.xml_template.contains("key: value"));
+        assert!(parsed.xml_template.contains("All before the marker!"));
     }
 }


### PR DESCRIPTION
## What problem(s) was I solving?

**1. Nested code fence parsing failure**

The gpt5_reasoner's LLM output parser would fail when the optimizer's response contained nested code fences. This happened when user prompts included code examples that got embedded in the XML template - the parser would terminate early at the first closing fence it found, cutting off the template before required GROUP markers and causing "Template missing marker" validation errors.

The root cause was using simple regex extraction (`(?s)```xml\s*(.*?)````) which greedily matches to the first closing fence, even if that fence is part of nested content inside the XML block.

**2. Slow failure on missing/invalid files**

When users provided non-existent or unreadable files, the tool would proceed through the expensive optimizer call (30+ seconds) before failing during file reading. This wasted time and API credits.

**3. Confusing MCP tool interface**

The original `optimize_and_execute` method name and sparse parameter descriptions made it unclear what the tool does and how to use it effectively from MCP clients like Claude Code.

## What user-facing changes did I ship?

**Robust nested fence handling**
- gpt5_reasoner now correctly parses LLM output containing nested code fences (e.g., user prompts with Python/Rust/YAML examples inside the XML template)
- Automatic retry on template validation failures (up to 3 attempts with 900ms delay between retries)
- Enhanced error messages include fence statistics and truncated raw output for easier debugging

**Fail-fast file validation (31s saved on errors)**
- Files are validated for existence, readability, and UTF-8 encoding BEFORE calling the optimizer
- Automatic path normalization to absolute paths prevents confusion between relative/absolute duplicates
- Improved deduplication with diagnostic logging showing how many duplicates were removed

**Clearer MCP interface**
- Renamed tool from `optimize_and_execute` to `request` for better semantic clarity
- Added comprehensive parameter descriptions explaining prompt types, file/directory handling
- More user-friendly tool description positioning it as a "super smart comrade"

## How I implemented it

**1. Mode-based fence candidate collection (`optimizer/parser.rs`)**

Added `CandidateScanMode` enum with two strategies:
- `GreedyCollectAll`: For XML blocks - continues collecting all closing fence candidates without stopping on inner language-tagged openers (e.g., ```python, ```yaml inside the XML)
- `StopOnLangOpenerAfterFirstCloser`: For YAML blocks - conservatively stops to prevent spanning multiple consecutive blocks

**2. Multi-candidate validation approach**

Replaced simple regex extraction with a 3-phase process:
1. **Label anchoring**: Find the label (FILE_GROUPING/OPTIMIZED_TEMPLATE) then scan for opening fence with N backticks
2. **Candidate collection**: Collect all potential closing fences (≥N backticks, only whitespace after, allowing up to 3 leading spaces per markdown spec)
3. **Validation**: For XML, try each candidate in order until finding one containing all required GROUP markers

**3. Layer 3 retry for template validation (`lib.rs`)**

Added retry loop wrapping the optimizer call:
- Retries only Template validation errors (not YAML parse errors or other failures)
- 3 total attempts with 900ms delay between retries
- Complements existing Layer 2 network retry in `optimizer/mod.rs`

**4. Early file validation pipeline (`lib.rs`)**

Added three helper functions called before optimizer:
- `normalize_paths_in_place()`: Convert all relative paths to absolute (skips embedded `plan_structure.md`)
- `dedup_files_in_place()`: Remove duplicates by normalized path with diagnostic logging
- `precheck_files()`: Validate existence, readability, and UTF-8 encoding (fail-fast)

**5. MCP interface refactor (`lib.rs`)**

- Changed `#[universal_tool_router]` to use only MCP (removed unused CLI)
- Renamed method to `request` with user-friendly description
- Reordered parameters (prompt first, directories/files/prompt_type following)
- Added detailed descriptions for each parameter explaining usage patterns

**6. Comprehensive test coverage**

Added 14 new tests covering:
- Nested triple fences inside triple-fence XML blocks
- 4-backtick outer fences with inner triple-backtick examples
- Label anchoring ignoring earlier example blocks
- Mixed bare and language-tagged inner blocks (python, yaml, etc.)
- Retry behavior for template vs YAML errors
- Path normalization (relative→absolute, deduplication)
- File validation (missing files, non-UTF8, empty files)

## How to verify it

- [x] All new parser tests pass (nested fences, mixed blocks, validation)
- [x] Retry logic tests pass (distinguishes Template vs YAML errors)
- [x] File validation tests pass (missing files, non-UTF8, deduplication)
- [x] Existing tests still pass (55 tests total)
- [x] Code formatting and clippy checks pass
