### PR TITLE
add claude code to opencode migration script

### DIFF
--- a/claude_to_opencode_migration/.gitignore
+++ b/claude_to_opencode_migration/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/

--- a/claude_to_opencode_migration/README.md
+++ b/claude_to_opencode_migration/README.md
@@ -1,0 +1,116 @@
+# Claude Code to OpenCode Migration Script
+
+A self-contained Python CLI that migrates Claude Code configurations into OpenCode format. Uses `uv` with PEP 723 inline dependencies for zero-setup execution.
+
+## Quick Start
+
+```bash
+# Dry-run to see what would change
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --dry-run
+
+# Migrate everything
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --all
+
+# Migrate specific components
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --agents
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --commands
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --permissions
+uv run claude_to_opencode_migration/migrate_claude_to_opencode.py --mcp
+```
+
+## What It Migrates
+
+| Source (Claude Code) | Target (OpenCode) |
+|---------------------|-------------------|
+| `.claude/agents/*.md` | `.opencode/agent/*.md` |
+| `.claude/commands/*.md` | `.opencode/command/*.md` |
+| `.claude/settings.json` | `opencode.json` (permission/tools) |
+| `~/.claude.json` / `.mcp.json` | `opencode.json` (mcp) |
+
+## Transformations
+
+### Agents
+- Removes `name` field, adds `mode: subagent`
+- Converts `tools` string to tools object with `"*": false` pattern
+- Maps model aliases: `sonnet` → `anthropic/claude-sonnet-4-5`
+- Maps colors to hex: `yellow` → `#EAB308`
+- Normalizes tool names: `mcp__tools__ls` → `tools_ls`
+
+### Commands
+- Adds `description` from first heading or filename
+- Maps model if present
+
+### Permissions
+- `Bash(git log:*)` → `permission.bash["git log *"] = "allow"`
+- `mcp__server__*` patterns → `tools["server_*"] = true`
+- Safe defaults: `bash["*"] = "ask"`, core tools enabled
+
+### MCP Servers
+- `stdio` → `local` with command array
+- `sse`/`http` → `remote` with url
+- `env` → `environment`
+- Adds `enabled: true`
+
+## CLI Options
+
+```
+--root ROOT           Project root (default: .)
+--agents              Migrate agents only
+--commands            Migrate commands only
+--permissions         Migrate permissions only
+--mcp                 Migrate MCP servers only
+--all                 Migrate all (default if no specific flags)
+--include-local       Include .claude/settings.local.json
+--mcp-target          Where to write MCP config: project|global (default: project)
+--dry-run             Show diffs without writing
+--conflict            Conflict handling: skip|overwrite|prompt (default: skip)
+--no-color            Disable colored output
+```
+
+## Safety Features
+
+- **Dry-run mode**: Preview all changes with unified diffs
+- **Timestamped backups**: Stored in `.opencode-migrate-backup/YYYYMMDD-HHMMSS/`
+- **Conflict strategies**: Skip (default), overwrite, or prompt
+- **Warnings**: Unsupported tools and unknown colors logged
+
+## Running Tests
+
+```bash
+# Run all tests
+uv run pytest claude_to_opencode_migration/tests/ -v
+
+# Run unit tests only
+uv run pytest claude_to_opencode_migration/tests/test_migration.py -v -k "not Integration"
+
+# Run integration tests only
+uv run pytest claude_to_opencode_migration/tests/test_migration.py -v -k "Integration"
+```
+
+## Directory Structure
+
+```
+claude_to_opencode_migration/
+├── migrate_claude_to_opencode.py  # Main script
+├── README.md                       # This file
+└── tests/
+    ├── test_migration.py          # Test suite
+    └── fixtures/
+        └── claude_sample/         # Sample Claude config for testing
+            └── .claude/
+                ├── agents/
+                ├── commands/
+                └── settings.json
+```
+
+## Unsupported Tools
+
+The following tools are dropped during migration (with warnings):
+- `WebSearch` - No OpenCode equivalent
+- `Task` - Use @mention or subagent instead
+
+## Known Limitations
+
+- Hook migration is not supported
+- Bidirectional migration (OpenCode → Claude) is not supported
+- No JSON schema validation against OpenCode schema

--- a/claude_to_opencode_migration/migrate_claude_to_opencode.py
+++ b/claude_to_opencode_migration/migrate_claude_to_opencode.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "PyYAML>=6.0.2",
+#   "rich>=13.7.0",
+# ]
+# ///
+"""
+Claude Code → OpenCode Migration Script
+
+Run:
+  uv run tools/migrate_claude_to_opencode.py --dry-run
+  uv run tools/migrate_claude_to_opencode.py --agents --commands --permissions --mcp
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import difflib
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+# ---------------------------
+# Constants and mappings
+# ---------------------------
+
+COLOR_MAP = {
+    "blue": "#3B82F6",
+    "cyan": "#06B6D4",
+    "green": "#22C55E",
+    "yellow": "#EAB308",
+    "magenta": "#D946EF",
+    "red": "#EF4444",
+}
+
+MODEL_MAP = {
+    "sonnet": "anthropic/claude-sonnet-4-5",
+    "opus": "anthropic/claude-opus-4-5",
+    "haiku": "anthropic/claude-haiku-4-5",
+    "sonnet-4.5": "anthropic/claude-sonnet-4-5",
+    "opus-4.5": "anthropic/claude-opus-4-5",
+    "haiku-4.5": "anthropic/claude-haiku-4-5",
+}
+
+UNSUPPORTED_TOOLS = {
+    "websearch",  # No OpenCode equivalent
+    "task",       # Use @mention or subagent instead
+}
+
+
+# ---------------------------
+# Utilities
+# ---------------------------
+
+def _now_ts() -> str:
+    return _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Invalid JSON at {path}: {e}")
+
+
+def dump_json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def unified_diff(old: str, new: str, path: str) -> str:
+    a = old.splitlines(keepends=True)
+    b = new.splitlines(keepends=True)
+    diff = difflib.unified_diff(a, b, fromfile=f"a/{path}", tofile=f"b/{path}")
+    return "".join(diff)
+
+
+def ensure_color_hex(value: Optional[str], console: Console, ctx: str) -> Optional[str]:
+    if not value:
+        return None
+    v = value.strip().lower()
+    if v in COLOR_MAP:
+        return COLOR_MAP[v]
+    if re.fullmatch(r"#?[0-9a-f]{6}", v, flags=re.IGNORECASE):
+        return v if v.startswith("#") else f"#{v}"
+    console.print(f"[yellow]Warning:[/yellow] Unknown color '{value}' at {ctx}; keeping as-is")
+    return value
+
+
+def map_model(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    v = value.strip()
+    low = v.lower()
+    if "/" in v:
+        return v  # Already namespaced, trust user
+    return MODEL_MAP.get(low, v)  # fallback to original if unmapped
+
+
+MCP_PAT = re.compile(r"^mcp__([A-Za-z0-9_\-]+)__([A-Za-z0-9_\-]+)$")
+
+def normalize_tool_name(token: str, *, console: Optional[Console] = None) -> Optional[str]:
+    token_lower = token.lower()
+
+    # Drop unsupported
+    if token_lower in UNSUPPORTED_TOOLS:
+        if console:
+            console.print(f"[yellow]Warning:[/yellow] Dropping unsupported tool '{token}'")
+        return None
+
+    m = MCP_PAT.match(token)
+    if m:
+        server, tool = m.group(1), m.group(2)
+        return f"{server.lower()}_{tool.lower()}"
+
+    # PascalCase or other → lowercase
+    return token_lower
+
+
+def tools_list_to_mapping(tools_list: Iterable[str], console: Console) -> Dict[str, bool]:
+    out: Dict[str, bool] = {"*": False}
+    for raw in tools_list:
+        t = normalize_tool_name(raw.strip(), console=console)
+        if not t:
+            continue
+        out[t] = True
+    return out
+
+
+def parse_yaml_frontmatter(md: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Return (frontmatter_dict_or_None, body)"""
+    if not md.startswith("---"):
+        return None, md
+    lines = md.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, md
+    # find closing '---' on a line by itself
+    end_idx = None
+    for i in range(1, min(len(lines), 2000)):  # safety bound
+        if lines[i].strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return None, md
+
+    fm_str = "\n".join(lines[1:end_idx]) + "\n"
+    body = "\n".join(lines[end_idx + 1:]) + ("\n" if md.endswith("\n") else "")
+    try:
+        fm = yaml.safe_load(fm_str) or {}
+        if not isinstance(fm, dict):
+            fm = {}
+    except Exception:
+        fm = {}
+    return fm, body
+
+
+def make_yaml_frontmatter(data: Dict[str, Any]) -> str:
+    dumped = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    return f"---\n{dumped}---\n"
+
+
+def extract_title_for_description(md_body: str, fallback_name: str) -> str:
+    for line in md_body.splitlines():
+        m = re.match(r"^\s*#\s+(.+)$", line.strip())
+        if m:
+            return m.group(1).strip()
+    # fallback from filename
+    name = Path(fallback_name).stem
+    name = re.sub(r"[_\-]+", " ", name).strip().title()
+    return name or "Command"
+
+
+def parse_bash_pattern(item: str) -> Optional[str]:
+    """
+    Convert Bash(git log:*) -> "git log *"
+    Bash(pwd) -> "pwd"
+    Bash(env | grep:*) -> "env | grep *"
+    """
+    if not item.startswith("Bash(") or not item.endswith(")"):
+        return None
+    inner = item[len("Bash("):-1].strip()
+    inner = inner.replace(":*", " *")
+    return inner
+
+
+# ---------------------------
+# Migration Plan Engine
+# ---------------------------
+
+@dataclass
+class Action:
+    kind: str  # "mkdir", "write_text", "update_json"
+    path: Path
+    description: str
+    content: Optional[str] = None
+    update_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None
+
+
+@dataclass
+class MigrationPlan:
+    root: Path
+    dry_run: bool
+    conflict: str  # "skip" | "overwrite" | "prompt"
+    console: Console
+    actions: List[Action] = field(default_factory=list)
+    _backup_dir: Optional[Path] = None
+
+    def backup_dir(self) -> Path:
+        if self._backup_dir is None:
+            ts = _now_ts()
+            self._backup_dir = self.root / f".opencode-migrate-backup/{ts}"
+        return self._backup_dir
+
+    def add_mkdir(self, path: Path, description: str = "Create directory") -> None:
+        self.actions.append(Action(kind="mkdir", path=path, description=description))
+
+    def add_write_text(self, path: Path, content: str, description: str) -> None:
+        self.actions.append(Action(kind="write_text", path=path, description=description, content=content))
+
+    def add_update_json(self, path: Path, update_fn: Callable[[Dict[str, Any]], Dict[str, Any]], description: str) -> None:
+        self.actions.append(Action(kind="update_json", path=path, description=description, update_fn=update_fn))
+
+    def _backup_if_exists(self, path: Path) -> None:
+        if not path.exists():
+            return
+        backup_root = self.backup_dir()
+        try:
+            rel = path.resolve().relative_to(self.root.resolve())
+            dest = backup_root / rel
+        except Exception:
+            safe_abs = str(path.resolve()).replace(":", "").replace("/", "_")
+            dest = backup_root / "external" / safe_abs
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dest)
+
+    def _maybe_prompt_overwrite(self, path: Path) -> bool:
+        if self.conflict == "overwrite":
+            return True
+        if self.conflict == "skip":
+            return False
+        self.console.print(f"[yellow]File exists:[/yellow] {path}")
+        resp = input("Overwrite? [y/N]: ").strip().lower()
+        return resp in {"y", "yes"}
+
+    def execute(self) -> int:
+        created = 0
+        updated = 0
+        skipped = 0
+        errored = 0
+
+        for act in self.actions:
+            try:
+                if act.kind == "mkdir":
+                    if self.dry_run:
+                        exists = act.path.exists()
+                        self.console.print(f"[cyan]mkdir[/cyan] {act.path} {'(exists)' if exists else ''}")
+                    else:
+                        act.path.mkdir(parents=True, exist_ok=True)
+                        self.console.print(f"[green]mkdir[/green] {act.path}")
+                    continue
+
+                if act.kind == "write_text":
+                    current = read_text(act.path)
+                    new = act.content or ""
+                    if current == new:
+                        skipped += 1
+                        self.console.print(f"[blue]up-to-date[/blue] {act.path}")
+                        continue
+
+                    if act.path.exists():
+                        if self.dry_run:
+                            diff = unified_diff(current or "", new, str(act.path))
+                            self.console.print(Panel(diff or "(no diff?)", title=f"diff: {act.path}", border_style="yellow"))
+                            skipped += 1
+                            continue
+                        else:
+                            if self.conflict == "skip":
+                                skipped += 1
+                                self.console.print(f"[yellow]skip (conflict)[/yellow] {act.path}")
+                                continue
+                            if self.conflict == "prompt":
+                                if not self._maybe_prompt_overwrite(act.path):
+                                    skipped += 1
+                                    self.console.print(f"[yellow]skip[/yellow] {act.path}")
+                                    continue
+                            self._backup_if_exists(act.path)
+                            write_text(act.path, new)
+                            updated += 1
+                            self.console.print(f"[green]updated[/green] {act.path}")
+                    else:
+                        if self.dry_run:
+                            self.console.print(f"[cyan]create[/cyan] {act.path}")
+                            diff = unified_diff("", new, str(act.path))
+                            self.console.print(Panel(diff or new, title=f"new: {act.path}", border_style="green"))
+                            created += 1
+                        else:
+                            write_text(act.path, new)
+                            created += 1
+                            self.console.print(f"[green]created[/green] {act.path}")
+                    continue
+
+                if act.kind == "update_json":
+                    current_obj = load_json(act.path)
+                    new_obj = act.update_fn(current_obj if isinstance(current_obj, dict) else {})
+                    new_json = dump_json(new_obj)
+                    current_json = dump_json(current_obj if isinstance(current_obj, dict) else {})
+
+                    if current_json == new_json:
+                        skipped += 1
+                        self.console.print(f"[blue]up-to-date[/blue] {act.path}")
+                        continue
+
+                    if self.dry_run:
+                        diff = unified_diff(current_json, new_json, str(act.path))
+                        self.console.print(Panel(diff or "(no diff?)", title=f"json diff: {act.path}", border_style="yellow"))
+                        skipped += 1
+                    else:
+                        if act.path.exists():
+                            if self.conflict == "skip":
+                                skipped += 1
+                                self.console.print(f"[yellow]skip (conflict)[/yellow] {act.path}")
+                                continue
+                            if self.conflict == "prompt":
+                                if not self._maybe_prompt_overwrite(act.path):
+                                    skipped += 1
+                                    self.console.print(f"[yellow]skip[/yellow] {act.path}")
+                                    continue
+                            self._backup_if_exists(act.path)
+                            self.console.print(f"[green]updated[/green] {act.path}")
+                            act.path.parent.mkdir(parents=True, exist_ok=True)
+                            act.path.write_text(new_json, encoding="utf-8")
+                            updated += 1
+                        else:
+                            self.console.print(f"[green]created[/green] {act.path}")
+                            act.path.parent.mkdir(parents=True, exist_ok=True)
+                            act.path.write_text(new_json, encoding="utf-8")
+                            created += 1
+                    continue
+
+                self.console.print(f"[red]Unknown action kind[/red]: {act.kind}")
+                errored += 1
+            except Exception as e:
+                errored += 1
+                self.console.print(f"[red]error[/red] {act.path}: {e}")
+
+        summary = Table(title="Migration Summary", show_header=False)
+        summary.add_row("Created", str(created))
+        summary.add_row("Updated", str(updated))
+        summary.add_row("Skipped", str(skipped))
+        summary.add_row("Errored", str(errored))
+        if not self.dry_run and (created or updated):
+            self.console.print(f"Backups stored under: {self.backup_dir()}")
+        self.console.print(summary)
+        return 0 if errored == 0 else 1
+
+
+# ---------------------------
+# Discovery and transforms
+# ---------------------------
+
+def discover_agent_files(root: Path) -> List[Path]:
+    return sorted((root / ".claude" / "agents").glob("*.md"))
+
+
+def discover_command_files(root: Path) -> List[Path]:
+    return sorted((root / ".claude" / "commands").glob("*.md"))
+
+
+def discover_settings(root: Path, include_local: bool) -> Dict[str, Any]:
+    merged: Dict[str, Any] = {}
+    settings_path = root / ".claude" / "settings.json"
+    base = load_json(settings_path)
+    merged.update(base)
+    if include_local:
+        local_path = root / ".claude" / "settings.local.json"
+        local = load_json(local_path)
+        if "permissions" in local:
+            mp = local["permissions"]
+            bp = merged.setdefault("permissions", {})
+            for k in ("allow", "deny"):
+                ba = set(bp.get(k, []))
+                la = set(mp.get(k, []))
+                bp[k] = sorted(ba.union(la))
+    return merged
+
+
+def load_mcp_sources(root: Path) -> Dict[str, Any]:
+    local = load_json(root / ".mcp.json")
+    global_path = Path(os.path.expanduser("~")) / ".claude.json"
+    glob = load_json(global_path)
+    res: Dict[str, Any] = {}
+
+    def extract(obj: Dict[str, Any]):
+        if not obj:
+            return
+        servers = obj.get("mcpServers") or obj.get("mcp") or {}
+        for name, cfg in servers.items():
+            res[name] = cfg
+
+    extract(glob)
+    extract(local)  # override global
+    return res
+
+
+def transform_agent_markdown(md: str, filename: str, console: Console) -> str:
+    fm, body = parse_yaml_frontmatter(md)
+    fm = fm or {}
+    description = fm.get("description") or ""
+    model = map_model(fm.get("model"))
+    color = ensure_color_hex(fm.get("color"), console, f"agent {filename}")
+    original_tools = fm.get("tools")
+
+    tools_map: Dict[str, bool] = {"*": False}
+    if isinstance(original_tools, str):
+        parts = [p.strip() for p in original_tools.split(",") if p.strip()]
+        tools_map = tools_list_to_mapping(parts, console)
+    elif isinstance(original_tools, list):
+        tools_map = tools_list_to_mapping(original_tools, console)
+    elif isinstance(original_tools, dict):
+        base = {"*": bool(original_tools.get("*", False))}
+        for k, v in original_tools.items():
+            if k == "*":
+                continue
+            nk = normalize_tool_name(k, console=console)
+            if nk:
+                base[nk] = bool(v)
+        tools_map = base
+    else:
+        tools_map = {"*": False}
+
+    new_fm: Dict[str, Any] = {
+        "mode": "subagent",
+        "description": description,
+        "tools": tools_map,
+    }
+    if model:
+        new_fm["model"] = model
+    if color:
+        new_fm["color"] = color
+
+    if body and not body.endswith("\n"):
+        body = body + "\n"
+    return make_yaml_frontmatter(new_fm) + body
+
+
+def transform_command_markdown(md: str, filename: str, console: Console) -> str:
+    fm, body = parse_yaml_frontmatter(md)
+    body = body or ""
+
+    new_fm: Dict[str, Any] = {}
+    if fm and "model" in fm:
+        mapped = map_model(fm.get("model"))
+        if mapped:
+            new_fm["model"] = mapped
+
+    desc = fm.get("description") if fm else None
+    if not desc:
+        desc = extract_title_for_description(body, filename)
+    new_fm["description"] = desc
+
+    return make_yaml_frontmatter(new_fm) + body
+
+
+def build_permissions_from_settings(settings: Dict[str, Any], console: Console) -> Tuple[Dict[str, Any], Dict[str, bool]]:
+    """Returns (permission_obj, tools_obj)"""
+    p = settings.get("permissions", {}) or {}
+    allow: List[str] = p.get("allow", []) or []
+    deny: List[str] = p.get("deny", []) or []
+
+    permission: Dict[str, Any] = {}
+    tools: Dict[str, bool] = {}
+
+    # Safe defaults
+    permission["bash"] = {"*": "ask"}
+    permission["edit"] = permission.get("edit", "ask")
+    permission["write"] = permission.get("write", "ask")
+
+    tools["*"] = tools.get("*", False)
+    tools["bash"] = tools.get("bash", True)
+    tools["edit"] = tools.get("edit", True)
+    tools["write"] = tools.get("write", True)
+
+    def handle_entry(lst: List[str], mode: str):
+        for raw in lst:
+            raw = raw.strip()
+            if not raw:
+                continue
+
+            bp = parse_bash_pattern(raw)
+            if bp:
+                permission.setdefault("bash", {}).setdefault(bp, mode)
+                permission["bash"][bp] = mode
+                continue
+
+            if raw.startswith("mcp__"):
+                m = MCP_PAT.match(raw)
+                if m:
+                    server = m.group(1).lower()
+                    tools[f"{server}_*"] = (mode == "allow")
+                else:
+                    console.print(f"[yellow]Warning:[/yellow] Unknown MCP pattern: {raw}")
+                continue
+
+            tool = normalize_tool_name(raw, console=console)
+            if not tool:
+                continue
+            tools[tool] = (mode == "allow")
+            if mode in ("allow", "deny"):
+                permission[tool] = mode
+
+    handle_entry(allow, "allow")
+    handle_entry(deny, "deny")
+
+    return permission, tools
+
+
+def update_opencode_json_factory(
+    add_permission: Dict[str, Any],
+    add_tools: Dict[str, bool],
+    add_mcp: Dict[str, Any],
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    def updater(current: Dict[str, Any]) -> Dict[str, Any]:
+        new = dict(current) if current else {}
+        perm = dict(new.get("permission", {}))
+        tools = dict(new.get("tools", {}))
+        mcp = dict(new.get("mcp", {}))
+
+        # Merge bash permissions
+        bash_cur = dict(perm.get("bash", {}))
+        bash_add = dict(add_permission.get("bash", {}))
+        for k, v in bash_add.items():
+            if k not in bash_cur:
+                bash_cur[k] = v
+        perm["bash"] = {"*": "ask", **bash_cur} if "*" not in bash_cur else bash_cur
+
+        for k, v in add_permission.items():
+            if k == "bash":
+                continue
+            if k not in perm:
+                perm[k] = v
+
+        tools.setdefault("*", False)
+        for k, v in add_tools.items():
+            tools.setdefault(k, v)
+
+        for name, cfg in add_mcp.items():
+            if name not in mcp:
+                mcp[name] = cfg
+
+        new["permission"] = perm
+        new["tools"] = tools
+        if add_mcp:
+            new["mcp"] = mcp
+
+        return new
+    return updater
+
+
+def transform_mcp_servers(mcp_src: Dict[str, Any], console: Console) -> Dict[str, Any]:
+    """Transform Claude MCP server entries to OpenCode format."""
+    out: Dict[str, Any] = {}
+    for name, cfg in (mcp_src or {}).items():
+        if not isinstance(cfg, dict):
+            continue
+        typ = cfg.get("type") or cfg.get("transport") or "stdio"
+        typ_low = str(typ).lower()
+        if typ_low == "stdio":
+            dest_type = "local"
+        elif typ_low in ("sse", "http", "https"):
+            dest_type = "remote"
+        else:
+            dest_type = "local"
+
+        command = cfg.get("command")
+        args = cfg.get("args", [])
+        env = cfg.get("env", {}) or cfg.get("environment", {})
+
+        command_arr: Optional[List[str]] = None
+        if isinstance(command, str):
+            if isinstance(args, list) and args:
+                command_arr = [command, *[str(a) for a in args]]
+            else:
+                command_arr = [command]
+        elif isinstance(command, list):
+            command_arr = [str(x) for x in command]
+
+        dest = {"type": dest_type, "enabled": True}
+        if command_arr and dest_type == "local":
+            dest["command"] = command_arr
+        if isinstance(env, dict) and env:
+            dest["environment"] = env
+
+        for key in ("url", "baseUrl", "endpoint"):
+            if key in cfg:
+                dest["url"] = cfg[key]
+                break
+
+        out[name] = dest
+    return out
+
+
+# ---------------------------
+# Orchestration
+# ---------------------------
+
+def run_migration(
+    root: Path,
+    *,
+    migrate_agents: bool,
+    migrate_commands: bool,
+    migrate_permissions: bool,
+    migrate_mcp: bool,
+    include_local_settings: bool,
+    mcp_target: str,
+    dry_run: bool,
+    conflict: str,
+    console: Console,
+) -> int:
+    plan = MigrationPlan(root=root, dry_run=dry_run, conflict=conflict, console=console)
+
+    op_agent_dir = root / ".opencode" / "agent"
+    op_command_dir = root / ".opencode" / "command"
+    op_project_config = root / "opencode.json"
+    op_global_config = Path(os.path.expanduser("~")) / ".config" / "opencode" / "opencode.json"
+
+    if migrate_agents:
+        plan.add_mkdir(op_agent_dir, "Ensure .opencode/agent directory")
+        for src in discover_agent_files(root):
+            try:
+                md = read_text(src)
+                if md is None:
+                    continue
+                new_md = transform_agent_markdown(md, src.name, console)
+                dest = op_agent_dir / src.name
+                plan.add_write_text(dest, new_md, f"Migrate agent {src.name}")
+            except Exception as e:
+                console.print(f"[red]Agent error[/red] {src}: {e}")
+
+    if migrate_commands:
+        plan.add_mkdir(op_command_dir, "Ensure .opencode/command directory")
+        for src in discover_command_files(root):
+            try:
+                md = read_text(src)
+                if md is None:
+                    continue
+                new_md = transform_command_markdown(md, src.name, console)
+                dest = op_command_dir / src.name
+                plan.add_write_text(dest, new_md, f"Migrate command {src.name}")
+            except Exception as e:
+                console.print(f"[red]Command error[/red] {src}: {e}")
+
+    add_permission: Dict[str, Any] = {}
+    add_tools: Dict[str, bool] = {}
+    add_mcp: Dict[str, Any] = {}
+
+    if migrate_permissions:
+        try:
+            settings = discover_settings(root, include_local=include_local_settings)
+            perm, tools = build_permissions_from_settings(settings, console)
+            add_permission.update(perm)
+            add_tools.update(tools)
+        except Exception as e:
+            console.print(f"[red]Permission migration error:[/red] {e}")
+
+    if migrate_mcp:
+        try:
+            mcp_src = load_mcp_sources(root)
+            add_mcp = transform_mcp_servers(mcp_src, console)
+            for server in add_mcp.keys():
+                add_tools.setdefault(f"{server}_*".lower(), True)
+        except Exception as e:
+            console.print(f"[red]MCP migration error:[/red] {e}")
+
+    if migrate_permissions or migrate_mcp:
+        updater = update_opencode_json_factory(add_permission, add_tools, add_mcp)
+        if mcp_target == "project":
+            plan.add_update_json(op_project_config, updater, "Update project opencode.json")
+        elif mcp_target == "global":
+            plan.add_update_json(op_global_config, updater, "Update global opencode.json")
+
+    return plan.execute()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Migrate Claude Code configuration to OpenCode format."
+    )
+    p.add_argument("--root", default=".", help="Project root (default: .)")
+
+    scope = p.add_argument_group("Scope selection")
+    scope.add_argument("--agents", dest="agents", action="store_true", help="Migrate agents")
+    scope.add_argument("--commands", dest="commands", action="store_true", help="Migrate commands")
+    scope.add_argument("--permissions", dest="permissions", action="store_true", help="Migrate permissions")
+    scope.add_argument("--mcp", dest="mcp", action="store_true", help="Migrate MCP servers")
+    scope.add_argument("--all", dest="all", action="store_true", help="Migrate all (default if no specific flags)")
+
+    p.add_argument("--include-local", action="store_true", help="Include .claude/settings.local.json")
+    p.add_argument("--mcp-target", choices=["project", "global"], default="project", help="Where to write MCP config")
+
+    p.add_argument("--dry-run", action="store_true", help="Show diffs without writing")
+    p.add_argument("--conflict", choices=["skip", "overwrite", "prompt"], default="skip", help="Conflict handling")
+    p.add_argument("--no-color", action="store_true", help="Disable colored output")
+    p.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    console = Console(no_color=args.no_color)
+
+    root = Path(args.root).resolve()
+
+    if args.all or not (args.agents or args.commands or args.permissions or args.mcp):
+        migrate_agents = migrate_commands = migrate_permissions = migrate_mcp = True
+    else:
+        migrate_agents = args.agents
+        migrate_commands = args.commands
+        migrate_permissions = args.permissions
+        migrate_mcp = args.mcp
+
+    console.print(Panel(
+        Text("Claude → OpenCode Migration", style="bold"),
+        subtitle=f"root={root} dry_run={args.dry_run} conflict={args.conflict} mcp_target={args.mcp_target}",
+        border_style="cyan",
+    ))
+
+    if not (root / ".claude").exists():
+        console.print("[yellow]Note:[/yellow] .claude directory not found. Continuing for MCP/global config if applicable.")
+
+    return run_migration(
+        root=root,
+        migrate_agents=migrate_agents,
+        migrate_commands=migrate_commands,
+        migrate_permissions=migrate_permissions,
+        migrate_mcp=migrate_mcp,
+        include_local_settings=args.include_local,
+        mcp_target=args.mcp_target,
+        dry_run=args.dry_run,
+        conflict=args.conflict,
+        console=console,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/agents/test-agent.md
+++ b/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/agents/test-agent.md
@@ -1,0 +1,13 @@
+---
+name: test-agent
+description: A test agent for migration testing
+tools: WebSearch, WebFetch, Read, Grep, mcp__tools__ls
+color: yellow
+model: sonnet
+---
+
+You are a test agent used for verifying the migration script works correctly.
+
+## Purpose
+
+This agent exists solely for testing purposes.

--- a/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/commands/test-command.md
+++ b/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/commands/test-command.md
@@ -1,0 +1,10 @@
+# Test Command
+
+This is a test command for migration testing.
+
+## Instructions
+
+Follow these steps:
+1. Step one
+2. Step two
+3. Step three

--- a/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/settings.json
+++ b/claude_to_opencode_migration/tests/fixtures/claude_sample/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch",
+      "Bash(git status)",
+      "Bash(git log:*)",
+      "Bash(cargo test:*)",
+      "mcp__tools__ls",
+      "mcp__linear-server__list_teams"
+    ],
+    "deny": [
+      "Bash(rm:*)"
+    ]
+  }
+}

--- a/claude_to_opencode_migration/tests/test_migration.py
+++ b/claude_to_opencode_migration/tests/test_migration.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "pytest>=8.0.0",
+#   "PyYAML>=6.0.2",
+#   "rich>=13.7.0",
+# ]
+# ///
+"""
+Tests for Claude Code → OpenCode Migration Script
+
+Run with: uv run pytest claude_to_opencode_migration/tests/test_migration.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from rich.console import Console
+
+# Import from sibling module
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from migrate_claude_to_opencode import (
+    normalize_tool_name,
+    tools_list_to_mapping,
+    map_model,
+    ensure_color_hex,
+    parse_bash_pattern,
+    parse_yaml_frontmatter,
+    make_yaml_frontmatter,
+    extract_title_for_description,
+    transform_agent_markdown,
+    transform_command_markdown,
+    build_permissions_from_settings,
+    transform_mcp_servers,
+    run_migration,
+)
+
+
+# ---------------------------
+# Fixtures
+# ---------------------------
+
+@pytest.fixture
+def console() -> Console:
+    """A console that captures output."""
+    return Console(force_terminal=False, no_color=True)
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Path:
+    """Create a temporary project with Claude config."""
+    fixtures = Path(__file__).parent / "fixtures" / "claude_sample"
+    if fixtures.exists():
+        shutil.copytree(fixtures, tmp_path / "project")
+        return tmp_path / "project"
+
+    # Fallback: create minimal structure
+    project = tmp_path / "project"
+    claude_dir = project / ".claude"
+    (claude_dir / "agents").mkdir(parents=True)
+    (claude_dir / "commands").mkdir(parents=True)
+
+    # Create sample agent
+    (claude_dir / "agents" / "test-agent.md").write_text("""---
+name: test-agent
+description: A test agent
+tools: Read, Grep, mcp__tools__ls
+color: blue
+model: sonnet
+---
+
+Test agent prompt content.
+""")
+
+    # Create sample command
+    (claude_dir / "commands" / "test-command.md").write_text("""# Test Command
+
+Do the thing.
+""")
+
+    # Create settings
+    (claude_dir / "settings.json").write_text(json.dumps({
+        "permissions": {
+            "allow": ["Bash(git status)", "WebFetch", "mcp__tools__ls"],
+            "deny": ["Bash(rm:*)"]
+        }
+    }))
+
+    return project
+
+
+# ---------------------------
+# Unit Tests: normalize_tool_name
+# ---------------------------
+
+class TestNormalizeToolName:
+    def test_lowercase_conversion(self):
+        # WebSearch is unsupported, so use other tools
+        assert normalize_tool_name("Read") == "read"
+        assert normalize_tool_name("GREP") == "grep"
+        assert normalize_tool_name("WebFetch") == "webfetch"
+
+    def test_mcp_pattern_conversion(self):
+        assert normalize_tool_name("mcp__tools__ls") == "tools_ls"
+        assert normalize_tool_name("mcp__linear-server__list_teams") == "linear-server_list_teams"
+        assert normalize_tool_name("mcp__pr_comments__get_all") == "pr_comments_get_all"
+
+    def test_hyphen_preservation_in_server_name(self):
+        result = normalize_tool_name("mcp__my-server__my_tool")
+        assert result == "my-server_my_tool"
+
+    def test_unsupported_tools_dropped(self, console):
+        assert normalize_tool_name("WebSearch", console=console) is None
+        assert normalize_tool_name("Task", console=console) is None
+
+    def test_already_lowercase(self):
+        assert normalize_tool_name("read") == "read"
+        assert normalize_tool_name("grep") == "grep"
+
+
+# ---------------------------
+# Unit Tests: tools_list_to_mapping
+# ---------------------------
+
+class TestToolsListToMapping:
+    def test_basic_conversion(self, console):
+        result = tools_list_to_mapping(["Read", "Grep", "Glob"], console)
+        assert result == {"*": False, "read": True, "grep": True, "glob": True}
+
+    def test_with_mcp_tools(self, console):
+        result = tools_list_to_mapping(["Read", "mcp__tools__ls"], console)
+        assert result == {"*": False, "read": True, "tools_ls": True}
+
+    def test_unsupported_tools_excluded(self, console):
+        result = tools_list_to_mapping(["Read", "WebSearch", "Grep"], console)
+        assert "websearch" not in result
+        assert result == {"*": False, "read": True, "grep": True}
+
+    def test_empty_list(self, console):
+        result = tools_list_to_mapping([], console)
+        assert result == {"*": False}
+
+
+# ---------------------------
+# Unit Tests: map_model
+# ---------------------------
+
+class TestMapModel:
+    def test_alias_mapping(self):
+        assert map_model("sonnet") == "anthropic/claude-sonnet-4-5"
+        assert map_model("opus") == "anthropic/claude-opus-4-5"
+        assert map_model("haiku") == "anthropic/claude-haiku-4-5"
+
+    def test_versioned_aliases(self):
+        assert map_model("sonnet-4.5") == "anthropic/claude-sonnet-4-5"
+        assert map_model("opus-4.5") == "anthropic/claude-opus-4-5"
+
+    def test_already_namespaced_passthrough(self):
+        assert map_model("anthropic/claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
+        assert map_model("openai/gpt-4") == "openai/gpt-4"
+
+    def test_case_insensitive(self):
+        assert map_model("SONNET") == "anthropic/claude-sonnet-4-5"
+        assert map_model("Opus") == "anthropic/claude-opus-4-5"
+
+    def test_none_handling(self):
+        assert map_model(None) is None
+        assert map_model("") is None
+
+    def test_unknown_passthrough(self):
+        assert map_model("unknown-model") == "unknown-model"
+
+
+# ---------------------------
+# Unit Tests: ensure_color_hex
+# ---------------------------
+
+class TestEnsureColorHex:
+    def test_known_colors(self, console):
+        assert ensure_color_hex("blue", console, "test") == "#3B82F6"
+        assert ensure_color_hex("yellow", console, "test") == "#EAB308"
+        assert ensure_color_hex("green", console, "test") == "#22C55E"
+        assert ensure_color_hex("red", console, "test") == "#EF4444"
+        assert ensure_color_hex("cyan", console, "test") == "#06B6D4"
+        assert ensure_color_hex("magenta", console, "test") == "#D946EF"
+
+    def test_hex_passthrough(self, console):
+        # Function normalizes to lowercase
+        assert ensure_color_hex("#FF5733", console, "test") == "#ff5733"
+        assert ensure_color_hex("FF5733", console, "test") == "#ff5733"
+
+    def test_case_insensitive(self, console):
+        assert ensure_color_hex("BLUE", console, "test") == "#3B82F6"
+        assert ensure_color_hex("Yellow", console, "test") == "#EAB308"
+
+    def test_none_handling(self, console):
+        assert ensure_color_hex(None, console, "test") is None
+        assert ensure_color_hex("", console, "test") is None
+
+    def test_unknown_color_warning(self, console):
+        result = ensure_color_hex("purple", console, "test")
+        assert result == "purple"  # Kept as-is with warning
+
+
+# ---------------------------
+# Unit Tests: parse_bash_pattern
+# ---------------------------
+
+class TestParseBashPattern:
+    def test_simple_command(self):
+        assert parse_bash_pattern("Bash(pwd)") == "pwd"
+        assert parse_bash_pattern("Bash(git status)") == "git status"
+
+    def test_wildcard_pattern(self):
+        assert parse_bash_pattern("Bash(git log:*)") == "git log *"
+        assert parse_bash_pattern("Bash(cargo test:*)") == "cargo test *"
+
+    def test_pipe_pattern(self):
+        assert parse_bash_pattern("Bash(env | grep:*)") == "env | grep *"
+
+    def test_non_bash_returns_none(self):
+        assert parse_bash_pattern("WebFetch") is None
+        assert parse_bash_pattern("Read") is None
+        assert parse_bash_pattern("mcp__tools__ls") is None
+
+
+# ---------------------------
+# Unit Tests: parse_yaml_frontmatter
+# ---------------------------
+
+class TestParseYamlFrontmatter:
+    def test_with_frontmatter(self):
+        md = """---
+name: test
+description: A test
+---
+
+Body content here.
+"""
+        fm, body = parse_yaml_frontmatter(md)
+        assert fm == {"name": "test", "description": "A test"}
+        assert "Body content here." in body
+
+    def test_without_frontmatter(self):
+        md = "# Just a heading\n\nSome content."
+        fm, body = parse_yaml_frontmatter(md)
+        assert fm is None
+        assert body == md
+
+    def test_empty_frontmatter(self):
+        md = """---
+---
+
+Body only.
+"""
+        fm, body = parse_yaml_frontmatter(md)
+        assert fm == {}
+        assert "Body only." in body
+
+
+# ---------------------------
+# Unit Tests: extract_title_for_description
+# ---------------------------
+
+class TestExtractTitleForDescription:
+    def test_extracts_h1(self):
+        md = "# My Command Title\n\nSome content."
+        assert extract_title_for_description(md, "fallback.md") == "My Command Title"
+
+    def test_fallback_to_filename(self):
+        md = "No heading here, just content."
+        assert extract_title_for_description(md, "my-command.md") == "My Command"
+        assert extract_title_for_description(md, "test_command.md") == "Test Command"
+
+    def test_first_h1_wins(self):
+        md = "# First\n\n# Second"
+        assert extract_title_for_description(md, "fallback.md") == "First"
+
+
+# ---------------------------
+# Unit Tests: transform_agent_markdown
+# ---------------------------
+
+class TestTransformAgentMarkdown:
+    def test_full_transformation(self, console):
+        md = """---
+name: test-agent
+description: Test agent description
+tools: Read, Grep, mcp__tools__ls
+color: yellow
+model: sonnet
+---
+
+Agent prompt content.
+"""
+        result = transform_agent_markdown(md, "test-agent.md", console)
+
+        assert "mode: subagent" in result
+        assert "description: Test agent description" in result
+        assert "model: anthropic/claude-sonnet-4-5" in result
+        assert "color: '#EAB308'" in result
+        assert "'*': false" in result
+        assert "read: true" in result
+        assert "grep: true" in result
+        assert "tools_ls: true" in result
+        assert "Agent prompt content." in result
+        # name should NOT be in output
+        assert "name: test-agent" not in result
+
+    def test_without_optional_fields(self, console):
+        md = """---
+description: Minimal agent
+---
+
+Content.
+"""
+        result = transform_agent_markdown(md, "minimal.md", console)
+        assert "mode: subagent" in result
+        assert "description: Minimal agent" in result
+        assert "'*': false" in result
+
+
+# ---------------------------
+# Unit Tests: transform_command_markdown
+# ---------------------------
+
+class TestTransformCommandMarkdown:
+    def test_without_frontmatter(self, console):
+        md = """# My Command
+
+Do something useful.
+"""
+        result = transform_command_markdown(md, "my-command.md", console)
+        assert "description: My Command" in result
+        assert "Do something useful." in result
+
+    def test_with_existing_frontmatter(self, console):
+        md = """---
+model: opus
+---
+
+# Custom Command
+
+Content here.
+"""
+        result = transform_command_markdown(md, "custom.md", console)
+        assert "model: anthropic/claude-opus-4-5" in result
+        assert "description: Custom Command" in result
+
+
+# ---------------------------
+# Unit Tests: build_permissions_from_settings
+# ---------------------------
+
+class TestBuildPermissionsFromSettings:
+    def test_bash_patterns(self, console):
+        settings = {
+            "permissions": {
+                "allow": ["Bash(git status)", "Bash(git log:*)"],
+                "deny": ["Bash(rm:*)"]
+            }
+        }
+        perm, tools = build_permissions_from_settings(settings, console)
+
+        assert perm["bash"]["git status"] == "allow"
+        assert perm["bash"]["git log *"] == "allow"
+        assert perm["bash"]["rm *"] == "deny"
+        assert perm["bash"]["*"] == "ask"
+
+    def test_mcp_tools(self, console):
+        settings = {
+            "permissions": {
+                "allow": ["mcp__tools__ls", "mcp__linear-server__list_teams"],
+                "deny": []
+            }
+        }
+        perm, tools = build_permissions_from_settings(settings, console)
+
+        assert tools["tools_*"] is True
+        assert tools["linear-server_*"] is True
+
+    def test_regular_tools(self, console):
+        settings = {
+            "permissions": {
+                "allow": ["WebFetch", "Read"],
+                "deny": []
+            }
+        }
+        perm, tools = build_permissions_from_settings(settings, console)
+
+        assert tools["webfetch"] is True
+        assert tools["read"] is True
+
+
+# ---------------------------
+# Unit Tests: transform_mcp_servers
+# ---------------------------
+
+class TestTransformMcpServers:
+    def test_stdio_to_local(self, console):
+        mcp_src = {
+            "tools": {
+                "type": "stdio",
+                "command": "my-tool",
+                "args": ["mcp"],
+                "env": {"FOO": "bar"}
+            }
+        }
+        result = transform_mcp_servers(mcp_src, console)
+
+        assert result["tools"]["type"] == "local"
+        assert result["tools"]["command"] == ["my-tool", "mcp"]
+        assert result["tools"]["environment"] == {"FOO": "bar"}
+        assert result["tools"]["enabled"] is True
+
+    def test_sse_to_remote(self, console):
+        mcp_src = {
+            "linear": {
+                "type": "sse",
+                "url": "https://mcp.linear.app/sse"
+            }
+        }
+        result = transform_mcp_servers(mcp_src, console)
+
+        assert result["linear"]["type"] == "remote"
+        assert result["linear"]["url"] == "https://mcp.linear.app/sse"
+        assert result["linear"]["enabled"] is True
+
+    def test_command_array_passthrough(self, console):
+        mcp_src = {
+            "tool": {
+                "type": "stdio",
+                "command": ["python", "-m", "mcp"]
+            }
+        }
+        result = transform_mcp_servers(mcp_src, console)
+        assert result["tool"]["command"] == ["python", "-m", "mcp"]
+
+
+# ---------------------------
+# Integration Tests
+# ---------------------------
+
+class TestIntegration:
+    def test_full_migration_dry_run(self, temp_project, console):
+        """Test that dry-run doesn't create files."""
+        result = run_migration(
+            root=temp_project,
+            migrate_agents=True,
+            migrate_commands=True,
+            migrate_permissions=True,
+            migrate_mcp=False,
+            include_local_settings=False,
+            mcp_target="project",
+            dry_run=True,
+            conflict="skip",
+            console=console,
+        )
+
+        assert result == 0
+        # Dry run should NOT create .opencode directory
+        # (it only prints what would happen)
+
+    def test_agent_migration_creates_files(self, temp_project, console):
+        """Test that agent migration creates correct files."""
+        result = run_migration(
+            root=temp_project,
+            migrate_agents=True,
+            migrate_commands=False,
+            migrate_permissions=False,
+            migrate_mcp=False,
+            include_local_settings=False,
+            mcp_target="project",
+            dry_run=False,
+            conflict="overwrite",
+            console=console,
+        )
+
+        assert result == 0
+
+        agent_dir = temp_project / ".opencode" / "agent"
+        assert agent_dir.exists()
+
+        agent_file = agent_dir / "test-agent.md"
+        assert agent_file.exists()
+
+        content = agent_file.read_text()
+        assert "mode: subagent" in content
+
+    def test_idempotency(self, temp_project, console):
+        """Test that running twice produces same result."""
+        # First run
+        run_migration(
+            root=temp_project,
+            migrate_agents=True,
+            migrate_commands=True,
+            migrate_permissions=True,
+            migrate_mcp=False,
+            include_local_settings=False,
+            mcp_target="project",
+            dry_run=False,
+            conflict="overwrite",
+            console=console,
+        )
+
+        # Capture state
+        agent_content = (temp_project / ".opencode" / "agent" / "test-agent.md").read_text()
+
+        # Second run
+        run_migration(
+            root=temp_project,
+            migrate_agents=True,
+            migrate_commands=True,
+            migrate_permissions=True,
+            migrate_mcp=False,
+            include_local_settings=False,
+            mcp_target="project",
+            dry_run=False,
+            conflict="overwrite",
+            console=console,
+        )
+
+        # Content should be identical
+        agent_content_2 = (temp_project / ".opencode" / "agent" / "test-agent.md").read_text()
+        assert agent_content == agent_content_2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What problem(s) was I solving?

Users migrating from Claude Code to OpenCode currently have no automated way to transfer their configurations. This includes agents, commands, permission settings, and MCP server configurations—all of which require manual conversion between different config formats and directory structures.

## What user-facing changes did I ship?

Added a new self-contained Python CLI migration script that converts Claude Code configurations to OpenCode format:

- **Agents**: Migrates `.claude/agents/*.md` → `.opencode/agent/*.md` with automatic frontmatter transformation (removes `name`, adds `mode: subagent`, converts tool names, maps models and colors)
- **Commands**: Migrates `.claude/commands/*.md` → `.opencode/command/*.md` with description extraction from headings
- **Permissions**: Converts `Bash(cmd:*)` patterns to OpenCode `permission.bash` format, transforms `mcp__server__tool` patterns to `server_*` wildcards
- **MCP Servers**: Transforms `stdio` → `local` with command arrays, `sse`/`http` → `remote` with URLs

## How I implemented it

Created `claude_to_opencode_migration/` as a standalone Python CLI tool using:

- **PEP 723 inline dependencies** (`PyYAML`, `rich`) for zero-setup execution via `uv run`
- **Action-based migration plan engine** that accumulates all changes before execution
- **Dry-run support** with unified diff output to preview changes
- **Timestamped backups** in `.opencode-migrate-backup/` before any overwrites
- **Conflict strategies**: skip (default), overwrite, or interactive prompt
- **Comprehensive test suite** (43 tests) covering all transformation logic

Key transformations:
- Model aliases: `sonnet` → `anthropic/claude-sonnet-4-5`
- Color names: `yellow` → `#EAB308`
- Tool names: `mcp__tools__ls` → `tools_ls`
- Unsupported tools (`WebSearch`, `Task`) dropped with warnings

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Add Claude Code to OpenCode migration CLI with support for agents, commands, permissions, and MCP servers. Features dry-run mode, automatic backups, and 43 unit/integration tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a Claude Code to OpenCode migration tool for converting agents, commands, permissions, and MCP server configurations, including dry-run preview and conflict resolution options.

* **Documentation**
  * Added comprehensive documentation for the migration tool with usage examples, transformation mappings, and CLI reference.

* **Tests**
  * Added test suite validating migration functionality and scenarios.

* **Chores**
  * Added Python-specific .gitignore rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->