### PR TITLE
fix(ci): disable git tags for library packages to prevent cargo-dist …

### DIFF
--- a/anthropic_async/Cargo.toml
+++ b/anthropic_async/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 categories = ["api-bindings"]
 keywords = ["anthropic", "claude", "llm", "client"]
 
+[package.metadata.dist]
+dist = false
+
 [features]
 default = []
 streaming = [] # placeholder for future SSE

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -58,18 +58,21 @@ release = true
 name = "universal-tool-core"
 changelog_path = "universal_tool/CHANGELOG.md"
 git_tag_name = "universal-tool-v{{ version }}"
+git_tag_enable = false
 release = true
 
 [[package]]
 name = "universal-tool-macros"
 changelog_path = "universal_tool/CHANGELOG.md"
 git_tag_name = "universal-tool-macros-v{{ version }}"
+git_tag_enable = false
 release = true
 
 [[package]]
 name = "claudecode"
 changelog_path = "claudecode_rs/CHANGELOG.md"
 git_tag_name = "claudecode-v{{ version }}"
+git_tag_enable = false
 release = true
 
 [[package]]
@@ -92,5 +95,6 @@ release = true
 name = "anthropic-async"
 changelog_path = "anthropic_async/CHANGELOG.md"
 git_tag_name = "anthropic-async-v{{ version }}"
+git_tag_enable = false
 release = true
 


### PR DESCRIPTION
## What problem(s) was I solving?

Library packages marked with `dist = false` in cargo-dist metadata were still receiving git tags from release-plz during the release process. When cargo-dist detected these tags, it triggered a build workflow that immediately failed with "nothing to release" because the packages are configured not to produce distributable artifacts.

This created a confusing CI state where releases would show partial failures even though the actual crate publishing to crates.io succeeded.

## What user-facing changes did I ship?

None. This is a CI/infrastructure fix that corrects release workflow behavior.

## How I implemented it

1. Added `git_tag_enable = false` to the library package configurations in `release-plz.toml`:
   - `universal-tool-core`
   - `universal-tool-macros`
   - `claudecode`
   - `anthropic-async`

2. Added the missing `[package.metadata.dist] dist = false` section to `anthropic_async/Cargo.toml` to ensure cargo-dist ignores this library package.

These library packages will continue to be published to crates.io via release-plz, but will no longer receive git tags that trigger the cargo-dist workflow.

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

fix(ci): disable git tags for library packages to prevent cargo-dist failures
