### PR TITLE
feat(claudecode_rs)!: update SDK API for current Claude CLI flags

### DIFF
--- a/claudecode_rs/examples/mcp.rs
+++ b/claudecode_rs/examples/mcp.rs
@@ -9,11 +9,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut servers = HashMap::new();
     servers.insert(
         "calculator".to_string(),
-        MCPServer {
-            command: "npx".to_string(),
-            args: vec!["@modelcontextprotocol/server-calculator".to_string()],
-            env: None,
-        },
+        MCPServer::stdio(
+            "npx",
+            vec!["@modelcontextprotocol/server-calculator".to_string()],
+        ),
     );
 
     let mcp_config = MCPConfig {

--- a/claudecode_rs/examples/streaming.rs
+++ b/claudecode_rs/examples/streaming.rs
@@ -8,7 +8,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = SessionConfig::builder("Write a haiku about Rust programming")
         .output_format(OutputFormat::StreamingJson)
-        .max_turns(1)
         .build()?;
 
     let mut session = client.launch(config).await?;

--- a/claudecode_rs/examples/streaming_debug.rs
+++ b/claudecode_rs/examples/streaming_debug.rs
@@ -13,7 +13,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = SessionConfig::builder("Write a haiku about Rust programming")
         .output_format(OutputFormat::StreamingJson)
-        .max_turns(1)
         .verbose(true) // Ensure verbose is on
         .build()?;
 

--- a/claudecode_rs/src/client.rs
+++ b/claudecode_rs/src/client.rs
@@ -46,7 +46,13 @@ impl Client {
             .as_ref()
             .map(|dir| expand_tilde(dir.to_str().unwrap_or("")));
 
-        let process = ProcessHandle::spawn(&self.claude_path, args, working_dir.as_deref()).await?;
+        let process = ProcessHandle::spawn(
+            &self.claude_path,
+            args,
+            working_dir.as_deref(),
+            config.env.as_ref(),
+        )
+        .await?;
 
         // Store the temp file in the session to keep it alive
         let mut session = Session::new(config, process).await?;
@@ -62,6 +68,24 @@ impl Client {
         session.wait().await
     }
 
+    /// Probe the CLI for supported capabilities.
+    ///
+    /// This runs `claude --help` and parses the output to detect supported flags.
+    /// Useful for validating SDK compatibility with the installed CLI version.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let client = Client::new().await?;
+    /// let caps = client.probe_cli().await?;
+    ///
+    /// if caps.supports("--permission-mode") {
+    ///     println!("Permission mode is supported");
+    /// }
+    /// ```
+    pub async fn probe_cli(&self) -> Result<crate::probe::CliCapabilities> {
+        crate::probe::probe_cli(&self.claude_path).await
+    }
+
     async fn build_args(
         &self,
         config: &SessionConfig,
@@ -72,59 +96,136 @@ impl Client {
         // Add print flag for non-interactive mode
         args.push("--print".to_string());
 
-        // Add query
-        args.push(config.query.clone());
-
-        // Add optional arguments
-        if let Some(ref session_id) = config.session_id {
-            args.push("--resume".to_string());
-            args.push(session_id.clone());
-        }
-
+        // Models
         if let Some(model) = config.model {
             args.push("--model".to_string());
             args.push(model.to_string());
         }
+        if let Some(model) = config.fallback_model {
+            args.push("--fallback-model".to_string());
+            args.push(model.to_string());
+        }
 
+        // Formats
         args.push("--output-format".to_string());
         args.push(config.output_format.to_string());
+        if let Some(ref format) = config.input_format {
+            args.push("--input-format".to_string());
+            args.push(format.to_string());
+        }
 
-        // Handle MCP config
+        // MCP config
         if let Some(ref mcp) = config.mcp_config {
             let temp_file = self.write_mcp_config(mcp).await?;
             args.push("--mcp-config".to_string());
             args.push(temp_file.path().to_string_lossy().to_string());
             mcp_file = Some(temp_file);
         }
-
-        if let Some(ref tool) = config.permission_prompt_tool {
-            args.push("--permission-prompt-tool".to_string());
-            args.push(tool.clone());
+        if config.strict_mcp_config {
+            args.push("--strict-mcp-config".to_string());
         }
 
-        if let Some(turns) = config.max_turns {
-            args.push("--max-turns".to_string());
-            args.push(turns.to_string());
+        // Permissions
+        if let Some(ref mode) = config.permission_mode {
+            args.push("--permission-mode".to_string());
+            args.push(mode.to_string());
+        }
+        if config.allow_dangerously_skip_permissions {
+            args.push("--allow-dangerously-skip-permissions".to_string());
+        }
+        if config.dangerously_skip_permissions {
+            args.push("--dangerously-skip-permissions".to_string());
         }
 
+        // Prompts
         if let Some(ref prompt) = config.system_prompt {
             args.push("--system-prompt".to_string());
             args.push(prompt.clone());
         }
-
         if let Some(ref prompt) = config.append_system_prompt {
             args.push("--append-system-prompt".to_string());
             args.push(prompt.clone());
         }
 
+        // Tools
+        if let Some(ref tools) = config.tools {
+            args.push("--tools".to_string());
+            args.push(tools.join(","));
+        }
         if let Some(ref tools) = config.allowed_tools {
             args.push("--allowedTools".to_string());
             args.push(tools.join(","));
         }
-
         if let Some(ref tools) = config.disallowed_tools {
             args.push("--disallowedTools".to_string());
             args.push(tools.join(","));
+        }
+
+        // Output shaping
+        if let Some(ref schema) = config.json_schema {
+            args.push("--json-schema".to_string());
+            args.push(schema.clone());
+        }
+        if config.include_partial_messages {
+            args.push("--include-partial-messages".to_string());
+        }
+        if config.replay_user_messages {
+            args.push("--replay-user-messages".to_string());
+        }
+
+        // Configuration
+        if let Some(ref settings) = config.settings {
+            args.push("--settings".to_string());
+            args.push(settings.clone());
+        }
+        if let Some(ref sources) = config.setting_sources {
+            args.push("--setting-sources".to_string());
+            args.push(sources.join(","));
+        }
+
+        // Directories and plugins (repeatable flags)
+        for dir in &config.additional_dirs {
+            let expanded = expand_tilde(dir.to_string_lossy().as_ref());
+            let path = tokio::fs::canonicalize(&expanded).await.unwrap_or(expanded);
+            args.push("--add-dir".to_string());
+            args.push(path.to_string_lossy().to_string());
+        }
+        for dir in &config.plugin_dirs {
+            let expanded = expand_tilde(dir.to_string_lossy().as_ref());
+            let path = tokio::fs::canonicalize(&expanded).await.unwrap_or(expanded);
+            args.push("--plugin-dir".to_string());
+            args.push(path.to_string_lossy().to_string());
+        }
+        if config.ide {
+            args.push("--ide".to_string());
+        }
+
+        // Advanced
+        if let Some(ref agents) = config.agents {
+            args.push("--agents".to_string());
+            args.push(agents.clone());
+        }
+        if config.debug {
+            args.push("--debug".to_string());
+            if let Some(ref filter) = config.debug_filter {
+                args.push(filter.clone());
+            }
+        }
+
+        // Session semantics
+        if let Some(ref id) = config.resume_session_id {
+            args.push("--resume".to_string());
+            args.push(id.clone());
+        }
+        if let Some(ref id) = config.explicit_session_id {
+            args.push("--session-id".to_string());
+            args.push(id.clone());
+        }
+        if config.continue_last_session {
+            args.push("--continue".to_string());
+        }
+        if config.fork_session {
+            args.push("--fork-session".to_string());
         }
 
         // Auto-add verbose flag for streaming JSON or if explicitly requested
@@ -132,10 +233,9 @@ impl Client {
             args.push("--verbose".to_string());
         }
 
-        if let Some(ref instructions) = config.custom_instructions {
-            args.push("--custom-instructions".to_string());
-            args.push(instructions.clone());
-        }
+        // Always add -- separator before query to protect dash-prefixed queries
+        args.push("--".to_string());
+        args.push(config.query.clone());
 
         Ok((args, mcp_file))
     }
@@ -145,5 +245,242 @@ impl Client {
         let json = serde_json::to_string_pretty(config)?;
         fs::write(temp_file.path(), json).await?;
         Ok(temp_file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{InputFormat, OutputFormat, PermissionMode};
+
+    fn create_test_client() -> Client {
+        Client {
+            claude_path: PathBuf::from("/usr/bin/claude"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_args_inserts_separator_for_dash_query() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("- list files")
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        // Find the -- separator
+        let sep_pos = args.iter().position(|a| a == "--");
+        assert!(sep_pos.is_some(), "Separator -- should be present");
+
+        let sep_pos = sep_pos.unwrap();
+        assert_eq!(args[sep_pos + 1], "- list files");
+    }
+
+    #[tokio::test]
+    async fn test_build_args_basic() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test query")
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--output-format".to_string()));
+        assert!(args.contains(&"text".to_string()));
+        assert!(args.contains(&"--".to_string()));
+        assert!(args.contains(&"test query".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_model() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .model(crate::types::Model::Sonnet)
+            .fallback_model(crate::types::Model::Haiku)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let model_pos = args.iter().position(|a| a == "--model").unwrap();
+        assert_eq!(args[model_pos + 1], "sonnet");
+
+        let fallback_pos = args.iter().position(|a| a == "--fallback-model").unwrap();
+        assert_eq!(args[fallback_pos + 1], "haiku");
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_permissions() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .permission_mode(PermissionMode::AcceptEdits)
+            .enable_dangerous_permissions()
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        assert!(args.contains(&"--permission-mode".to_string()));
+        assert!(args.contains(&"acceptEdits".to_string()));
+        assert!(args.contains(&"--allow-dangerously-skip-permissions".to_string()));
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_tools() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .tools(vec!["Read".to_string(), "Write".to_string()])
+            .allowed_tools(vec!["Bash".to_string()])
+            .disallowed_tools(vec!["WebSearch".to_string()])
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let tools_pos = args.iter().position(|a| a == "--tools").unwrap();
+        assert_eq!(args[tools_pos + 1], "Read,Write");
+
+        let allowed_pos = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[allowed_pos + 1], "Bash");
+
+        let disallowed_pos = args.iter().position(|a| a == "--disallowedTools").unwrap();
+        assert_eq!(args[disallowed_pos + 1], "WebSearch");
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_session_semantics() {
+        let client = create_test_client();
+
+        // Test resume
+        let config = SessionConfig::builder("test")
+            .resume_session_id("session-123")
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        let resume_pos = args.iter().position(|a| a == "--resume").unwrap();
+        assert_eq!(args[resume_pos + 1], "session-123");
+
+        // Test explicit session ID
+        let config = SessionConfig::builder("test")
+            .explicit_session_id("uuid-456")
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        let session_id_pos = args.iter().position(|a| a == "--session-id").unwrap();
+        assert_eq!(args[session_id_pos + 1], "uuid-456");
+
+        // Test continue
+        let config = SessionConfig::builder("test")
+            .continue_last_session(true)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        assert!(args.contains(&"--continue".to_string()));
+
+        // Test fork
+        let config = SessionConfig::builder("test")
+            .fork_session(true)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        assert!(args.contains(&"--fork-session".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_input_format() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .input_format(InputFormat::StreamJson)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let input_pos = args.iter().position(|a| a == "--input-format").unwrap();
+        assert_eq!(args[input_pos + 1], "stream-json");
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_output_shaping() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .json_schema(r#"{"type":"object"}"#)
+            .include_partial_messages(true)
+            .replay_user_messages(true)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let schema_pos = args.iter().position(|a| a == "--json-schema").unwrap();
+        assert_eq!(args[schema_pos + 1], r#"{"type":"object"}"#);
+        assert!(args.contains(&"--include-partial-messages".to_string()));
+        assert!(args.contains(&"--replay-user-messages".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_args_with_advanced_options() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .agents(r#"{"test":"config"}"#)
+            .debug(true)
+            .debug_filter("filter*")
+            .ide(true)
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let agents_pos = args.iter().position(|a| a == "--agents").unwrap();
+        assert_eq!(args[agents_pos + 1], r#"{"test":"config"}"#);
+
+        let debug_pos = args.iter().position(|a| a == "--debug").unwrap();
+        assert_eq!(args[debug_pos + 1], "filter*");
+
+        assert!(args.contains(&"--ide".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_args_verbose_auto_added_for_streaming() {
+        let client = create_test_client();
+
+        // Streaming JSON should auto-add verbose
+        let config = SessionConfig::builder("test")
+            .output_format(OutputFormat::StreamingJson)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        assert!(args.contains(&"--verbose".to_string()));
+
+        // Text format should not auto-add verbose
+        let config = SessionConfig::builder("test")
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        assert!(!args.contains(&"--verbose".to_string()));
+
+        // Explicit verbose flag should be added
+        let config = SessionConfig::builder("test")
+            .output_format(OutputFormat::Text)
+            .verbose(true)
+            .build()
+            .unwrap();
+        let (args, _) = client.build_args(&config).await.unwrap();
+        assert!(args.contains(&"--verbose".to_string()));
     }
 }

--- a/claudecode_rs/src/config.rs
+++ b/claudecode_rs/src/config.rs
@@ -1,15 +1,68 @@
 use crate::error::{ClaudeError, Result};
-use crate::types::{Model, OutputFormat};
+use crate::types::{InputFormat, Model, OutputFormat, PermissionMode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// MCP Server configuration - supports both stdio (subprocess) and HTTP server types
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MCPServer {
-    pub command: String,
-    pub args: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub env: Option<HashMap<String, String>>,
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum MCPServer {
+    /// Stdio MCP server (subprocess)
+    #[serde(rename = "stdio")]
+    Stdio {
+        command: String,
+        args: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        env: Option<HashMap<String, String>>,
+    },
+    /// HTTP MCP server
+    #[serde(rename = "http")]
+    Http {
+        url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        headers: Option<HashMap<String, String>>,
+    },
+}
+
+impl MCPServer {
+    /// Create a new stdio MCP server
+    pub fn stdio(command: impl Into<String>, args: Vec<String>) -> Self {
+        MCPServer::Stdio {
+            command: command.into(),
+            args,
+            env: None,
+        }
+    }
+
+    /// Create a new stdio MCP server with environment variables
+    pub fn stdio_with_env(
+        command: impl Into<String>,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Self {
+        MCPServer::Stdio {
+            command: command.into(),
+            args,
+            env: Some(env),
+        }
+    }
+
+    /// Create a new HTTP MCP server
+    pub fn http(url: impl Into<String>) -> Self {
+        MCPServer::Http {
+            url: url.into(),
+            headers: None,
+        }
+    }
+
+    /// Create a new HTTP MCP server with headers
+    pub fn http_with_headers(url: impl Into<String>, headers: HashMap<String, String>) -> Self {
+        MCPServer::Http {
+            url: url.into(),
+            headers: Some(headers),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,21 +71,100 @@ pub struct MCPConfig {
     pub mcp_servers: HashMap<String, MCPServer>,
 }
 
+/// Configuration for a Claude CLI session
 #[derive(Debug, Clone, Default)]
 pub struct SessionConfig {
+    /// The query/prompt to send to Claude
     pub query: String,
-    pub session_id: Option<String>,
+
+    // Session semantics
+    /// Resume a specific session (maps to --resume)
+    pub resume_session_id: Option<String>,
+    /// Use a specific session ID (maps to --session-id)
+    pub explicit_session_id: Option<String>,
+    /// Continue the last session (maps to --continue)
+    pub continue_last_session: bool,
+    /// Fork an existing session (maps to --fork-session)
+    pub fork_session: bool,
+
+    // Models
+    /// Primary model to use
     pub model: Option<Model>,
+    /// Fallback model if primary is unavailable (maps to --fallback-model)
+    pub fallback_model: Option<Model>,
+
+    // Formats
+    /// Output format (maps to --output-format)
     pub output_format: OutputFormat,
+    /// Input format (maps to --input-format)
+    pub input_format: Option<InputFormat>,
+
+    // MCP
+    /// MCP server configuration (maps to --mcp-config)
     pub mcp_config: Option<MCPConfig>,
-    pub permission_prompt_tool: Option<String>,
-    pub working_dir: Option<PathBuf>,
-    pub max_turns: Option<u32>,
+    /// Strict MCP config validation (maps to --strict-mcp-config)
+    pub strict_mcp_config: bool,
+
+    // Permissions
+    /// Permission mode (maps to --permission-mode)
+    pub permission_mode: Option<PermissionMode>,
+    /// Skip permission checks dangerously (maps to --dangerously-skip-permissions)
+    pub dangerously_skip_permissions: bool,
+    /// Allow dangerous permission skipping (maps to --allow-dangerously-skip-permissions)
+    pub allow_dangerously_skip_permissions: bool,
+
+    // Prompts
+    /// System prompt override (maps to --system-prompt)
     pub system_prompt: Option<String>,
+    /// Append to system prompt (maps to --append-system-prompt)
     pub append_system_prompt: Option<String>,
+
+    // Tools and filtering
+    /// Specific tools to enable (maps to --tools)
+    pub tools: Option<Vec<String>>,
+    /// Tools to allow (maps to --allowedTools)
     pub allowed_tools: Option<Vec<String>>,
+    /// Tools to disallow (maps to --disallowedTools)
     pub disallowed_tools: Option<Vec<String>>,
-    pub custom_instructions: Option<String>,
+
+    // Output shaping
+    /// JSON schema for structured output (maps to --json-schema)
+    pub json_schema: Option<String>,
+    /// Include partial messages in stream (maps to --include-partial-messages)
+    pub include_partial_messages: bool,
+    /// Replay user messages (maps to --replay-user-messages)
+    pub replay_user_messages: bool,
+
+    // Configuration
+    /// Settings JSON (maps to --settings)
+    pub settings: Option<String>,
+    /// Setting sources (maps to --setting-sources)
+    pub setting_sources: Option<Vec<String>>,
+
+    // Directories and plugins
+    /// Additional directories to add to context (maps to --add-dir, repeatable)
+    pub additional_dirs: Vec<PathBuf>,
+    /// Plugin directories (maps to --plugin-dir, repeatable)
+    pub plugin_dirs: Vec<PathBuf>,
+    /// IDE mode (maps to --ide)
+    pub ide: bool,
+
+    // Advanced
+    /// Agents configuration JSON (maps to --agents)
+    pub agents: Option<String>,
+    /// Enable debug mode (maps to --debug)
+    pub debug: bool,
+    /// Debug filter pattern
+    pub debug_filter: Option<String>,
+
+    // Process control
+    /// Working directory for the Claude process
+    pub working_dir: Option<PathBuf>,
+    /// Environment variables to inject into the Claude process
+    pub env: Option<HashMap<String, String>>,
+
+    // Misc
+    /// Enable verbose output
     pub verbose: bool,
 }
 
@@ -48,11 +180,22 @@ impl SessionConfig {
             });
         }
 
-        if let Some(turns) = self.max_turns
-            && turns == 0
-        {
+        // Mutually exclusive session controls
+        if self.continue_last_session && self.resume_session_id.is_some() {
             return Err(ClaudeError::InvalidConfiguration {
-                message: "Max turns must be greater than 0".to_string(),
+                message: "Cannot set both continue_last_session and resume_session_id".to_string(),
+            });
+        }
+        if self.resume_session_id.is_some() && self.explicit_session_id.is_some() {
+            return Err(ClaudeError::InvalidConfiguration {
+                message: "Cannot set both resume_session_id and explicit_session_id".to_string(),
+            });
+        }
+
+        // Safe dangerous permissions: both must be set together or neither
+        if self.dangerously_skip_permissions ^ self.allow_dangerously_skip_permissions {
+            return Err(ClaudeError::InvalidConfiguration {
+                message: "Dangerous permissions require both flags enabled together (use enable_dangerous_permissions())".to_string(),
             });
         }
 
@@ -60,6 +203,7 @@ impl SessionConfig {
     }
 }
 
+/// Builder for SessionConfig with fluent API
 pub struct SessionConfigBuilder {
     config: SessionConfig,
 }
@@ -74,66 +218,119 @@ impl SessionConfigBuilder {
         }
     }
 
-    pub fn session_id(mut self, id: impl Into<String>) -> Self {
-        self.config.session_id = Some(id.into());
+    // Session semantics
+    /// Resume a specific session by ID (maps to --resume)
+    pub fn resume_session_id(mut self, id: impl Into<String>) -> Self {
+        self.config.resume_session_id = Some(id.into());
         self
     }
 
+    /// Use a specific session ID (maps to --session-id)
+    pub fn explicit_session_id(mut self, id: impl Into<String>) -> Self {
+        self.config.explicit_session_id = Some(id.into());
+        self
+    }
+
+    /// Continue the last session (maps to --continue)
+    pub fn continue_last_session(mut self, yes: bool) -> Self {
+        self.config.continue_last_session = yes;
+        self
+    }
+
+    /// Fork an existing session (maps to --fork-session)
+    pub fn fork_session(mut self, yes: bool) -> Self {
+        self.config.fork_session = yes;
+        self
+    }
+
+    // Models
+    /// Set the primary model
     pub fn model(mut self, model: Model) -> Self {
         self.config.model = Some(model);
         self
     }
 
+    /// Set the fallback model (maps to --fallback-model)
+    pub fn fallback_model(mut self, model: Model) -> Self {
+        self.config.fallback_model = Some(model);
+        self
+    }
+
+    // Formats
+    /// Set the output format
     pub fn output_format(mut self, format: OutputFormat) -> Self {
         self.config.output_format = format;
         self
     }
 
+    /// Set the input format (maps to --input-format)
+    pub fn input_format(mut self, format: InputFormat) -> Self {
+        self.config.input_format = Some(format);
+        self
+    }
+
+    // MCP
+    /// Set MCP server configuration
     pub fn mcp_config(mut self, config: MCPConfig) -> Self {
         self.config.mcp_config = Some(config);
         self
     }
 
-    pub fn permission_prompt_tool(mut self, tool: impl Into<String>) -> Self {
-        self.config.permission_prompt_tool = Some(tool.into());
+    /// Enable strict MCP config validation (maps to --strict-mcp-config)
+    pub fn strict_mcp_config(mut self, yes: bool) -> Self {
+        self.config.strict_mcp_config = yes;
         self
     }
 
-    pub fn working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
-        self.config.working_dir = Some(dir.into());
+    // Permissions
+    /// Set permission mode (maps to --permission-mode)
+    pub fn permission_mode(mut self, mode: PermissionMode) -> Self {
+        self.config.permission_mode = Some(mode);
         self
     }
 
-    pub fn max_turns(mut self, turns: u32) -> Self {
-        self.config.max_turns = Some(turns);
+    /// Enable dangerous permission skipping.
+    /// This sets both --allow-dangerously-skip-permissions and --dangerously-skip-permissions.
+    /// Use with extreme caution.
+    pub fn enable_dangerous_permissions(mut self) -> Self {
+        self.config.allow_dangerously_skip_permissions = true;
+        self.config.dangerously_skip_permissions = true;
         self
     }
 
+    // Prompts
+    /// Set system prompt override (maps to --system-prompt)
     pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
         self.config.system_prompt = Some(prompt.into());
         self
     }
 
+    /// Append to system prompt (maps to --append-system-prompt)
     pub fn append_system_prompt(mut self, prompt: impl Into<String>) -> Self {
         self.config.append_system_prompt = Some(prompt.into());
         self
     }
 
+    // Tools
+    /// Set specific tools to enable (maps to --tools)
+    pub fn tools(mut self, tools: Vec<String>) -> Self {
+        self.config.tools = Some(tools);
+        self
+    }
+
+    /// Set allowed tools (maps to --allowedTools)
     pub fn allowed_tools(mut self, tools: Vec<String>) -> Self {
         self.config.allowed_tools = Some(tools);
         self
     }
 
+    /// Set disallowed tools (maps to --disallowedTools)
     pub fn disallowed_tools(mut self, tools: Vec<String>) -> Self {
         self.config.disallowed_tools = Some(tools);
         self
     }
 
-    pub fn verbose(mut self, verbose: bool) -> Self {
-        self.config.verbose = verbose;
-        self
-    }
-
+    /// Add a single tool to allowed list
     pub fn allow_tool(mut self, tool: impl Into<String>) -> Self {
         self.config
             .allowed_tools
@@ -142,6 +339,7 @@ impl SessionConfigBuilder {
         self
     }
 
+    /// Add a single tool to disallowed list
     pub fn disallow_tool(mut self, tool: impl Into<String>) -> Self {
         self.config
             .disallowed_tools
@@ -150,11 +348,106 @@ impl SessionConfigBuilder {
         self
     }
 
-    pub fn custom_instructions(mut self, instructions: impl Into<String>) -> Self {
-        self.config.custom_instructions = Some(instructions.into());
+    // Output shaping
+    /// Set JSON schema for structured output (maps to --json-schema)
+    pub fn json_schema(mut self, schema: impl Into<String>) -> Self {
+        self.config.json_schema = Some(schema.into());
         self
     }
 
+    /// Include partial messages in stream (maps to --include-partial-messages)
+    pub fn include_partial_messages(mut self, yes: bool) -> Self {
+        self.config.include_partial_messages = yes;
+        self
+    }
+
+    /// Replay user messages (maps to --replay-user-messages)
+    pub fn replay_user_messages(mut self, yes: bool) -> Self {
+        self.config.replay_user_messages = yes;
+        self
+    }
+
+    // Configuration
+    /// Set settings JSON (maps to --settings)
+    pub fn settings(mut self, s: impl Into<String>) -> Self {
+        self.config.settings = Some(s.into());
+        self
+    }
+
+    /// Set setting sources (maps to --setting-sources)
+    pub fn setting_sources(mut self, sources: Vec<String>) -> Self {
+        self.config.setting_sources = Some(sources);
+        self
+    }
+
+    // Directories and plugins
+    /// Add a directory to context (maps to --add-dir, repeatable)
+    pub fn add_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.config.additional_dirs.push(dir.into());
+        self
+    }
+
+    /// Add a plugin directory (maps to --plugin-dir, repeatable)
+    pub fn plugin_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.config.plugin_dirs.push(dir.into());
+        self
+    }
+
+    /// Enable IDE mode (maps to --ide)
+    pub fn ide(mut self, yes: bool) -> Self {
+        self.config.ide = yes;
+        self
+    }
+
+    // Advanced
+    /// Set agents configuration JSON (maps to --agents)
+    pub fn agents(mut self, json: impl Into<String>) -> Self {
+        self.config.agents = Some(json.into());
+        self
+    }
+
+    /// Enable debug mode (maps to --debug)
+    pub fn debug(mut self, yes: bool) -> Self {
+        self.config.debug = yes;
+        self
+    }
+
+    /// Set debug filter pattern
+    pub fn debug_filter(mut self, filter: impl Into<String>) -> Self {
+        self.config.debug_filter = Some(filter.into());
+        self
+    }
+
+    // Process control
+    /// Set working directory for the Claude process
+    pub fn working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.config.working_dir = Some(dir.into());
+        self
+    }
+
+    /// Set environment variables to inject into the Claude process
+    pub fn env(mut self, env: HashMap<String, String>) -> Self {
+        self.config.env = Some(env);
+        self
+    }
+
+    /// Add a single environment variable
+    pub fn env_var(mut self, key: impl Into<String>, val: impl Into<String>) -> Self {
+        self.config
+            .env
+            .get_or_insert_with(HashMap::new)
+            .insert(key.into(), val.into());
+        self
+    }
+
+    // Misc
+    /// Enable verbose output
+    pub fn verbose(mut self, verbose: bool) -> Self {
+        self.config.verbose = verbose;
+        self
+    }
+
+    /// Build the SessionConfig, validating all settings
     pub fn build(self) -> Result<SessionConfig> {
         self.config.validate()?;
         Ok(self.config)
@@ -166,42 +459,159 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_session_config_validation() {
-        // Empty query should fail
+    fn test_session_config_validation_empty_query() {
         let config = SessionConfig::builder("").build();
         assert!(config.is_err());
+        assert!(
+            config
+                .unwrap_err()
+                .to_string()
+                .contains("Query cannot be empty")
+        );
+    }
 
-        // Zero max turns should fail
-        let config = SessionConfig::builder("test").max_turns(0).build();
-        assert!(config.is_err());
-
-        // Valid config should succeed
+    #[test]
+    fn test_session_config_validation_valid() {
         let config = SessionConfig::builder("test query").build();
         assert!(config.is_ok());
     }
 
     #[test]
+    fn test_session_config_validation_session_conflicts() {
+        // continue + resume should fail
+        let config = SessionConfig {
+            query: "test".to_string(),
+            continue_last_session: true,
+            resume_session_id: Some("id".to_string()),
+            ..Default::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("continue_last_session and resume_session_id")
+        );
+
+        // resume + explicit should fail
+        let config = SessionConfig {
+            query: "test".to_string(),
+            resume_session_id: Some("id1".to_string()),
+            explicit_session_id: Some("id2".to_string()),
+            ..Default::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("resume_session_id and explicit_session_id")
+        );
+    }
+
+    #[test]
+    fn test_session_config_validation_dangerous_permissions() {
+        // Only one dangerous flag set should fail
+        let config = SessionConfig {
+            query: "test".to_string(),
+            dangerously_skip_permissions: true,
+            allow_dangerously_skip_permissions: false,
+            ..Default::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("enable_dangerous_permissions")
+        );
+
+        // Both set should succeed
+        let config = SessionConfig {
+            query: "test".to_string(),
+            dangerously_skip_permissions: true,
+            allow_dangerously_skip_permissions: true,
+            ..Default::default()
+        };
+        let result = config.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enable_dangerous_permissions() {
+        let config = SessionConfig::builder("test")
+            .enable_dangerous_permissions()
+            .build()
+            .unwrap();
+
+        assert!(config.dangerously_skip_permissions);
+        assert!(config.allow_dangerously_skip_permissions);
+    }
+
+    #[test]
     fn test_session_config_builder() {
         let config = SessionConfig::builder("my query")
-            .session_id("test-id")
+            .resume_session_id("test-id")
             .model(Model::Sonnet)
             .output_format(OutputFormat::Json)
-            .max_turns(5)
             .verbose(true)
-            .custom_instructions("Always be helpful")
             .build()
             .unwrap();
 
         assert_eq!(config.query, "my query");
-        assert_eq!(config.session_id.as_deref(), Some("test-id"));
+        assert_eq!(config.resume_session_id.as_deref(), Some("test-id"));
         assert_eq!(config.model, Some(Model::Sonnet));
         assert_eq!(config.output_format, OutputFormat::Json);
-        assert_eq!(config.max_turns, Some(5));
         assert!(config.verbose);
+    }
+
+    #[test]
+    fn test_session_config_builder_new_fields() {
+        let config = SessionConfig::builder("query")
+            .fallback_model(Model::Haiku)
+            .input_format(InputFormat::StreamJson)
+            .permission_mode(PermissionMode::AcceptEdits)
+            .strict_mcp_config(true)
+            .json_schema(r#"{"type":"object"}"#)
+            .include_partial_messages(true)
+            .replay_user_messages(true)
+            .tools(vec!["Read".to_string(), "Write".to_string()])
+            .settings(r#"{"key":"value"}"#)
+            .setting_sources(vec!["source1".to_string()])
+            .add_dir("/tmp/dir1")
+            .add_dir("/tmp/dir2")
+            .plugin_dir("/tmp/plugins")
+            .ide(true)
+            .agents(r#"{"agent":"config"}"#)
+            .debug(true)
+            .debug_filter("filter*")
+            .env_var("KEY", "VALUE")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.fallback_model, Some(Model::Haiku));
+        assert_eq!(config.input_format, Some(InputFormat::StreamJson));
+        assert_eq!(config.permission_mode, Some(PermissionMode::AcceptEdits));
+        assert!(config.strict_mcp_config);
+        assert_eq!(config.json_schema.as_deref(), Some(r#"{"type":"object"}"#));
+        assert!(config.include_partial_messages);
+        assert!(config.replay_user_messages);
         assert_eq!(
-            config.custom_instructions.as_deref(),
-            Some("Always be helpful")
+            config.tools,
+            Some(vec!["Read".to_string(), "Write".to_string()])
         );
+        assert_eq!(config.settings.as_deref(), Some(r#"{"key":"value"}"#));
+        assert_eq!(config.setting_sources, Some(vec!["source1".to_string()]));
+        assert_eq!(config.additional_dirs.len(), 2);
+        assert_eq!(config.plugin_dirs.len(), 1);
+        assert!(config.ide);
+        assert_eq!(config.agents.as_deref(), Some(r#"{"agent":"config"}"#));
+        assert!(config.debug);
+        assert_eq!(config.debug_filter.as_deref(), Some("filter*"));
+        assert_eq!(config.env.as_ref().unwrap().get("KEY").unwrap(), "VALUE");
     }
 
     #[test]
@@ -212,15 +622,79 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_config_serialization() {
+    fn test_mcp_config_serialization_stdio() {
         let mut servers = HashMap::new();
         servers.insert(
             "test".to_string(),
-            MCPServer {
-                command: "cmd".to_string(),
-                args: vec!["arg1".to_string(), "arg2".to_string()],
-                env: None,
-            },
+            MCPServer::stdio("cmd", vec!["arg1".to_string(), "arg2".to_string()]),
+        );
+
+        let mcp_config = MCPConfig {
+            mcp_servers: servers,
+        };
+        let json = serde_json::to_string(&mcp_config).unwrap();
+
+        // Verify JSON contains type field
+        assert!(json.contains(r#""type":"stdio""#));
+
+        let deserialized: MCPConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.mcp_servers.len(), 1);
+        assert!(deserialized.mcp_servers.contains_key("test"));
+
+        // Verify it's a stdio server
+        match &deserialized.mcp_servers["test"] {
+            MCPServer::Stdio { command, args, env } => {
+                assert_eq!(command, "cmd");
+                assert_eq!(args, &vec!["arg1".to_string(), "arg2".to_string()]);
+                assert!(env.is_none());
+            }
+            _ => panic!("Expected Stdio server"),
+        }
+    }
+
+    #[test]
+    fn test_mcp_config_serialization_http() {
+        let mut servers = HashMap::new();
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer token".to_string());
+        servers.insert(
+            "http-server".to_string(),
+            MCPServer::http_with_headers("https://example.com/mcp", headers),
+        );
+
+        let mcp_config = MCPConfig {
+            mcp_servers: servers,
+        };
+        let json = serde_json::to_string(&mcp_config).unwrap();
+
+        // Verify JSON contains type field
+        assert!(json.contains(r#""type":"http""#));
+
+        let deserialized: MCPConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.mcp_servers.len(), 1);
+        assert!(deserialized.mcp_servers.contains_key("http-server"));
+
+        // Verify it's an http server
+        match &deserialized.mcp_servers["http-server"] {
+            MCPServer::Http { url, headers } => {
+                assert_eq!(url, "https://example.com/mcp");
+                assert!(headers.is_some());
+                assert_eq!(headers.as_ref().unwrap()["Authorization"], "Bearer token");
+            }
+            _ => panic!("Expected Http server"),
+        }
+    }
+
+    #[test]
+    fn test_mcp_config_mixed_servers() {
+        let mut servers = HashMap::new();
+        servers.insert(
+            "stdio-server".to_string(),
+            MCPServer::stdio("node", vec!["server.js".to_string()]),
+        );
+        servers.insert(
+            "http-server".to_string(),
+            MCPServer::http("https://api.example.com/mcp"),
         );
 
         let mcp_config = MCPConfig {
@@ -229,7 +703,15 @@ mod tests {
         let json = serde_json::to_string(&mcp_config).unwrap();
 
         let deserialized: MCPConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.mcp_servers.len(), 1);
-        assert!(deserialized.mcp_servers.contains_key("test"));
+        assert_eq!(deserialized.mcp_servers.len(), 2);
+
+        assert!(matches!(
+            &deserialized.mcp_servers["stdio-server"],
+            MCPServer::Stdio { .. }
+        ));
+        assert!(matches!(
+            &deserialized.mcp_servers["http-server"],
+            MCPServer::Http { .. }
+        ));
     }
 }

--- a/claudecode_rs/src/error.rs
+++ b/claudecode_rs/src/error.rs
@@ -36,6 +36,9 @@ pub enum ClaudeError {
     #[error("Session error: {message}")]
     SessionError { message: String },
 
+    #[error("CLI probe failed: {message}")]
+    ProbeError { message: String },
+
     #[error("IO error: {source}")]
     IoError {
         #[from]

--- a/claudecode_rs/src/lib.rs
+++ b/claudecode_rs/src/lib.rs
@@ -63,6 +63,7 @@
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod probe;
 pub mod process;
 pub mod session;
 pub mod stream;
@@ -72,10 +73,12 @@ pub mod types;
 pub use client::Client;
 pub use config::{MCPConfig, MCPServer, SessionConfig, SessionConfigBuilder};
 pub use error::{ClaudeError, Result};
+pub use probe::CliCapabilities;
 pub use session::Session;
 pub use types::{
-    AssistantEvent, Content, ErrorEvent, Event, MCPStatus, Message, Model, OutputFormat,
-    Result as ClaudeResult, ResultEvent, ServerToolUse, SystemEvent, Usage,
+    AssistantEvent, Content, ErrorEvent, Event, InputFormat, MCPStatus, Message, Model,
+    OutputFormat, PermissionMode, Result as ClaudeResult, ResultEvent, ServerToolUse, SystemEvent,
+    Usage,
 };
 
 // Version information

--- a/claudecode_rs/src/probe.rs
+++ b/claudecode_rs/src/probe.rs
@@ -1,0 +1,206 @@
+//! CLI capability detection module.
+//!
+//! Provides optional functionality to probe the Claude CLI for supported flags
+//! and capabilities. This is useful for validating SDK compatibility with the
+//! installed CLI version.
+
+use crate::error::{ClaudeError, Result};
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Stdio;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+/// Represents the capabilities detected from the CLI.
+#[derive(Debug, Clone, Default)]
+pub struct CliCapabilities {
+    /// Set of flags detected from `claude --help` output.
+    pub flags: HashSet<String>,
+}
+
+impl CliCapabilities {
+    /// Check if a specific flag is supported by the CLI.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let caps = client.probe_cli().await?;
+    /// if caps.supports("--permission-mode") {
+    ///     // Use permission mode
+    /// }
+    /// ```
+    pub fn supports(&self, flag: &str) -> bool {
+        self.flags.contains(flag)
+    }
+
+    /// Check if all the given flags are supported.
+    pub fn supports_all(&self, flags: &[&str]) -> bool {
+        flags.iter().all(|f| self.supports(f))
+    }
+
+    /// Check if any of the given flags are supported.
+    pub fn supports_any(&self, flags: &[&str]) -> bool {
+        flags.iter().any(|f| self.supports(f))
+    }
+}
+
+/// Probe the Claude CLI for supported flags by parsing `--help` output.
+///
+/// This function runs `claude --help` and extracts all flags (tokens starting
+/// with `--`) from the output.
+///
+/// # Arguments
+/// * `claude_path` - Path to the claude executable
+///
+/// # Returns
+/// * `Ok(CliCapabilities)` - The detected capabilities
+/// * `Err(ClaudeError::ProbeError)` - If the probe failed
+///
+/// # Example
+/// ```ignore
+/// use claudecode::probe::probe_cli;
+/// use std::path::Path;
+///
+/// let caps = probe_cli(Path::new("/usr/local/bin/claude")).await?;
+/// println!("Supports {} flags", caps.flags.len());
+/// ```
+pub async fn probe_cli(claude_path: &Path) -> Result<CliCapabilities> {
+    let mut cmd = Command::new(claude_path);
+    cmd.arg("--help")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| ClaudeError::SpawnError {
+        command: claude_path.display().to_string(),
+        args: vec!["--help".into()],
+        source: e,
+    })?;
+
+    let mut stdout_content = String::new();
+    if let Some(mut stdout) = child.stdout.take() {
+        stdout.read_to_string(&mut stdout_content).await.ok();
+    }
+
+    let status = child.wait().await.map_err(|e| ClaudeError::ProbeError {
+        message: format!("Failed to wait for --help: {}", e),
+    })?;
+
+    if !status.success() {
+        return Err(ClaudeError::ProbeError {
+            message: "claude --help exited with non-zero status".into(),
+        });
+    }
+
+    let flags = parse_flags_from_help(&stdout_content);
+    Ok(CliCapabilities { flags })
+}
+
+/// Parse flags from help output text.
+fn parse_flags_from_help(help_text: &str) -> HashSet<String> {
+    let mut flags = HashSet::new();
+
+    for line in help_text.lines() {
+        for token in line.split_whitespace() {
+            if token.starts_with("--") {
+                // Clean up the flag (remove trailing punctuation)
+                let cleaned = token
+                    .trim_end_matches([',', ';', ')', ']'])
+                    .trim_start_matches('[');
+
+                // Handle flags with = in them (e.g., --model=<model>)
+                let flag = cleaned.split('=').next().unwrap_or(cleaned);
+
+                if !flag.is_empty() && flag.starts_with("--") {
+                    flags.insert(flag.to_string());
+                }
+            }
+        }
+    }
+
+    flags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_flags_from_help() {
+        let help_text = r#"
+Usage: claude [options] [query]
+
+Options:
+  --help                   Show help
+  --version                Show version
+  --model <model>          Model to use
+  --output-format <format> Output format (text, json, stream-json)
+  --permission-mode <mode> Permission mode
+  --dangerously-skip-permissions  Skip permission checks
+  --allow-dangerously-skip-permissions  Allow skipping permissions
+  --mcp-config <path>      MCP configuration file
+  --add-dir <path>         Add directory to context
+  --resume <id>            Resume session
+  --continue               Continue last session
+  --session-id <uuid>      Use specific session ID
+  --fork-session           Fork existing session
+  --tools <tools>          Tools to enable
+  --allowedTools <tools>   Allowed tools
+  --disallowedTools <tools> Disallowed tools
+  --json-schema <schema>   JSON schema for output
+  --include-partial-messages  Include partial messages
+  --replay-user-messages   Replay user messages
+  --settings <json>        Settings JSON
+  --setting-sources <sources>  Setting sources
+  --plugin-dir <path>      Plugin directory
+  --ide                    IDE mode
+  --agents <json>          Agents configuration
+  --debug [filter]         Debug mode
+  --verbose                Verbose output
+        "#;
+
+        let flags = parse_flags_from_help(help_text);
+
+        assert!(flags.contains("--help"));
+        assert!(flags.contains("--version"));
+        assert!(flags.contains("--model"));
+        assert!(flags.contains("--permission-mode"));
+        assert!(flags.contains("--dangerously-skip-permissions"));
+        assert!(flags.contains("--allow-dangerously-skip-permissions"));
+        assert!(flags.contains("--mcp-config"));
+        assert!(flags.contains("--add-dir"));
+        assert!(flags.contains("--resume"));
+        assert!(flags.contains("--continue"));
+        assert!(flags.contains("--session-id"));
+        assert!(flags.contains("--fork-session"));
+        assert!(flags.contains("--tools"));
+        assert!(flags.contains("--allowedTools"));
+        assert!(flags.contains("--disallowedTools"));
+        assert!(flags.contains("--json-schema"));
+        assert!(flags.contains("--include-partial-messages"));
+        assert!(flags.contains("--replay-user-messages"));
+        assert!(flags.contains("--settings"));
+        assert!(flags.contains("--plugin-dir"));
+        assert!(flags.contains("--ide"));
+        assert!(flags.contains("--agents"));
+        assert!(flags.contains("--debug"));
+        assert!(flags.contains("--verbose"));
+    }
+
+    #[test]
+    fn test_cli_capabilities_supports() {
+        let mut caps = CliCapabilities::default();
+        caps.flags.insert("--help".to_string());
+        caps.flags.insert("--model".to_string());
+        caps.flags.insert("--verbose".to_string());
+
+        assert!(caps.supports("--help"));
+        assert!(caps.supports("--model"));
+        assert!(!caps.supports("--nonexistent"));
+
+        assert!(caps.supports_all(&["--help", "--model"]));
+        assert!(!caps.supports_all(&["--help", "--nonexistent"]));
+
+        assert!(caps.supports_any(&["--nonexistent", "--model"]));
+        assert!(!caps.supports_any(&["--nonexistent", "--also-nonexistent"]));
+    }
+}

--- a/claudecode_rs/src/session.rs
+++ b/claudecode_rs/src/session.rs
@@ -38,10 +38,14 @@ pub struct Session {
 
 impl Session {
     pub async fn new(config: SessionConfig, process: ProcessHandle) -> Result<Self> {
-        let id = config
-            .session_id
-            .clone()
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        // Determine session ID from explicit_session_id, resume_session_id, or generate new
+        let id = if let Some(ref id) = config.explicit_session_id {
+            id.clone()
+        } else if let Some(ref id) = config.resume_session_id {
+            id.clone()
+        } else {
+            Uuid::new_v4().to_string()
+        };
 
         let (events_tx, events) = match config.output_format {
             OutputFormat::StreamingJson => {

--- a/claudecode_rs/src/types.rs
+++ b/claudecode_rs/src/types.rs
@@ -41,6 +41,45 @@ impl fmt::Display for OutputFormat {
     }
 }
 
+/// Permission mode for Claude CLI session
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionMode {
+    Default,
+    AcceptEdits,
+    DontAsk,
+    Plan,
+    BypassPermissions,
+}
+
+impl fmt::Display for PermissionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            PermissionMode::Default => "default",
+            PermissionMode::AcceptEdits => "acceptEdits",
+            PermissionMode::DontAsk => "dontAsk",
+            PermissionMode::Plan => "plan",
+            PermissionMode::BypassPermissions => "bypassPermissions",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+/// Input format for Claude CLI session
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputFormat {
+    Text,
+    StreamJson,
+}
+
+impl fmt::Display for InputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InputFormat::Text => write!(f, "text"),
+            InputFormat::StreamJson => write!(f, "stream-json"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Content {
@@ -369,5 +408,23 @@ mod tests {
         assert!(content.is_text());
         assert_eq!(content.get_text(), Some("Hello, world!"));
         assert!(matches!(content, Content::Text { .. }));
+    }
+
+    #[test]
+    fn test_permission_mode_display() {
+        assert_eq!(PermissionMode::Default.to_string(), "default");
+        assert_eq!(PermissionMode::AcceptEdits.to_string(), "acceptEdits");
+        assert_eq!(PermissionMode::DontAsk.to_string(), "dontAsk");
+        assert_eq!(PermissionMode::Plan.to_string(), "plan");
+        assert_eq!(
+            PermissionMode::BypassPermissions.to_string(),
+            "bypassPermissions"
+        );
+    }
+
+    #[test]
+    fn test_input_format_display() {
+        assert_eq!(InputFormat::Text.to_string(), "text");
+        assert_eq!(InputFormat::StreamJson.to_string(), "stream-json");
     }
 }

--- a/claudecode_rs/tests/integration.rs
+++ b/claudecode_rs/tests/integration.rs
@@ -24,7 +24,6 @@ async fn test_simple_query() {
 
     let config = SessionConfig::builder("Say 'Hello, Rust!' and nothing else")
         .output_format(OutputFormat::Text)
-        .max_turns(1)
         .build()
         .unwrap();
 
@@ -79,11 +78,10 @@ async fn test_mcp_config() {
     let mut servers = HashMap::new();
     servers.insert(
         "calculator".to_string(),
-        MCPServer {
-            command: "npx".to_string(),
-            args: vec!["@modelcontextprotocol/server-calculator".to_string()],
-            env: None,
-        },
+        MCPServer::stdio(
+            "npx",
+            vec!["@modelcontextprotocol/server-calculator".to_string()],
+        ),
     );
 
     let mcp_config = MCPConfig {
@@ -93,7 +91,6 @@ async fn test_mcp_config() {
     let config = SessionConfig::builder("What is 123 * 456?")
         .mcp_config(mcp_config)
         .output_format(OutputFormat::Json)
-        .max_turns(1)
         .build()
         .unwrap();
 
@@ -119,7 +116,6 @@ async fn test_haiku_model() {
     let config = SessionConfig::builder("Say 'Hello from Haiku!' and nothing else")
         .model(Model::Haiku)
         .output_format(OutputFormat::Text)
-        .max_turns(1)
         .build()
         .unwrap();
 


### PR DESCRIPTION
## What problem(s) was I solving?

The claudecode_rs SDK had an outdated API that didn't match current Claude CLI flags. Many CLI features were unsupported:
- No fallback model support
- Missing permission modes (acceptEdits, bypassPermissions, plan, autoAccept)
- No input format configuration
- Missing session semantics (--session-id, --continue, --fork-session)
- MCPServer only supported stdio servers, not HTTP
- No way to detect CLI capabilities
- Deprecated fields like `max_turns`, `permission_prompt_tool`, and `custom_instructions` were still in the API

## What user-facing changes did I ship?

**Breaking changes to SessionConfig:**
- Removed: `session_id`, `max_turns`, `permission_prompt_tool`, `custom_instructions`
- Added 30+ new fields matching current CLI flags:
  - Session semantics: `resume_session_id`, `explicit_session_id`, `continue_last_session`, `fork_session`
  - Models: `fallback_model`
  - Formats: `input_format`
  - Permissions: `permission_mode`, `dangerously_skip_permissions`, `allow_dangerously_skip_permissions`
  - Tools: `tools`, `json_schema`, `include_partial_messages`, `replay_user_messages`
  - Config: `settings`, `setting_sources`
  - Directories: `additional_dirs`, `plugin_dirs`, `ide`
  - Advanced: `agents`, `debug`, `debug_filter`, `env`

**MCPServer refactored to enum:**
- Changed from struct to enum with `Stdio` and `Http` variants
- New constructors: `MCPServer::stdio()`, `MCPServer::stdio_with_env()`, `MCPServer::http()`, `MCPServer::http_with_headers()`

**New capabilities:**
- `Client::probe_cli()` method for detecting CLI capabilities
- Environment variable injection via `env` field
- `CLAUDE_PATH` environment variable support

## How I implemented it

- Refactored `MCPServer` from struct to tagged enum with Stdio/Http variants
- Expanded `SessionConfig` with comprehensive fields matching `claude --help` output
- Added `PermissionMode` and `InputFormat` enums to types.rs
- Created `probe.rs` module for CLI capability detection via `--help` parsing
- Rewrote `build_args` to handle all new flags with proper ordering and `--` separator for dash-prefixed queries
- Added env overlay support in `ProcessHandle::spawn()`
- Added validation for mutually exclusive session options
- Added comprehensive unit tests for all new build_args paths

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

**claudecode_rs**: Update SDK API to match current Claude CLI flags. Breaking changes to SessionConfig - removed deprecated fields (max_turns, session_id, permission_prompt_tool, custom_instructions), added 30+ new fields for current CLI features. MCPServer refactored to enum supporting both stdio and HTTP servers. Added CLI capability probing via `Client::probe_cli()`.
