### PR TITLE
Allison eng 659 opencode orchestrator troubleshooting tools

### DIFF
--- a/.opencode/command/openai.md
+++ b/.opencode/command/openai.md
@@ -1,5 +1,5 @@
 ---
-description: Interact with Linear for issue/project management
+description: Interact with OpenAI for general-purpose assistant tasks
 agent: NormalOpenAI
 ---
 $ARGUMENTS

--- a/.opencode/command/openai.md
+++ b/.opencode/command/openai.md
@@ -1,0 +1,5 @@
+---
+description: Interact with Linear for issue/project management
+agent: NormalOpenAI
+---
+$ARGUMENTS

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -18,6 +18,7 @@ You have access to these orchestrator tools:
 |------|---------|
 | `orchestrator_run` | Start or resume a session. Accepts optional `command`, `message`, and `session_id` parameters. |
 | `orchestrator_list_sessions` | List available sessions with IDs and descriptions. |
+| `orchestrator_get_session_state` | Inspect one session's status, pending messages, recent tool calls, and last activity. |
 | `orchestrator_list_commands` | List available commands that can be run. |
 | `orchestrator_respond_permission` | Respond to permission requests with "once", "always", or "reject". |
 

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -213,6 +213,22 @@ Limit responses to 4 bullets maximum, 2 sentences each. When reporting session r
 
 **Directory access requests:** These often indicate a session is doing something incorrectly. Sessions should use `ask_agent` with `location=references` to explore reference repos, not direct file access. Reject directory permission requests and redirect the session to use the appropriate agent tools.
 
+### Session Troubleshooting
+
+When a session appears stuck, fails silently, or returns unexpected results:
+
+1. **List all sessions** using `orchestrator_list_sessions` to see session status (Idle/Busy/Retry) and identify which sessions you launched.
+2. **Inspect detailed state** using `orchestrator_get_session_state` (surfaced prompt alias for the MCP app's `get_session_state` tool) with the session ID to see:
+   - Current status including retry information
+   - Pending message count
+   - Recent tool calls and their states (pending/running/completed/error)
+   - Last activity timestamp
+3. **Common patterns**:
+   - Session stuck in "Busy" for too long → may indicate a hung tool or deadlock
+   - Session in "Retry" → provider overload or rate limiting; check retry details
+   - Tool calls stuck in "pending" or "running" → execution interrupted or timed out
+   - `launched_by_you: false` → session was created by another process; may need context
+
 </edge_cases>
 
 <appendix>

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -21,6 +21,7 @@ You have access to these orchestrator tools:
 | `orchestrator_get_session_state` | Inspect one session's status, pending messages, recent tool calls, and last activity. |
 | `orchestrator_list_commands` | List available commands that can be run. |
 | `orchestrator_respond_permission` | Respond to permission requests with "once", "always", or "reject". |
+| `orchestrator_respond_question` | Respond to question requests from sessions. |
 
 You also have `read` access for inspecting files when coordinating work.
 
@@ -218,17 +219,18 @@ Limit responses to 4 bullets maximum, 2 sentences each. When reporting session r
 
 When a session appears stuck, fails silently, or returns unexpected results:
 
-1. **List all sessions** using `orchestrator_list_sessions` to see session status (Idle/Busy/Retry) and identify which sessions you launched.
+1. **List all sessions** using `orchestrator_list_sessions` to see session status (Idle/Busy/Retry/unknown) and identify which sessions you launched.
 2. **Inspect detailed state** using `orchestrator_get_session_state` (surfaced prompt alias for the MCP app's `get_session_state` tool) with the session ID to see:
    - Current status including retry information
    - Pending message count
    - Recent tool calls and their states (pending/running/completed/error)
    - Last activity timestamp
 3. **Common patterns**:
-   - Session stuck in "Busy" for too long → may indicate a hung tool or deadlock
-   - Session in "Retry" → provider overload or rate limiting; check retry details
-   - Tool calls stuck in "pending" or "running" → execution interrupted or timed out
-   - `launched_by_you: false` → session was created by another process; may need context
+    - Session stuck in "Busy" for too long → may indicate a hung tool or deadlock
+    - Session in "Retry" → provider overload or rate limiting; check retry details
+    - Session shown as `unknown` in `orchestrator_list_sessions` → status enrichment failed or was unavailable; retry or investigate instead of treating it like `Idle`
+    - Tool calls stuck in "pending" or "running" → execution interrupted or timed out
+    - `launched_by_you: false` → session was created by another process; may need context
 
 </edge_cases>
 

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -1,7 +1,7 @@
 <tool_definitions>
 orchestrator_run: Start or resume a session.
   Parameters:
-    command: Optional command name (research_openai, create_plan_init_openai, create_plan_final_openai, implement_plan_openai, review_pr_comments_openai, unwind_openai, resume_work_openai, commit, bash, linear, playwright, describe_pr)
+    command: Optional command name. Use orchestrator_list_commands to discover the current set (for example openai, research_openai, implement_plan_openai, commit, bash, or capture_pr_comments_openai)
     message: The prompt or arguments for the command
     session_id: Optional session ID to resume instead of creating new
 
@@ -17,6 +17,13 @@ orchestrator_respond_permission: Respond to permission requests from sessions.
   Parameters:
     session_id: The session requesting permission
     reply: "once" (allow this request), "always" (allow pattern), or "reject"
+
+orchestrator_respond_question: Respond to question requests from sessions.
+  Parameters:
+    session_id: The session requesting question answers
+    question_request_id: Optional specific pending question ID when more than one exists
+    action: "reply" or "reject"
+    answers: Required when action=reply; one list per question
 </tool_definitions>
 
 <available_commands>
@@ -25,13 +32,18 @@ linear: Grants 9 Linear tools for issue management (read, search, create, archiv
 playwright: Grants 22 browser automation tools (navigate, click, fill, screenshot, evaluate, and more).
 commit: Uses bash agent for creating atomic conventional commits.
 describe_pr: Uses the existing bash-based PR description workflow; no OpenAI-specific variant yet.
+openai: Interact with OpenAI for general-purpose assistant tasks.
 research_openai: Gathers facts, explores code, and documents findings with file:line references using the GPT-5.4 workflow.
 create_plan_init_openai: Interactive discovery phase for planning with explicit GPT-5.4 reasoning and user question resolution.
 create_plan_final_openai: Writes the requirements dossier and generates the implementation plan with GPT-5.4-oriented structure.
 implement_plan_openai: Executes plan phases with verification, resume discipline, and GPT-5.4 workflow guidance.
 review_pr_comments_openai: Triage and analyze PR review comments, then write a versioned artifact and overview.
+capture_pr_comments_openai: Capture PR review comments and code snapshots into a normalized artifact.
+resolve_pr_comments_openai: Resolve PR review comments from the orchestrator layer with bounded child sessions.
 unwind_openai: Capture a structured handoff artifact for later GPT-5.4 resumption.
 resume_work_openai: Resume from a structured OpenAI handoff artifact with re-grounding and verification.
+decide_findings_openai: Resolve findings from the orchestrator layer with bounded child sessions.
+frame_openai: Turn a short or under-specified prompt into a stronger GPT-5.4 working frame.
 </available_commands>
 
 <session_tools>
@@ -220,7 +232,7 @@ For multi-session implementations after summarization:
 When sessions appear stuck, fail silently, or return unexpected results, use these diagnostic tools:
 
 1. `orchestrator_list_sessions` — Lists all sessions with:
-   - Session status (Idle/Busy/Retry)
+   - Session status (Idle/Busy/Retry/unknown)
    - `launched_by_you` marker for sessions you created
    - Working directory and change statistics
 
@@ -233,6 +245,7 @@ When sessions appear stuck, fail silently, or return unexpected results, use the
 **Diagnostic patterns:**
 - Session stuck in "Busy" too long → possible hung tool or deadlock
 - Session in "Retry" → check retry message for provider issues
+- Session shown as `unknown` in `orchestrator_list_sessions` → status enrichment failed or was unavailable; retry or investigate instead of treating it like `Idle`
 - Tool calls in "pending"/"running" → execution was interrupted
 - `launched_by_you: false` → session from another process
 

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -7,6 +7,10 @@ orchestrator_run: Start or resume a session.
 
 orchestrator_list_sessions: List available sessions with their IDs and descriptions. No parameters.
 
+orchestrator_get_session_state: Inspect a specific session's status, pending messages, recent tool calls, and last activity.
+  Parameters:
+    session_id: The session ID to inspect
+
 orchestrator_list_commands: List available commands that can be run. No parameters.
 
 orchestrator_respond_permission: Respond to permission requests from sessions.

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -209,6 +209,37 @@ For multi-session implementations after summarization:
 3. Resume with `/resume_work_openai {artifact_path}` instead of manually restating completed phases
 </context_limit_handling>
 
+<troubleshooting>
+
+## Session Troubleshooting
+
+When sessions appear stuck, fail silently, or return unexpected results, use these diagnostic tools:
+
+1. `orchestrator_list_sessions` — Lists all sessions with:
+   - Session status (Idle/Busy/Retry)
+   - `launched_by_you` marker for sessions you created
+   - Working directory and change statistics
+
+2. `orchestrator_get_session_state` — Detailed inspection of a specific session (surfaced prompt alias for the MCP app's `get_session_state` tool):
+   - Current status with retry details (attempt count, reason, next retry time)
+   - Pending message count
+   - Recent tool calls with states (pending/running/completed/error)
+   - Last activity timestamp
+
+**Diagnostic patterns:**
+- Session stuck in "Busy" too long → possible hung tool or deadlock
+- Session in "Retry" → check retry message for provider issues
+- Tool calls in "pending"/"running" → execution was interrupted
+- `launched_by_you: false` → session from another process
+
+**When to use:**
+- Before resuming work on a session
+- When a session returns an error or unexpected result
+- When you need to understand what a session was doing
+- When triaging multiple active sessions
+
+</troubleshooting>
+
 <prompting_sessions>
 For research tasks:
 1. Ask specific questions

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -11,8 +11,10 @@ use opencode_rs::types::message::Message;
 use opencode_rs::types::message::Part;
 use opencode_rs::types::provider::ProviderListResponse;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::RwLock;
 
 use crate::version;
 
@@ -83,6 +85,8 @@ pub struct OrchestratorServer {
     base_url: String,
     /// Orchestrator configuration (session timeouts, compaction threshold)
     config: OrchestratorConfig,
+    /// Session IDs created by this orchestrator instance.
+    spawned_sessions: Arc<RwLock<HashSet<String>>>,
 }
 
 impl OrchestratorServer {
@@ -208,6 +212,7 @@ impl OrchestratorServer {
             model_context_limits,
             base_url,
             config,
+            spawned_sessions: Arc::new(RwLock::new(HashSet::new())),
         })
     }
 
@@ -291,6 +296,7 @@ impl OrchestratorServer {
             model_context_limits,
             base_url,
             config,
+            spawned_sessions: Arc::new(RwLock::new(HashSet::new())),
         })
     }
 
@@ -325,6 +331,11 @@ impl OrchestratorServer {
     /// Get the compaction threshold (0.0 - 1.0).
     pub fn compaction_threshold(&self) -> f64 {
         self.config.compaction_threshold
+    }
+
+    /// Returns session IDs created by this orchestrator instance.
+    pub fn spawned_sessions(&self) -> &Arc<RwLock<HashSet<String>>> {
+        &self.spawned_sessions
     }
 
     /// Load model context limits from GET /provider.
@@ -396,6 +407,7 @@ impl OrchestratorServer {
             model_context_limits: HashMap::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             config: OrchestratorConfig::default(),
+            spawned_sessions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 }

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -1090,7 +1090,7 @@ fn extract_recent_tool_calls(messages: &[Message], limit: usize) -> Vec<ToolCall
     let mut tool_calls = Vec::new();
 
     for message in messages.iter().rev() {
-        for part in &message.parts {
+        for part in message.parts.iter().rev() {
             if let Part::Tool {
                 call_id,
                 tool,

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -4,7 +4,10 @@ use crate::config;
 use crate::logging;
 use crate::server::OrchestratorServer;
 use crate::token_tracker::TokenTracker;
+use crate::types::ChangeStats;
 use crate::types::CommandInfo;
+use crate::types::GetSessionStateInput;
+use crate::types::GetSessionStateOutput;
 use crate::types::ListCommandsInput;
 use crate::types::ListCommandsOutput;
 use crate::types::ListSessionsInput;
@@ -20,7 +23,10 @@ use crate::types::RespondPermissionOutput;
 use crate::types::RespondQuestionInput;
 use crate::types::RespondQuestionOutput;
 use crate::types::RunStatus;
+use crate::types::SessionStatusSummary;
 use crate::types::SessionSummary;
+use crate::types::ToolCallSummary;
+use crate::types::ToolStateSummary;
 use agentic_logging::CallTimer;
 use agentic_logging::ToolCallRecord;
 use agentic_tools_core::Tool;
@@ -32,8 +38,11 @@ use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
 use opencode_rs::types::event::Event;
 use opencode_rs::types::message::CommandRequest;
+use opencode_rs::types::message::Message;
+use opencode_rs::types::message::Part;
 use opencode_rs::types::message::PromptPart;
 use opencode_rs::types::message::PromptRequest;
+use opencode_rs::types::message::ToolState;
 use opencode_rs::types::permission::PermissionReply as ApiPermissionReply;
 use opencode_rs::types::permission::PermissionReplyRequest;
 use opencode_rs::types::question::QuestionReply;
@@ -363,6 +372,12 @@ impl OrchestratorRunTool {
                 .create(&CreateSessionRequest::default())
                 .await
                 .map_err(|e| ToolError::Internal(format!("Failed to create session: {e}")))?;
+
+            {
+                let mut spawned = server.spawned_sessions().write().await;
+                spawned.insert(session.id.clone());
+            }
+
             session.id
         };
 
@@ -977,20 +992,235 @@ impl Tool for ListSessionsTool {
                     server.client().sessions().list().await.map_err(|e| {
                         ToolError::Internal(format!("Failed to list sessions: {e}"))
                     })?;
+                let status_map = server
+                    .client()
+                    .sessions()
+                    .status_map()
+                    .await
+                    .unwrap_or_default();
+                let spawned = server.spawned_sessions().read().await;
 
                 let limit = input.limit.unwrap_or(20);
                 let summaries: Vec<SessionSummary> = sessions
                     .into_iter()
                     .take(limit)
-                    .map(|s| SessionSummary {
-                        id: s.id,
-                        title: s.title,
-                        updated: s.time.as_ref().map(|t| t.updated),
+                    .map(|s| {
+                        let status =
+                            status_map
+                                .get(&s.id)
+                                .map_or(SessionStatusSummary::Idle, |info| match info {
+                                    SessionStatusInfo::Idle => SessionStatusSummary::Idle,
+                                    SessionStatusInfo::Busy => SessionStatusSummary::Busy,
+                                    SessionStatusInfo::Retry {
+                                        attempt,
+                                        message,
+                                        next,
+                                    } => SessionStatusSummary::Retry {
+                                        attempt: *attempt,
+                                        message: message.clone(),
+                                        next: *next,
+                                    },
+                                });
+
+                        let change_stats = s.summary.as_ref().map(|summary| ChangeStats {
+                            additions: summary.additions,
+                            deletions: summary.deletions,
+                            files: summary.files,
+                        });
+
+                        SessionSummary {
+                            launched_by_you: spawned.contains(&s.id),
+                            created: s.time.as_ref().map(|t| t.created),
+                            updated: s.time.as_ref().map(|t| t.updated),
+                            directory: s.directory,
+                            title: s.title,
+                            id: s.id,
+                            status: Some(status),
+                            change_stats,
+                        }
                     })
                     .collect();
 
                 Ok(ListSessionsOutput {
                     sessions: summaries,
+                })
+            }
+            .await;
+
+            match result {
+                Ok(output) => {
+                    log_tool_success(
+                        &timer,
+                        Self::NAME,
+                        &input,
+                        &output,
+                        ToolLogMeta::default(),
+                        false,
+                    );
+                    Ok(output)
+                }
+                Err(error) => {
+                    log_tool_error(&timer, Self::NAME, &input, &error);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+fn count_pending_messages(messages: &[Message]) -> usize {
+    let mut pending = 0;
+    let mut last_was_user = false;
+
+    for message in messages.iter().rev() {
+        if message.role() == "user" {
+            if !last_was_user {
+                pending += 1;
+            }
+            last_was_user = true;
+        } else if message.role() == "assistant" {
+            break;
+        }
+    }
+
+    pending
+}
+
+fn get_last_activity_time(messages: &[Message]) -> Option<i64> {
+    messages.last().map(|message| {
+        message
+            .info
+            .time
+            .completed
+            .unwrap_or(message.info.time.created)
+    })
+}
+
+fn extract_recent_tool_calls(messages: &[Message], limit: usize) -> Vec<ToolCallSummary> {
+    let mut tool_calls = Vec::new();
+
+    for message in messages.iter().rev() {
+        for part in &message.parts {
+            if let Part::Tool {
+                call_id,
+                tool,
+                state,
+                ..
+            } = part
+            {
+                let (state, started_at, completed_at) = match state {
+                    Some(ToolState::Running(running)) => {
+                        (ToolStateSummary::Running, Some(running.time.start), None)
+                    }
+                    Some(ToolState::Completed(completed)) => (
+                        ToolStateSummary::Completed,
+                        Some(completed.time.start),
+                        Some(completed.time.end),
+                    ),
+                    Some(ToolState::Error(error)) => (
+                        ToolStateSummary::Error {
+                            message: error.error.clone(),
+                        },
+                        Some(error.time.start),
+                        Some(error.time.end),
+                    ),
+                    _ => (ToolStateSummary::Pending, None, None),
+                };
+
+                tool_calls.push(ToolCallSummary {
+                    call_id: call_id.clone(),
+                    tool_name: tool.clone(),
+                    state,
+                    started_at,
+                    completed_at,
+                });
+
+                if tool_calls.len() >= limit {
+                    return tool_calls;
+                }
+            }
+        }
+    }
+
+    tool_calls
+}
+
+/// Tool for getting detailed state of a specific `OpenCode` session.
+#[derive(Clone)]
+pub struct GetSessionStateTool {
+    server: Arc<OnceCell<OrchestratorServer>>,
+}
+
+impl GetSessionStateTool {
+    pub fn new(server: Arc<OnceCell<OrchestratorServer>>) -> Self {
+        Self { server }
+    }
+}
+
+impl Tool for GetSessionStateTool {
+    type Input = GetSessionStateInput;
+    type Output = GetSessionStateOutput;
+    const NAME: &'static str = "get_session_state";
+    const DESCRIPTION: &'static str = "Get detailed state of a specific session including status, pending messages, and recent tool calls.";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let server_cell = Arc::clone(&self.server);
+        Box::pin(async move {
+            let timer = CallTimer::start();
+            let result: Result<GetSessionStateOutput, ToolError> = async {
+                let server = server_cell
+                    .get_or_try_init(OrchestratorServer::start_lazy)
+                    .await
+                    .map_err(|e| ToolError::Internal(e.to_string()))?;
+
+                let client = server.client();
+                let session_id = &input.session_id;
+
+                let session = client.sessions().get(session_id).await.map_err(|e| {
+                    if e.is_not_found() {
+                        ToolError::InvalidInput(format!(
+                            "Session '{session_id}' not found. Use list_sessions to discover available sessions."
+                        ))
+                    } else {
+                        ToolError::Internal(format!("Failed to get session: {e}"))
+                    }
+                })?;
+
+                let status = match client.sessions().status_for(session_id).await {
+                    Ok(SessionStatusInfo::Busy) => SessionStatusSummary::Busy,
+                    Ok(SessionStatusInfo::Retry {
+                        attempt,
+                        message,
+                        next,
+                    }) => SessionStatusSummary::Retry {
+                        attempt,
+                        message,
+                        next,
+                    },
+                    Ok(SessionStatusInfo::Idle) | Err(_) => SessionStatusSummary::Idle,
+                };
+
+                let messages = client.messages().list(session_id).await.unwrap_or_default();
+                let pending_message_count = count_pending_messages(&messages);
+                let last_activity = get_last_activity_time(&messages);
+                let recent_tool_calls = extract_recent_tool_calls(&messages, 10);
+
+                let spawned = server.spawned_sessions().read().await;
+                let launched_by_you = spawned.contains(session_id);
+
+                Ok(GetSessionStateOutput {
+                    session_id: session.id,
+                    title: session.title,
+                    directory: session.directory,
+                    status,
+                    launched_by_you,
+                    pending_message_count,
+                    last_activity,
+                    recent_tool_calls,
                 })
             }
             .await;
@@ -1473,6 +1703,7 @@ pub fn build_registry(server: &Arc<OnceCell<OrchestratorServer>>) -> ToolRegistr
     ToolRegistry::builder()
         .register::<OrchestratorRunTool, ()>(OrchestratorRunTool::new(Arc::clone(server)))
         .register::<ListSessionsTool, ()>(ListSessionsTool::new(Arc::clone(server)))
+        .register::<GetSessionStateTool, ()>(GetSessionStateTool::new(Arc::clone(server)))
         .register::<ListCommandsTool, ()>(ListCommandsTool::new(Arc::clone(server)))
         .register::<RespondPermissionTool, ()>(RespondPermissionTool::new(Arc::clone(server)))
         .register::<RespondQuestionTool, ()>(RespondQuestionTool::new(Arc::clone(server)))
@@ -1488,6 +1719,7 @@ mod tests {
     fn tool_names_are_short() {
         assert_eq!(<OrchestratorRunTool as Tool>::NAME, "run");
         assert_eq!(<ListSessionsTool as Tool>::NAME, "list_sessions");
+        assert_eq!(<GetSessionStateTool as Tool>::NAME, "get_session_state");
         assert_eq!(<ListCommandsTool as Tool>::NAME, "list_commands");
         assert_eq!(<RespondPermissionTool as Tool>::NAME, "respond_permission");
         assert_eq!(<RespondQuestionTool as Tool>::NAME, "respond_question");

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -1000,21 +1000,24 @@ impl Tool for ListSessionsTool {
                     .into_iter()
                     .take(limit)
                     .map(|s| {
-                        let status = status_map.as_ref().and_then(|status_map| {
-                            status_map.get(&s.id).map(|info| match info {
-                                SessionStatusInfo::Idle => SessionStatusSummary::Idle,
-                                SessionStatusInfo::Busy => SessionStatusSummary::Busy,
-                                SessionStatusInfo::Retry {
-                                    attempt,
-                                    message,
-                                    next,
-                                } => SessionStatusSummary::Retry {
-                                    attempt: *attempt,
-                                    message: message.clone(),
-                                    next: *next,
-                                },
-                            })
-                        });
+                        let status =
+                            status_map
+                                .as_ref()
+                                .map(|status_map| match status_map.get(&s.id) {
+                                    Some(SessionStatusInfo::Busy) => SessionStatusSummary::Busy,
+                                    Some(SessionStatusInfo::Retry {
+                                        attempt,
+                                        message,
+                                        next,
+                                    }) => SessionStatusSummary::Retry {
+                                        attempt: *attempt,
+                                        message: message.clone(),
+                                        next: *next,
+                                    },
+                                    Some(SessionStatusInfo::Idle) | None => {
+                                        SessionStatusSummary::Idle
+                                    }
+                                });
 
                         let change_stats = s.summary.as_ref().map(|summary| ChangeStats {
                             additions: summary.additions,

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -992,12 +992,7 @@ impl Tool for ListSessionsTool {
                     server.client().sessions().list().await.map_err(|e| {
                         ToolError::Internal(format!("Failed to list sessions: {e}"))
                     })?;
-                let status_map = server
-                    .client()
-                    .sessions()
-                    .status_map()
-                    .await
-                    .unwrap_or_default();
+                let status_map = server.client().sessions().status_map().await.ok();
                 let spawned = server.spawned_sessions().read().await;
 
                 let limit = input.limit.unwrap_or(20);
@@ -1005,22 +1000,21 @@ impl Tool for ListSessionsTool {
                     .into_iter()
                     .take(limit)
                     .map(|s| {
-                        let status =
-                            status_map
-                                .get(&s.id)
-                                .map_or(SessionStatusSummary::Idle, |info| match info {
-                                    SessionStatusInfo::Idle => SessionStatusSummary::Idle,
-                                    SessionStatusInfo::Busy => SessionStatusSummary::Busy,
-                                    SessionStatusInfo::Retry {
-                                        attempt,
-                                        message,
-                                        next,
-                                    } => SessionStatusSummary::Retry {
-                                        attempt: *attempt,
-                                        message: message.clone(),
-                                        next: *next,
-                                    },
-                                });
+                        let status = status_map.as_ref().and_then(|status_map| {
+                            status_map.get(&s.id).map(|info| match info {
+                                SessionStatusInfo::Idle => SessionStatusSummary::Idle,
+                                SessionStatusInfo::Busy => SessionStatusSummary::Busy,
+                                SessionStatusInfo::Retry {
+                                    attempt,
+                                    message,
+                                    next,
+                                } => SessionStatusSummary::Retry {
+                                    attempt: *attempt,
+                                    message: message.clone(),
+                                    next: *next,
+                                },
+                            })
+                        });
 
                         let change_stats = s.summary.as_ref().map(|summary| ChangeStats {
                             additions: summary.additions,
@@ -1035,7 +1029,7 @@ impl Tool for ListSessionsTool {
                             directory: s.directory,
                             title: s.title,
                             id: s.id,
-                            status: Some(status),
+                            status,
                             change_stats,
                         }
                     })
@@ -1070,14 +1064,10 @@ impl Tool for ListSessionsTool {
 
 fn count_pending_messages(messages: &[Message]) -> usize {
     let mut pending = 0;
-    let mut last_was_user = false;
 
     for message in messages.iter().rev() {
         if message.role() == "user" {
-            if !last_was_user {
-                pending += 1;
-            }
-            last_was_user = true;
+            pending += 1;
         } else if message.role() == "assistant" {
             break;
         }
@@ -1190,21 +1180,25 @@ impl Tool for GetSessionStateTool {
                     }
                 })?;
 
-                let status = match client.sessions().status_for(session_id).await {
-                    Ok(SessionStatusInfo::Busy) => SessionStatusSummary::Busy,
-                    Ok(SessionStatusInfo::Retry {
+                let status = match client.sessions().status_for(session_id).await.map_err(|e| {
+                    ToolError::Internal(format!("Failed to get session status: {e}"))
+                })? {
+                    SessionStatusInfo::Busy => SessionStatusSummary::Busy,
+                    SessionStatusInfo::Retry {
                         attempt,
                         message,
                         next,
-                    }) => SessionStatusSummary::Retry {
+                    } => SessionStatusSummary::Retry {
                         attempt,
                         message,
                         next,
                     },
-                    Ok(SessionStatusInfo::Idle) | Err(_) => SessionStatusSummary::Idle,
+                    SessionStatusInfo::Idle => SessionStatusSummary::Idle,
                 };
 
-                let messages = client.messages().list(session_id).await.unwrap_or_default();
+                let messages = client.messages().list(session_id).await.map_err(|e| {
+                    ToolError::Internal(format!("Failed to list messages: {e}"))
+                })?;
                 let pending_message_count = count_pending_messages(&messages);
                 let last_activity = get_last_activity_time(&messages);
                 let recent_tool_calls = extract_recent_tool_calls(&messages, 10);

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -1079,13 +1079,15 @@ fn count_pending_messages(messages: &[Message]) -> usize {
     pending
 }
 
-fn get_last_activity_time(messages: &[Message]) -> Option<i64> {
-    messages.last().map(|message| {
-        message
-            .info
-            .time
-            .completed
-            .unwrap_or(message.info.time.created)
+fn get_last_activity_time(messages: &[Message], fallback: Option<i64>) -> Option<i64> {
+    messages.last().map_or(fallback, |message| {
+        Some(
+            message
+                .info
+                .time
+                .completed
+                .unwrap_or(message.info.time.created),
+        )
     })
 }
 
@@ -1203,7 +1205,10 @@ impl Tool for GetSessionStateTool {
                     ToolError::Internal(format!("Failed to list messages: {e}"))
                 })?;
                 let pending_message_count = count_pending_messages(&messages);
-                let last_activity = get_last_activity_time(&messages);
+                let last_activity = get_last_activity_time(
+                    &messages,
+                    session.time.as_ref().map(|time| time.updated),
+                );
                 let recent_tool_calls = extract_recent_tool_calls(&messages, 10);
 
                 let spawned = server.spawned_sessions().read().await;
@@ -1720,5 +1725,10 @@ mod tests {
         assert_eq!(<ListCommandsTool as Tool>::NAME, "list_commands");
         assert_eq!(<RespondPermissionTool as Tool>::NAME, "respond_permission");
         assert_eq!(<RespondQuestionTool as Tool>::NAME, "respond_question");
+    }
+
+    #[test]
+    fn last_activity_falls_back_to_session_timestamp_when_messages_are_empty() {
+        assert_eq!(get_last_activity_time(&[], Some(1_234)), Some(1_234));
     }
 }

--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -216,7 +216,92 @@ pub struct SessionSummary {
     /// Session title
     pub title: String,
     /// Unix timestamp of last update
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated: Option<i64>,
+    /// Unix timestamp of creation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<i64>,
+    /// Session working directory
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    /// Current session status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<SessionStatusSummary>,
+    /// File change statistics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_stats: Option<ChangeStats>,
+    /// True when the current orchestrator created this session.
+    pub launched_by_you: bool,
+}
+
+/// Session status summary for list/detail views.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum SessionStatusSummary {
+    Idle,
+    Busy,
+    Retry {
+        attempt: u64,
+        message: String,
+        /// Unix timestamp (ms) of next retry attempt.
+        next: u64,
+    },
+}
+
+/// File change statistics from a session summary.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ChangeStats {
+    pub additions: u64,
+    pub deletions: u64,
+    pub files: u64,
+}
+
+/// Input for the `get_session_state` tool.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GetSessionStateInput {
+    /// The session ID to inspect.
+    pub session_id: String,
+}
+
+/// Detailed session state output.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GetSessionStateOutput {
+    pub session_id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    pub status: SessionStatusSummary,
+    /// True when the current orchestrator created this session.
+    pub launched_by_you: bool,
+    /// Number of pending messages awaiting an assistant reply.
+    pub pending_message_count: usize,
+    /// Unix timestamp of the latest activity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_activity: Option<i64>,
+    /// Recent tool calls, most recent first.
+    pub recent_tool_calls: Vec<ToolCallSummary>,
+}
+
+/// Summary of a recent tool call in a session.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ToolCallSummary {
+    pub call_id: String,
+    pub tool_name: String,
+    pub state: ToolStateSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<i64>,
+}
+
+/// Simplified tool state for session diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum ToolStateSummary {
+    Pending,
+    Running,
+    Completed,
+    Error { message: String },
 }
 
 /// Output from the `list_sessions` tool.
@@ -234,11 +319,68 @@ impl TextFormat for ListSessionsOutput {
             let age = s
                 .updated
                 .map_or_else(|| "unknown".to_string(), format_time_ago);
-            let _ = writeln!(out, "  {} - {} ({age})", s.id, s.title);
+            let status = match &s.status {
+                Some(SessionStatusSummary::Idle) => "idle",
+                Some(SessionStatusSummary::Busy) => "busy",
+                Some(SessionStatusSummary::Retry { .. }) => "retry",
+                None => "unknown",
+            };
+            let launched = if s.launched_by_you {
+                " [launched by you]"
+            } else {
+                ""
+            };
+            let _ = writeln!(out, "  {} - {} ({age}, {status}){launched}", s.id, s.title);
         }
 
         if self.sessions.is_empty() {
             out.push_str("  (no sessions found)\n");
+        }
+
+        out
+    }
+}
+
+impl TextFormat for GetSessionStateOutput {
+    fn fmt_text(&self, _opts: &TextOptions) -> String {
+        let mut out = format!("Session: {} ({})\n", self.session_id, self.title);
+
+        if let Some(dir) = &self.directory {
+            let _ = writeln!(out, "  Directory: {dir}");
+        }
+
+        let status_str = match &self.status {
+            SessionStatusSummary::Idle => "Idle".to_string(),
+            SessionStatusSummary::Busy => "Busy".to_string(),
+            SessionStatusSummary::Retry {
+                attempt,
+                message,
+                next,
+            } => format!("Retry (attempt {attempt}, next at {next}, reason: {message})"),
+        };
+        let _ = writeln!(out, "  Status: {status_str}");
+        let _ = writeln!(out, "  Launched by you: {}", self.launched_by_you);
+        let _ = writeln!(out, "  Pending messages: {}", self.pending_message_count);
+
+        if let Some(last) = self.last_activity {
+            let _ = writeln!(out, "  Last activity: {}", format_time_ago(last));
+        }
+
+        if !self.recent_tool_calls.is_empty() {
+            out.push_str("  Recent tool calls:\n");
+            for tool_call in &self.recent_tool_calls {
+                let state_str = match &tool_call.state {
+                    ToolStateSummary::Pending => "pending".to_string(),
+                    ToolStateSummary::Running => "running".to_string(),
+                    ToolStateSummary::Completed => "completed".to_string(),
+                    ToolStateSummary::Error { message } => format!("error: {message}"),
+                };
+                let _ = writeln!(
+                    out,
+                    "    {} ({}) - {}",
+                    tool_call.call_id, tool_call.tool_name, state_str
+                );
+            }
         }
 
         out
@@ -463,6 +605,15 @@ mod tests {
                 id: "sess-1".into(),
                 title: "Research caching".into(),
                 updated: Some(0),
+                created: Some(0),
+                directory: Some("/tmp/project".into()),
+                status: Some(SessionStatusSummary::Idle),
+                change_stats: Some(ChangeStats {
+                    additions: 1,
+                    deletions: 0,
+                    files: 1,
+                }),
+                launched_by_you: true,
             }],
         };
 
@@ -470,6 +621,8 @@ mod tests {
         assert!(text.contains("Sessions (1)"));
         assert!(text.contains("sess-1"));
         assert!(text.contains("Research caching"));
+        assert!(text.contains("idle"));
+        assert!(text.contains("launched by you"));
     }
 
     #[test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -58,6 +58,8 @@ async fn list_sessions_returns_session_ids() {
     assert_eq!(result.sessions.len(), 2);
     assert_eq!(result.sessions[0].id, "ses-1");
     assert_eq!(result.sessions[1].id, "ses-2");
+    assert!(result.sessions[0].status.is_none());
+    assert!(result.sessions[1].status.is_none());
 }
 
 #[tokio::test]
@@ -435,6 +437,128 @@ async fn get_session_state_summarizes_messages_and_launched_by_you() {
         result.recent_tool_calls[3].state,
         ToolStateSummary::Pending
     ));
+}
+
+#[tokio::test]
+async fn get_session_state_returns_error_when_status_lookup_fails() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "name": "InternalError",
+            "message": "boom"
+        })))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let err = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("status lookup failure should error");
+
+    assert!(matches!(err, ToolError::Internal(_)));
+    assert!(err.to_string().contains("Failed to get session status"));
+}
+
+#[tokio::test]
+async fn get_session_state_returns_error_when_message_lookup_fails() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "name": "InternalError",
+            "message": "boom"
+        })))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let err = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("message lookup failure should error");
+
+    assert!(matches!(err, ToolError::Internal(_)));
+    assert!(err.to_string().contains("Failed to list messages"));
+}
+
+#[tokio::test]
+async fn get_session_state_counts_each_trailing_user_message() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock)
+        .await;
+
+    let history = message_history_fixture(vec![
+        message_fixture("ses-1", "m1", "assistant", 1, Some(2), vec![]),
+        message_fixture("ses-1", "m2", "user", 3, None, vec![]),
+        message_fixture("ses-1", "m3", "user", 4, None, vec![]),
+    ]);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(history))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert_eq!(result.pending_message_count, 2);
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -6,10 +6,16 @@ mod support;
 
 use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use opencode_orchestrator_mcp::tools::GetSessionStateTool;
 use opencode_orchestrator_mcp::tools::ListCommandsTool;
 use opencode_orchestrator_mcp::tools::ListSessionsTool;
+use opencode_orchestrator_mcp::types::GetSessionStateInput;
 use opencode_orchestrator_mcp::types::ListCommandsInput;
 use opencode_orchestrator_mcp::types::ListSessionsInput;
+use opencode_orchestrator_mcp::types::SessionStatusSummary;
+use opencode_orchestrator_mcp::types::ToolStateSummary;
+use serde_json::json;
 use std::sync::Arc;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -17,9 +23,17 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
+use support::busy_status_fixture;
 use support::commands_list_fixture;
+use support::message_fixture;
+use support::message_history_fixture;
+use support::retry_status_fixture;
+use support::seed_spawned_sessions;
+use support::session_fixture;
+use support::session_status_fixture;
 use support::sessions_list_fixture;
 use support::test_orchestrator_server;
+use support::tool_part_fixture;
 
 #[tokio::test]
 async fn list_sessions_returns_session_ids() {
@@ -65,6 +79,391 @@ async fn list_sessions_returns_empty_list() {
         .expect("list_sessions should succeed");
 
     assert!(result.sessions.is_empty());
+}
+
+#[tokio::test]
+async fn list_sessions_returns_enriched_fields() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "ses-1",
+                "slug": "ses-1",
+                "projectId": "proj1",
+                "directory": "/tmp/project-a",
+                "title": "Session A",
+                "version": "1.0",
+                "summary": { "additions": 5, "deletions": 2, "files": 1 },
+                "time": { "created": 10, "updated": 20 }
+            },
+            {
+                "id": "ses-2",
+                "slug": "ses-2",
+                "projectId": "proj1",
+                "directory": "/tmp/project-b",
+                "title": "Session B",
+                "version": "1.0",
+                "summary": { "additions": 1, "deletions": 0, "files": 3 },
+                "time": { "created": 30, "updated": 40 }
+            }
+        ])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(session_status_fixture(&[
+                ("ses-1", busy_status_fixture()),
+                ("ses-2", retry_status_fixture(2, "rate limited", 1234)),
+            ])),
+        )
+        .mount(&mock)
+        .await;
+
+    let tool = ListSessionsTool::new(Arc::clone(&server));
+    let result = tool
+        .call(ListSessionsInput { limit: None }, &ToolContext::default())
+        .await
+        .expect("list_sessions should succeed");
+
+    assert_eq!(result.sessions.len(), 2);
+
+    let first = &result.sessions[0];
+    assert_eq!(first.created, Some(10));
+    assert_eq!(first.updated, Some(20));
+    assert_eq!(first.directory.as_deref(), Some("/tmp/project-a"));
+    assert!(matches!(first.status, Some(SessionStatusSummary::Busy)));
+    let first_stats = first.change_stats.as_ref().expect("change stats expected");
+    assert_eq!(first_stats.additions, 5);
+    assert_eq!(first_stats.deletions, 2);
+    assert_eq!(first_stats.files, 1);
+
+    let second = &result.sessions[1];
+    assert!(matches!(
+        second.status,
+        Some(SessionStatusSummary::Retry {
+            attempt: 2,
+            ref message,
+            next: 1234,
+        }) if message == "rate limited"
+    ));
+}
+
+#[tokio::test]
+async fn list_sessions_marks_launched_by_you() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    seed_spawned_sessions(&server, &["ses-1"]).await;
+
+    Mock::given(method("GET"))
+        .and(path("/session"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sessions_list_fixture(&["ses-1", "ses-2"])),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock)
+        .await;
+
+    let tool = ListSessionsTool::new(Arc::clone(&server));
+    let result = tool
+        .call(ListSessionsInput { limit: None }, &ToolContext::default())
+        .await
+        .expect("list_sessions should succeed");
+
+    assert!(result.sessions[0].launched_by_you);
+    assert!(!result.sessions[1].launched_by_you);
+}
+
+#[tokio::test]
+async fn get_session_state_returns_idle_status() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert!(matches!(result.status, SessionStatusSummary::Idle));
+    assert!(!result.launched_by_you);
+}
+
+#[tokio::test]
+async fn get_session_state_returns_busy_status() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert!(matches!(result.status, SessionStatusSummary::Busy));
+}
+
+#[tokio::test]
+async fn get_session_state_returns_retry_status() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(session_status_fixture(&[(
+                "ses-1",
+                retry_status_fixture(3, "provider overloaded", 9876),
+            )])),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert!(matches!(
+        result.status,
+        SessionStatusSummary::Retry {
+            attempt: 3,
+            ref message,
+            next: 9876,
+        } if message == "provider overloaded"
+    ));
+}
+
+#[tokio::test]
+async fn get_session_state_summarizes_messages_and_launched_by_you() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    seed_spawned_sessions(&server, &["ses-1"]).await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
+        )
+        .mount(&mock)
+        .await;
+
+    let history = message_history_fixture(vec![
+        message_fixture(
+            "ses-1",
+            "m1",
+            "assistant",
+            1,
+            Some(2),
+            vec![tool_part_fixture(
+                "call-pending",
+                "read",
+                Some(json!({ "status": "pending", "input": {}, "raw": "read" })),
+            )],
+        ),
+        message_fixture(
+            "ses-1",
+            "m2",
+            "assistant",
+            2,
+            Some(3),
+            vec![tool_part_fixture(
+                "call-running",
+                "write",
+                Some(json!({ "status": "running", "input": {}, "time": { "start": 20 } })),
+            )],
+        ),
+        message_fixture(
+            "ses-1",
+            "m3",
+            "assistant",
+            3,
+            Some(4),
+            vec![tool_part_fixture(
+                "call-completed",
+                "grep",
+                Some(json!({
+                    "status": "completed",
+                    "input": {},
+                    "output": "done",
+                    "title": "grep",
+                    "metadata": {},
+                    "time": { "start": 30, "end": 31 }
+                })),
+            )],
+        ),
+        message_fixture(
+            "ses-1",
+            "m4",
+            "assistant",
+            4,
+            Some(5),
+            vec![tool_part_fixture(
+                "call-error",
+                "edit",
+                Some(json!({
+                    "status": "error",
+                    "input": {},
+                    "error": "boom",
+                    "time": { "start": 40, "end": 41 }
+                })),
+            )],
+        ),
+        message_fixture("ses-1", "m5", "user", 6, None, vec![]),
+    ]);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(history))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert!(result.launched_by_you);
+    assert_eq!(result.pending_message_count, 1);
+    assert_eq!(result.last_activity, Some(6));
+    assert_eq!(result.directory.as_deref(), Some("/tmp"));
+    assert_eq!(result.recent_tool_calls.len(), 4);
+    assert!(matches!(
+        result.recent_tool_calls[0].state,
+        ToolStateSummary::Error { ref message } if message == "boom"
+    ));
+    assert!(matches!(
+        result.recent_tool_calls[1].state,
+        ToolStateSummary::Completed
+    ));
+    assert!(matches!(
+        result.recent_tool_calls[2].state,
+        ToolStateSummary::Running
+    ));
+    assert!(matches!(
+        result.recent_tool_calls[3].state,
+        ToolStateSummary::Pending
+    ));
+}
+
+#[tokio::test]
+async fn get_session_state_unknown_session_returns_error() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "name": "NotFound",
+            "message": "Session not found"
+        })))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let err = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "missing".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("missing session should fail");
+
+    assert!(matches!(err, ToolError::InvalidInput(_)));
+    assert!(err.to_string().contains("Use list_sessions"));
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -184,6 +184,14 @@ async fn list_sessions_marks_launched_by_you() {
 
     assert!(result.sessions[0].launched_by_you);
     assert!(!result.sessions[1].launched_by_you);
+    assert!(matches!(
+        result.sessions[0].status,
+        Some(SessionStatusSummary::Idle)
+    ));
+    assert!(matches!(
+        result.sessions[1].status,
+        Some(SessionStatusSummary::Idle)
+    ));
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -440,6 +440,84 @@ async fn get_session_state_summarizes_messages_and_launched_by_you() {
 }
 
 #[tokio::test]
+async fn get_session_state_orders_tool_parts_recent_first_within_message() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("ses-1")))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
+        )
+        .mount(&mock)
+        .await;
+
+    let history = message_history_fixture(vec![message_fixture(
+        "ses-1",
+        "m1",
+        "assistant",
+        1,
+        Some(2),
+        vec![
+            tool_part_fixture(
+                "call-older",
+                "read",
+                Some(json!({
+                    "status": "completed",
+                    "input": {},
+                    "output": "first",
+                    "title": "read",
+                    "metadata": {},
+                    "time": { "start": 10, "end": 11 }
+                })),
+            ),
+            tool_part_fixture(
+                "call-newer",
+                "write",
+                Some(json!({
+                    "status": "completed",
+                    "input": {},
+                    "output": "second",
+                    "title": "write",
+                    "metadata": {},
+                    "time": { "start": 20, "end": 21 }
+                })),
+            ),
+        ],
+    )]);
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(history))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert_eq!(result.recent_tool_calls.len(), 2);
+    assert_eq!(result.recent_tool_calls[0].call_id, "call-newer");
+    assert_eq!(result.recent_tool_calls[0].tool_name, "write");
+    assert_eq!(result.recent_tool_calls[1].call_id, "call-older");
+    assert_eq!(result.recent_tool_calls[1].tool_name, "read");
+}
+
+#[tokio::test]
 async fn get_session_state_returns_error_when_status_lookup_fails() {
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock);

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 use opencode_orchestrator_mcp::server::OrchestratorServer;
+use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -180,6 +181,30 @@ pub fn status_v2_retry(session_id: &str, attempt: u64) -> serde_json::Value {
     })
 }
 
+/// Create a modern session status map fixture from explicit entries.
+pub fn session_status_fixture(statuses: &[(&str, Value)]) -> Value {
+    let mut map = serde_json::Map::new();
+    for (session_id, status) in statuses {
+        map.insert((*session_id).to_string(), status.clone());
+    }
+    Value::Object(map)
+}
+
+/// Create a busy status fixture entry.
+pub fn busy_status_fixture() -> Value {
+    serde_json::json!({ "type": "busy" })
+}
+
+/// Create a retry status fixture entry.
+pub fn retry_status_fixture(attempt: u64, message: &str, next: u64) -> Value {
+    serde_json::json!({
+        "type": "retry",
+        "attempt": attempt,
+        "message": message,
+        "next": next,
+    })
+}
+
 /// Create a permission fixture.
 pub fn permission_fixture(
     id: &str,
@@ -232,6 +257,53 @@ pub fn messages_fixture(session_id: &str, assistant_text: Option<&str>) -> serde
     serde_json::Value::Array(msgs)
 }
 
+/// Create a message fixture with explicit parts and timestamps.
+pub fn message_fixture(
+    session_id: &str,
+    message_id: &str,
+    role: &str,
+    created: i64,
+    completed: Option<i64>,
+    parts: Vec<Value>,
+) -> Value {
+    let mut time = serde_json::json!({ "created": created });
+    if let Some(completed) = completed {
+        time["completed"] = serde_json::json!(completed);
+    }
+    let parts = Value::Array(parts);
+
+    serde_json::json!({
+        "info": {
+            "id": message_id,
+            "sessionId": session_id,
+            "role": role,
+            "time": time,
+        },
+        "parts": parts,
+    })
+}
+
+/// Create a tool part fixture with an optional state payload.
+pub fn tool_part_fixture(call_id: &str, tool: &str, state: Option<Value>) -> Value {
+    let mut part = serde_json::json!({
+        "type": "tool",
+        "callID": call_id,
+        "tool": tool,
+        "input": {},
+    });
+
+    if let Some(state) = state {
+        part["state"] = state;
+    }
+
+    part
+}
+
+/// Create a message history response fixture.
+pub fn message_history_fixture(messages: Vec<Value>) -> Value {
+    Value::Array(messages)
+}
+
 /// Create a sessions list response fixture.
 pub fn sessions_list_fixture(session_ids: &[&str]) -> serde_json::Value {
     serde_json::json!(
@@ -249,4 +321,16 @@ pub fn commands_list_fixture() -> serde_json::Value {
         {"name": "build", "description": "Build project"},
         {"name": "lint", "description": "Run linter"}
     ])
+}
+
+/// Seed launched sessions on the in-memory test server.
+pub async fn seed_spawned_sessions(
+    server: &Arc<OnceCell<OrchestratorServer>>,
+    session_ids: &[&str],
+) {
+    let srv = server.get().expect("test server should be initialized");
+    let mut spawned = srv.spawned_sessions().write().await;
+    for session_id in session_ids {
+        spawned.insert((*session_id).to_string());
+    }
 }

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -172,19 +172,17 @@ impl SchemaEngine {
 // Centralized Draft 2020-12 Generator for MCP + Registry
 // ============================================================================
 
-/// Centralized schema generation using Draft 2020-12 with AddNullable transform.
+/// Centralized schema generation using Draft 2020-12.
 ///
-/// This module provides cached schema generation matching the MCP Rust SDK pattern:
+/// This module provides cached schema generation for MCP:
 /// - JSON Schema Draft 2020-12 (MCP protocol requirement)
-/// - AddNullable transform for `Option<T>` fields
+/// - `Option<T>` fields generate `{"type": ["T", "null"]}` (schemars default)
 /// - Thread-local caching keyed by TypeId for performance
 pub mod mcp_schema {
     use schemars::JsonSchema;
     use schemars::Schema;
     use schemars::generate::SchemaSettings;
-    use schemars::transform::AddNullable;
     use schemars::transform::RestrictFormats;
-    use schemars::transform::Transform;
     use std::any::TypeId;
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -195,60 +193,11 @@ pub mod mcp_schema {
         static CACHE_FOR_OUTPUT: RefCell<HashMap<TypeId, Result<Arc<Schema>, String>>> = RefCell::new(HashMap::new());
     }
 
-    /// Sanitizes null-only schema branches that AddNullable produces.
-    /// Converts `{"const": null, "nullable": true}` (no type) → `{"type": "null"}`
-    #[derive(Clone, Copy, Default)]
-    struct SanitizeNullBranches;
-
-    impl Transform for SanitizeNullBranches {
-        fn transform(&mut self, schema: &mut Schema) {
-            // Serialize to JSON, sanitize recursively, deserialize back
-            let mut v = serde_json::to_value(&*schema).expect("serialize schema for sanitize");
-            sanitize_null_branches_recursive(&mut v);
-            *schema = Schema::try_from(v).expect("rebuild sanitized schema");
-        }
-    }
-
-    fn sanitize_null_branches_recursive(node: &mut serde_json::Value) {
-        use serde_json::Value as Json;
-        match node {
-            Json::Object(map) => {
-                // Fix pattern: {"const": null, "nullable": true} without "type"
-                let has_nullable_true = map
-                    .get("nullable")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                let const_is_null = map.get("const").map(|v| v.is_null()).unwrap_or(false);
-                let has_type = map.contains_key("type");
-
-                if has_nullable_true && const_is_null && !has_type {
-                    map.remove("const");
-                    map.remove("nullable");
-                    map.insert("type".to_string(), Json::String("null".to_string()));
-                }
-
-                // Recurse into all values (covers subschemas at arbitrary keys)
-                for value in map.values_mut() {
-                    sanitize_null_branches_recursive(value);
-                }
-            }
-            Json::Array(arr) => {
-                for elem in arr {
-                    sanitize_null_branches_recursive(elem);
-                }
-            }
-            _ => {}
-        }
-    }
-
     fn settings() -> SchemaSettings {
-        SchemaSettings::draft2020_12()
-            .with_transform(AddNullable::default())
-            .with_transform(RestrictFormats::default())
-            .with_transform(SanitizeNullBranches)
+        SchemaSettings::draft2020_12().with_transform(RestrictFormats::default())
     }
 
-    /// Generate a cached schema for type T using Draft 2020-12 + AddNullable.
+    /// Generate a cached schema for type T using Draft 2020-12.
     pub fn cached_schema_for<T: JsonSchema + 'static>() -> Arc<Schema> {
         CACHE_FOR_TYPE.with(|cache| {
             let mut cache = cache.borrow_mut();
@@ -404,15 +353,15 @@ mod tests {
         }
 
         #[test]
-        fn test_central_generator_addnullable() {
+        fn test_option_generates_type_array() {
             let root = mcp_schema::cached_schema_for::<WithOption>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let a = &v["properties"]["a"];
-            // AddNullable should add "nullable": true
+            // Option<String> should produce {"type": ["string", "null"]}
             assert_eq!(
-                a.get("nullable"),
-                Some(&serde_json::Value::Bool(true)),
-                "Option<T> fields should have nullable: true"
+                a.get("type"),
+                Some(&serde_json::json!(["string", "null"])),
+                "Option<T> fields should have type array with null"
             );
         }
 
@@ -467,7 +416,7 @@ mod tests {
         }
 
         // ====================================================================
-        // SanitizeNullBranches and RestrictFormats transform tests
+        // RestrictFormats transform and Option<Enum> tests
         // ====================================================================
 
         #[allow(dead_code)]
@@ -548,20 +497,21 @@ mod tests {
         }
 
         #[test]
-        fn test_option_string_preserves_nullable() {
+        fn test_option_string_uses_type_array() {
             let root = mcp_schema::cached_schema_for::<HasOptString>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let s = &v["properties"]["s"];
 
+            // Option<String> should produce {"type": ["string", "null"]}
             assert_eq!(
                 s.get("type"),
-                Some(&serde_json::json!("string")),
-                "Option<String> should have type: string"
+                Some(&serde_json::json!(["string", "null"])),
+                "Option<String> should have type array with null"
             );
-            assert_eq!(
-                s.get("nullable"),
-                Some(&serde_json::json!(true)),
-                "Option<String> should retain nullable: true"
+            // Should NOT have nullable keyword (that was from AddNullable)
+            assert!(
+                s.get("nullable").is_none(),
+                "Option<String> should not have nullable keyword"
             );
         }
     }

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -176,7 +176,8 @@ impl SchemaEngine {
 ///
 /// This module provides cached schema generation for MCP:
 /// - JSON Schema Draft 2020-12 (MCP protocol requirement)
-/// - `Option<T>` fields generate `{"type": ["T", "null"]}` (schemars default)
+/// - `Option<T>` fields include `null` in schema shape (for example, `type`
+///   arrays for simple scalar cases and `anyOf`/`$ref` forms for complex types)
 /// - Thread-local caching keyed by TypeId for performance
 pub mod mcp_schema {
     use schemars::JsonSchema;
@@ -358,11 +359,13 @@ mod tests {
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let a = &v["properties"]["a"];
             // Option<String> should produce {"type": ["string", "null"]}
-            assert_eq!(
-                a.get("type"),
-                Some(&serde_json::json!(["string", "null"])),
-                "Option<T> fields should have type array with null"
-            );
+            let ty = a
+                .get("type")
+                .and_then(|v| v.as_array())
+                .expect("Option<T> should emit a type array");
+            assert!(ty.contains(&serde_json::json!("string")));
+            assert!(ty.contains(&serde_json::json!("null")));
+            assert_eq!(ty.len(), 2, "Option<T> should contain only string|null");
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -503,10 +506,16 @@ mod tests {
             let s = &v["properties"]["s"];
 
             // Option<String> should produce {"type": ["string", "null"]}
+            let ty = s
+                .get("type")
+                .and_then(|v| v.as_array())
+                .expect("Option<String> should emit a type array");
+            assert!(ty.contains(&serde_json::json!("string")));
+            assert!(ty.contains(&serde_json::json!("null")));
             assert_eq!(
-                s.get("type"),
-                Some(&serde_json::json!(["string", "null"])),
-                "Option<String> should have type array with null"
+                ty.len(),
+                2,
+                "Option<String> should contain only string|null"
             );
             // Should NOT have nullable keyword (that was from AddNullable)
             assert!(

--- a/crates/services/opencode-rs/src/http/sessions.rs
+++ b/crates/services/opencode-rs/src/http/sessions.rs
@@ -17,6 +17,7 @@ use crate::types::session::SummarizeRequest;
 use crate::types::session::TodoItem;
 use crate::types::session::UpdateSessionRequest;
 use reqwest::Method;
+use std::collections::HashMap;
 
 /// Sessions API client.
 #[derive(Clone)]
@@ -131,6 +132,31 @@ impl SessionsApi {
             .request_json(Method::GET, "/session/status", None)
             .await?;
         Ok(response.status_for(session_id))
+    }
+
+    /// Get the full per-session status map.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn status_map(&self) -> Result<HashMap<String, SessionStatusInfo>> {
+        let response: SessionStatusResponse = self
+            .http
+            .request_json(Method::GET, "/session/status", None)
+            .await?;
+
+        Ok(match response {
+            SessionStatusResponse::Map(map) => map,
+            SessionStatusResponse::Legacy(summary) => {
+                let mut map = HashMap::new();
+                if summary.busy
+                    && let Some(active_session_id) = summary.active_session_id
+                {
+                    map.insert(active_session_id, SessionStatusInfo::Busy);
+                }
+                map
+            }
+        })
     }
 
     /// Get children of a session (forked sessions).
@@ -390,6 +416,63 @@ mod tests {
         let sessions = SessionsApi::new(http);
         let list = sessions.list().await.unwrap();
         assert_eq!(list.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_status_map_from_modern_response() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "s1": {"type": "busy"},
+                "s2": {"type": "retry", "attempt": 2, "message": "rate limited", "next": 12345}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let sessions = SessionsApi::new(http);
+        let map = sessions.status_map().await.unwrap();
+
+        assert!(matches!(map.get("s1"), Some(SessionStatusInfo::Busy)));
+        assert!(matches!(
+            map.get("s2"),
+            Some(SessionStatusInfo::Retry { attempt: 2, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_status_map_from_legacy_response() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "busy": true,
+                "activeSessionId": "s1"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let sessions = SessionsApi::new(http);
+        let map = sessions.status_map().await.unwrap();
+
+        assert_eq!(map.len(), 1);
+        assert!(matches!(map.get("s1"), Some(SessionStatusInfo::Busy)));
     }
 
     #[tokio::test]

--- a/crates/services/opencode-rs/src/http/sessions.rs
+++ b/crates/services/opencode-rs/src/http/sessions.rs
@@ -11,7 +11,6 @@ use crate::types::session::Session;
 use crate::types::session::SessionDiff;
 use crate::types::session::SessionStatus;
 use crate::types::session::SessionStatusInfo;
-use crate::types::session::SessionStatusResponse;
 use crate::types::session::ShareInfo;
 use crate::types::session::SummarizeRequest;
 use crate::types::session::TodoItem;
@@ -114,11 +113,36 @@ impl SessionsApi {
     ///
     /// Returns an error if the request fails.
     pub async fn status(&self) -> Result<SessionStatus> {
-        let response: SessionStatusResponse = self
+        let map: HashMap<String, SessionStatusInfo> = self
             .http
             .request_json(Method::GET, "/session/status", None)
             .await?;
-        Ok(response.into_legacy_summary())
+
+        let active: Vec<String> = map
+            .into_iter()
+            .filter_map(|(sid, status)| {
+                if matches!(
+                    status,
+                    SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }
+                ) {
+                    Some(sid)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let busy = !active.is_empty();
+        let active_session_id = if active.len() == 1 {
+            active.into_iter().next()
+        } else {
+            None
+        };
+
+        Ok(SessionStatus {
+            active_session_id,
+            busy,
+        })
     }
 
     /// Get status for a specific session.
@@ -127,11 +151,14 @@ impl SessionsApi {
     ///
     /// Returns an error if the request fails.
     pub async fn status_for(&self, session_id: &str) -> Result<SessionStatusInfo> {
-        let response: SessionStatusResponse = self
+        let map: HashMap<String, SessionStatusInfo> = self
             .http
             .request_json(Method::GET, "/session/status", None)
             .await?;
-        Ok(response.status_for(session_id))
+        Ok(map
+            .get(session_id)
+            .cloned()
+            .unwrap_or(SessionStatusInfo::Idle))
     }
 
     /// Get the full per-session status map.
@@ -140,23 +167,9 @@ impl SessionsApi {
     ///
     /// Returns an error if the request fails.
     pub async fn status_map(&self) -> Result<HashMap<String, SessionStatusInfo>> {
-        let response: SessionStatusResponse = self
-            .http
+        self.http
             .request_json(Method::GET, "/session/status", None)
-            .await?;
-
-        Ok(match response {
-            SessionStatusResponse::Map(map) => map,
-            SessionStatusResponse::Legacy(summary) => {
-                let mut map = HashMap::new();
-                if summary.busy
-                    && let Some(active_session_id) = summary.active_session_id
-                {
-                    map.insert(active_session_id, SessionStatusInfo::Busy);
-                }
-                map
-            }
-        })
+            .await
     }
 
     /// Get children of a session (forked sessions).
@@ -449,14 +462,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_status_map_from_legacy_response() {
+    async fn test_status_from_modern_response() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
             .and(path("/session/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "busy": true,
-                "activeSessionId": "s1"
+                "s1": {"type": "busy"},
+                "s2": {"type": "retry", "attempt": 2, "message": "rate limited", "next": 12345}
             })))
             .mount(&mock_server)
             .await;
@@ -469,10 +482,10 @@ mod tests {
         .unwrap();
 
         let sessions = SessionsApi::new(http);
-        let map = sessions.status_map().await.unwrap();
+        let status = sessions.status().await.unwrap();
 
-        assert_eq!(map.len(), 1);
-        assert!(matches!(map.get("s1"), Some(SessionStatusInfo::Busy)));
+        assert!(status.busy);
+        assert!(status.active_session_id.is_none());
     }
 
     #[tokio::test]

--- a/crates/services/opencode-rs/src/types/session.rs
+++ b/crates/services/opencode-rs/src/types/session.rs
@@ -3,7 +3,6 @@
 use crate::types::permission::Ruleset;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
 
 /// A session in `OpenCode`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -176,7 +175,7 @@ pub struct RevertRequest {
     pub part_id: Option<String>,
 }
 
-/// Session status response.
+/// Legacy-compatible session status summary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionStatus {
@@ -205,93 +204,6 @@ pub enum SessionStatusInfo {
         /// Next retry timestamp.
         next: u64,
     },
-}
-
-/// Backward-compatible `/session/status` response wrapper.
-#[derive(Debug, Clone)]
-pub enum SessionStatusResponse {
-    /// Legacy global status shape.
-    Legacy(SessionStatus),
-    /// Modern per-session map shape.
-    Map(HashMap<String, SessionStatusInfo>),
-}
-
-impl SessionStatusResponse {
-    /// Get status for a specific session ID.
-    pub fn status_for(&self, session_id: &str) -> SessionStatusInfo {
-        match self {
-            Self::Map(map) => map
-                .get(session_id)
-                .cloned()
-                .unwrap_or(SessionStatusInfo::Idle),
-            Self::Legacy(status) => {
-                if status.busy && status.active_session_id.as_deref() == Some(session_id) {
-                    SessionStatusInfo::Busy
-                } else if status.busy && status.active_session_id.is_none() {
-                    // Conservative fallback for legacy busy-without-active-session responses.
-                    SessionStatusInfo::Busy
-                } else {
-                    SessionStatusInfo::Idle
-                }
-            }
-        }
-    }
-
-    /// Convert to a legacy summary for compatibility with existing API consumers.
-    pub fn into_legacy_summary(self) -> SessionStatus {
-        match self {
-            Self::Legacy(status) => status,
-            Self::Map(map) => {
-                let active: Vec<String> = map
-                    .into_iter()
-                    .filter_map(|(sid, status)| {
-                        if matches!(
-                            status,
-                            SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }
-                        ) {
-                            Some(sid)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                let busy = !active.is_empty();
-                let active_session_id = if active.len() == 1 {
-                    active.into_iter().next()
-                } else {
-                    None
-                };
-
-                SessionStatus {
-                    active_session_id,
-                    busy,
-                }
-            }
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for SessionStatusResponse {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = serde_json::Value::deserialize(deserializer)?;
-        let is_legacy = value.get("busy").is_some()
-            || value.get("activeSessionId").is_some()
-            || value.get("active_session_id").is_some();
-
-        if is_legacy {
-            let legacy: SessionStatus =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(Self::Legacy(legacy))
-        } else {
-            let map: HashMap<String, SessionStatusInfo> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(Self::Map(map))
-        }
-    }
 }
 
 /// A file diff entry from the session diff endpoint.
@@ -352,6 +264,7 @@ pub struct TodoItem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_session_deserialize() {
@@ -407,36 +320,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_legacy_status() {
+    fn parse_legacy_status_shape_is_rejected() {
         let json = r#"{"busy": true, "activeSessionId": "s1"}"#;
-        let resp: SessionStatusResponse = serde_json::from_str(json).unwrap();
-
-        assert!(matches!(resp, SessionStatusResponse::Legacy(_)));
-        assert!(matches!(resp.status_for("s1"), SessionStatusInfo::Busy));
-        assert!(matches!(resp.status_for("s2"), SessionStatusInfo::Idle));
+        let resp: Result<HashMap<String, SessionStatusInfo>, _> = serde_json::from_str(json);
+        assert!(resp.is_err());
     }
 
     #[test]
     fn parse_map_status() {
         let json = r#"{"s1": {"type": "busy"}, "s2": {"type": "retry", "attempt": 2, "message": "rate limited", "next": 12345}}"#;
-        let resp: SessionStatusResponse = serde_json::from_str(json).unwrap();
+        let resp: HashMap<String, SessionStatusInfo> = serde_json::from_str(json).unwrap();
 
-        assert!(matches!(resp, SessionStatusResponse::Map(_)));
-        assert!(matches!(resp.status_for("s1"), SessionStatusInfo::Busy));
+        assert!(matches!(resp.get("s1"), Some(SessionStatusInfo::Busy)));
         assert!(matches!(
-            resp.status_for("s2"),
-            SessionStatusInfo::Retry { attempt: 2, .. }
+            resp.get("s2"),
+            Some(SessionStatusInfo::Retry { attempt: 2, .. })
         ));
-        assert!(matches!(resp.status_for("s3"), SessionStatusInfo::Idle));
+        assert!(!resp.contains_key("s3"));
     }
 
     #[test]
     fn parse_empty_map_status() {
         let json = r"{}";
-        let resp: SessionStatusResponse = serde_json::from_str(json).unwrap();
+        let resp: HashMap<String, SessionStatusInfo> = serde_json::from_str(json).unwrap();
 
-        assert!(matches!(resp, SessionStatusResponse::Map(_)));
-        assert!(matches!(resp.status_for("any"), SessionStatusInfo::Idle));
+        assert!(resp.is_empty());
     }
 
     #[test]

--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
-  "default_agent": "Normal",
+  "default_agent": "NormalOpenAI",
   "permission": {
     "edit": "ask",
     "write": "ask",

--- a/workflow.md
+++ b/workflow.md
@@ -14,8 +14,10 @@ First is orchestration level, allowing full management of opencode sessions.
 LEVEL 0: ORCHESTRATOR (Parent Agent)
 ├── orchestrator_run              - Spawn/resume sessions
 ├── orchestrator_list_sessions    - List active sessions
+├── orchestrator_get_session_state - Inspect one session in detail
 ├── orchestrator_list_commands    - List available commands
 ├── orchestrator_respond_permission - Handle permission requests
+├── orchestrator_respond_question - Answer session questions
 ├── read                          - Inspect files for coordination
 └── todowrite                     - Task tracking
                         │

--- a/workflow.md
+++ b/workflow.md
@@ -33,22 +33,28 @@ Inside of normal we have a handful of tools, most are custom, and pluggable into
 
 ### Agent Variants
 
-| NORMAL (19)   | BASH (20)     | LINEAR (28)   | PLAYWRIGHT (37)       | REVIEW (9)            |
-|---------------|---------------|---------------|-----------------------|-----------------------|
-| File ops      | File ops      | File ops      | File ops              | Read only             |
-| Search        | Search        | Search        | Search                | Search (cli_*)        |
-| Tasks         | Tasks         | Tasks         | Tasks                 |                       |
-| Just runner   | Just runner   | Just runner   | Just runner           | Just runner (limited) |
-| Thoughts      | Thoughts      | Thoughts      | Thoughts              | Thoughts (write only) |
-| GitHub PRs    | GitHub PRs    | GitHub PRs    | GitHub PRs            |                       |
-| Sub-agents    | Sub-agents    | Sub-agents    | Sub-agents            | Reasoning model       |
-|               | + mcp_bash (shell) | + 9 Linear tools | + 18 Browser automation | + review_* tools |
+| NORMAL (19)   | NORMAL_OPENAI (19) | BASH (20)     | LINEAR (28)   | PLAYWRIGHT (37)       | REVIEW (9)            |
+|---------------|--------------------|---------------|---------------|-----------------------|-----------------------|
+| File ops      | File ops           | File ops      | File ops      | File ops              | Read only             |
+| Search        | Search             | Search        | Search        | Search                | Search (cli_*)        |
+| Tasks         | Tasks              | Tasks         | Tasks         | Tasks                 |                       |
+| Just runner   | Just runner        | Just runner   | Just runner   | Just runner           | Just runner (limited) |
+| Thoughts      | Thoughts           | Thoughts      | Thoughts      | Thoughts              | Thoughts (write only) |
+| GitHub PRs    | GitHub PRs         | GitHub PRs    | GitHub PRs    | GitHub PRs            |                       |
+| Sub-agents    | Sub-agents         | Sub-agents    | Sub-agents    | Sub-agents            | Reasoning model       |
+|               | GPT-5.4-oriented commands | + mcp_bash (shell) | + 9 Linear tools | + 18 Browser automation | + review_* tools |
 
 ### Commands Using Each
 
 ```
 NORMAL:     research, create_plan_init, create_plan_final, implement_plan,
             review_pr_comments, init
+NORMAL_OPENAI:
+            openai, research_openai, create_plan_init_openai,
+            create_plan_final_openai, implement_plan_openai,
+            review_pr_comments_openai, capture_pr_comments_openai,
+            resolve_pr_comments_openai, resume_work_openai,
+            unwind_openai, decide_findings_openai, frame_openai
 BASH:       bash, commit, describe_pr
 LINEAR:     linear
 PLAYWRIGHT: playwright

--- a/workflow.md
+++ b/workflow.md
@@ -35,7 +35,7 @@ Inside of normal we have a handful of tools, most are custom, and pluggable into
 
 ### Agent Variants
 
-| NORMAL (19)   | NORMAL_OPENAI (19) | BASH (20)     | LINEAR (28)   | PLAYWRIGHT (37)       | REVIEW (9)            |
+| NORMAL (19)   | NORMAL_OPENAI (19) | BASH (20)     | LINEAR (28)   | PLAYWRIGHT (41)       | REVIEW (9)            |
 |---------------|--------------------|---------------|---------------|-----------------------|-----------------------|
 | File ops      | File ops           | File ops      | File ops      | File ops              | Read only             |
 | Search        | Search             | Search        | Search        | Search                | Search (cli_*)        |
@@ -44,7 +44,7 @@ Inside of normal we have a handful of tools, most are custom, and pluggable into
 | Thoughts      | Thoughts           | Thoughts      | Thoughts      | Thoughts              | Thoughts (write only) |
 | GitHub PRs    | GitHub PRs         | GitHub PRs    | GitHub PRs    | GitHub PRs            |                       |
 | Sub-agents    | Sub-agents         | Sub-agents    | Sub-agents    | Sub-agents            | Reasoning model       |
-|               | GPT-5.4-oriented commands | + mcp_bash (shell) | + 9 Linear tools | + 18 Browser automation | + review_* tools |
+|               | GPT-5.4-oriented commands | + mcp_bash (shell) | + 9 Linear tools | + 22 Browser automation | + review_* tools |
 
 ### Commands Using Each
 


### PR DESCRIPTION
## My Notes (preserved)

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

When orchestrating multiple OpenCode sessions, diagnosing stuck, silent, or failed sessions was difficult:
- No way to see session status (Idle/Busy/Retry) in the session list
- No way to identify which sessions the current orchestrator created vs pre-existing ones
- No tool to inspect detailed session state (pending messages, recent tool calls, retry info)
- Orchestrators had to guess why a session wasn't responding

## What user-facing changes did I ship?

**Enhanced `list_sessions` tool output** now includes:
- Session status (Idle, Busy, or Retry with attempt/reason details)
- `launched_by_you` marker to identify sessions this orchestrator created
- Working directory and file change statistics (additions/deletions/files)
- Both created and updated timestamps

**New `get_session_state` tool** for detailed session inspection:
- Current status with retry details (attempt count, reason, next retry time)
- Pending message count (user messages awaiting assistant reply)
- Last activity timestamp
- Recent tool calls with their states (pending/running/completed/error)

**New orchestrator documentation** with troubleshooting guidance explaining common diagnostic patterns.

## How I implemented it

1. **opencode_rs client enhancement**: Added `status_map()` method to batch-fetch all session statuses in one API call, avoiding N+1 queries when listing sessions.

2. **Session ownership tracking**: Added `spawned_sessions: Arc<RwLock<HashSet<String>>>` to the orchestrator server, populated when creating new sessions via the `run` tool.

3. **Enriched list_sessions**: The tool now fetches status map alongside session list, merges the data, and marks sessions as `launched_by_you` based on the tracked set.

4. **New get_session_state tool**: Fetches session details, status, and message history. Helper functions (`count_pending_messages`, `get_last_activity_time`, `extract_recent_tool_calls`) process the message history to extract diagnostic information.

5. **New types**: `SessionStatusSummary`, `ChangeStats`, `GetSessionStateInput/Output`, `ToolCallSummary`, `ToolStateSummary` with proper serde serialization and JSON schema derivation.

6. **Test coverage**: Added 9 new wiremock integration tests covering all status variants, launched_by_you tracking, message summarization, and error handling for unknown sessions.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog

Add session troubleshooting diagnostics to the orchestrator: `list_sessions` now shows status (Idle/Busy/Retry) and ownership markers, new `get_session_state` tool provides detailed session inspection including pending messages and recent tool call states.
<!-- END:describe_pr:autogen -->

