### PR TITLE
fix(schema): use null-first ordering instead of stripping null

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,9 +50,6 @@ These items have dependencies and should be done in order.
 - Currently initializes the old v1 config - that's not used anywhere anymore.
 - Should completely get rid of v1 and all the logic related to it. No need for backwards compatibility when user count is low.
 
-### Align output serialization with StripNullFromOptional
-- Follow-up after the schema transform: add `skip_serializing_if = "Option::is_none"` or equivalent cleanup where output schemas now say optional fields are non-nullable but some output structs may still serialize `None` as `null`.
-
 ### Discord search tool (ENG-392)
 - Search tool for Discord context, similar to Linear search tool. Not the same as glittercowboy/discord-mcp (server admin).
 - Probably only needs one tool for searching, maybe a second for reading context around results.

--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,9 @@ These items have dependencies and should be done in order.
 - Currently initializes the old v1 config - that's not used anywhere anymore.
 - Should completely get rid of v1 and all the logic related to it. No need for backwards compatibility when user count is low.
 
+### Align output serialization with StripNullFromOptional
+- Follow-up after the schema transform: add `skip_serializing_if = "Option::is_none"` or equivalent cleanup where output schemas now say optional fields are non-nullable but some output structs may still serialize `None` as `null`.
+
 ### Discord search tool (ENG-392)
 - Search tool for Discord context, similar to Linear search tool. Not the same as glittercowboy/discord-mcp (server admin).
 - Probably only needs one tool for searching, maybe a second for reading context around results.

--- a/apps/agentic-mcp/src/main.rs
+++ b/apps/agentic-mcp/src/main.rs
@@ -9,6 +9,7 @@ compile_error!(
 );
 
 use agentic_config::loader::load_merged;
+use agentic_tools_core::fmt::TextOptions;
 use agentic_tools_mcp::OutputMode;
 use agentic_tools_mcp::RegistryServer;
 use agentic_tools_mcp::ServiceExt;
@@ -41,6 +42,10 @@ struct Args {
     /// Output mode: text | structured (default: text)
     #[arg(long, value_parser = ["text", "structured"])]
     output: Option<String>,
+
+    /// Suppress search reminder footer in grep/glob text output.
+    #[arg(long)]
+    suppress_search_reminder: bool,
 
     // Convenience flags for individual tool filtering
     // TODO(3): Probably don't need these convenience flags. They are kinda archaic for the old
@@ -199,7 +204,10 @@ async fn main() -> anyhow::Result<()> {
 
     let server = RegistryServer::new(Arc::new(reg))
         .with_info("agentic-mcp", env!("CARGO_PKG_VERSION"))
-        .with_output_mode(output_mode);
+        .with_output_mode(output_mode)
+        .with_text_options(
+            TextOptions::default().with_suppress_search_reminder(args.suppress_search_reminder),
+        );
     let transport = stdio();
     let service = server.serve(transport).await?;
     service.waiting().await?;

--- a/crates/agentic-tools/core/src/fmt.rs
+++ b/crates/agentic-tools/core/src/fmt.rs
@@ -61,6 +61,8 @@ pub struct TextOptions {
     pub markdown: bool,
     /// Maximum number of items to display in collections.
     pub max_items: Option<usize>,
+    /// Whether search tools should omit the search reminder footer.
+    pub suppress_search_reminder: bool,
 }
 
 impl TextOptions {
@@ -84,6 +86,12 @@ impl TextOptions {
     /// Set the maximum number of items to display.
     pub fn with_max_items(mut self, max_items: Option<usize>) -> Self {
         self.max_items = max_items;
+        self
+    }
+
+    /// Enable or disable search reminder suppression for grep/glob text output.
+    pub fn with_suppress_search_reminder(mut self, suppress_search_reminder: bool) -> Self {
+        self.suppress_search_reminder = suppress_search_reminder;
         self
     }
 }
@@ -202,6 +210,7 @@ mod tests {
         assert_eq!(opts.style, TextStyle::Humanized);
         assert!(!opts.markdown);
         assert!(opts.max_items.is_none());
+        assert!(!opts.suppress_search_reminder);
     }
 
     #[test]
@@ -209,11 +218,13 @@ mod tests {
         let opts = TextOptions::new()
             .with_style(TextStyle::Plain)
             .with_markdown(true)
-            .with_max_items(Some(10));
+            .with_max_items(Some(10))
+            .with_suppress_search_reminder(true);
 
         assert_eq!(opts.style, TextStyle::Plain);
         assert!(opts.markdown);
         assert_eq!(opts.max_items, Some(10));
+        assert!(opts.suppress_search_reminder);
     }
 
     #[test]

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -169,19 +169,20 @@ impl SchemaEngine {
     }
 }
 
-#[derive(Clone, Default)]
-struct StripNullFromOptional;
+const OPTIONAL_PROPERTY_GUIDANCE: &str = "Optional; omit or use null.";
 
-impl schemars::transform::Transform for StripNullFromOptional {
+#[derive(Clone, Default)]
+struct NullFirstOptional;
+
+impl schemars::transform::Transform for NullFirstOptional {
     fn transform(&mut self, schema: &mut Schema) {
         let mut value = serde_json::to_value(&*schema).expect("serialize schema");
-        strip_nulls_from_optional_properties(&mut value);
-        *schema =
-            Schema::try_from(value).expect("StripNullFromOptional must preserve schema validity");
+        normalize_optional_properties(&mut value);
+        *schema = Schema::try_from(value).expect("NullFirstOptional must preserve schema validity");
     }
 }
 
-fn strip_nulls_from_optional_properties(node: &mut Json) {
+fn normalize_optional_properties(node: &mut Json) {
     let Some(obj) = node.as_object_mut() else {
         return;
     };
@@ -193,9 +194,10 @@ fn strip_nulls_from_optional_properties(node: &mut Json) {
     if let Some(properties) = obj.get_mut("properties").and_then(Json::as_object_mut) {
         for (property_name, property_schema) in properties {
             if !required.contains(property_name.as_str()) {
-                strip_known_nullable_shapes(property_schema);
+                normalize_known_nullable_shapes(property_schema);
+                annotate_optional_property(property_schema);
             }
-            strip_nulls_from_optional_properties(property_schema);
+            normalize_optional_properties(property_schema);
         }
     }
 
@@ -221,7 +223,7 @@ fn recurse_object_entries(obj: &mut serde_json::Map<String, Json>, key: &str) {
     };
 
     for value in entries.values_mut() {
-        strip_nulls_from_optional_properties(value);
+        normalize_optional_properties(value);
     }
 }
 
@@ -230,7 +232,7 @@ fn recurse_schema_entry(obj: &mut serde_json::Map<String, Json>, key: &str) {
         return;
     };
 
-    strip_nulls_from_optional_properties(value);
+    normalize_optional_properties(value);
 }
 
 fn recurse_schema_array_entry(obj: &mut serde_json::Map<String, Json>, key: &str) {
@@ -239,7 +241,7 @@ fn recurse_schema_array_entry(obj: &mut serde_json::Map<String, Json>, key: &str
     };
 
     for value in values {
-        strip_nulls_from_optional_properties(value);
+        normalize_optional_properties(value);
     }
 }
 
@@ -253,13 +255,13 @@ fn required_property_names(required: Option<&Json>) -> HashSet<String> {
         .collect()
 }
 
-fn strip_known_nullable_shapes(node: &mut Json) {
-    strip_null_from_type_array(node);
-    strip_null_from_enum_values(node);
-    strip_null_from_any_of(node);
+fn normalize_known_nullable_shapes(node: &mut Json) {
+    move_null_to_front_in_type_array(node);
+    move_null_to_front_in_enum_values(node);
+    move_null_to_front_in_any_of(node);
 }
 
-fn strip_null_from_type_array(node: &mut Json) {
+fn move_null_to_front_in_type_array(node: &mut Json) {
     let Some(obj) = node.as_object_mut() else {
         return;
     };
@@ -268,24 +270,10 @@ fn strip_null_from_type_array(node: &mut Json) {
         return;
     };
 
-    let filtered: Vec<_> = type_values
-        .iter()
-        .filter(|value| *value != &Json::String("null".into()))
-        .cloned()
-        .collect();
-
-    match filtered.as_slice() {
-        [] => {}
-        [single] => {
-            obj.insert("type".to_string(), single.clone());
-        }
-        _ => {
-            obj.insert("type".to_string(), Json::Array(filtered));
-        }
-    }
+    move_values_to_front(type_values, |value| value == &Json::String("null".into()));
 }
 
-fn strip_null_from_enum_values(node: &mut Json) {
+fn move_null_to_front_in_enum_values(node: &mut Json) {
     let Some(obj) = node.as_object_mut() else {
         return;
     };
@@ -294,43 +282,65 @@ fn strip_null_from_enum_values(node: &mut Json) {
         return;
     };
 
-    enum_values.retain(|value| !value.is_null());
+    move_values_to_front(enum_values, Json::is_null);
 }
 
-fn strip_null_from_any_of(node: &mut Json) {
+fn move_null_to_front_in_any_of(node: &mut Json) {
     let Some(obj) = node.as_object_mut() else {
         return;
     };
 
-    let Some(any_of) = obj.get("anyOf").and_then(Json::as_array) else {
+    let Some(any_of) = obj.get_mut("anyOf").and_then(Json::as_array_mut) else {
         return;
     };
 
-    let non_null_branches: Vec<Json> = any_of
-        .iter()
-        .filter(|branch| !is_explicit_null_branch(branch))
-        .cloned()
-        .collect();
+    move_values_to_front(any_of, is_explicit_null_branch);
+}
 
-    if non_null_branches.len() == any_of.len() || non_null_branches.is_empty() {
+fn annotate_optional_property(node: &mut Json) {
+    let Some(obj) = node.as_object_mut() else {
         return;
-    }
+    };
 
-    if non_null_branches.len() == 1 {
-        let remaining_branch = non_null_branches.into_iter().next().unwrap();
-        obj.remove("anyOf");
-
-        if let Some(branch_obj) = remaining_branch.as_object() {
-            for (key, value) in branch_obj {
-                obj.entry(key.clone()).or_insert_with(|| value.clone());
+    match obj.get_mut("description") {
+        Some(Json::String(description)) => {
+            if !description.contains(OPTIONAL_PROPERTY_GUIDANCE) {
+                description.push_str("\n\n");
+                description.push_str(OPTIONAL_PROPERTY_GUIDANCE);
             }
-        } else {
-            obj.insert("anyOf".to_string(), Json::Array(vec![remaining_branch]));
         }
+        Some(_) => {}
+        None => {
+            obj.insert(
+                "description".to_string(),
+                Json::String(OPTIONAL_PROPERTY_GUIDANCE.to_string()),
+            );
+        }
+    }
+}
+
+fn move_values_to_front<F>(values: &mut Vec<Json>, predicate: F)
+where
+    F: Fn(&Json) -> bool,
+{
+    let mut matching = Vec::new();
+    let mut non_matching = Vec::new();
+
+    for value in values.drain(..) {
+        if predicate(&value) {
+            matching.push(value);
+        } else {
+            non_matching.push(value);
+        }
+    }
+
+    if matching.is_empty() {
+        *values = non_matching;
         return;
     }
 
-    obj.insert("anyOf".to_string(), Json::Array(non_null_branches));
+    matching.extend(non_matching);
+    *values = matching;
 }
 
 fn is_explicit_null_branch(node: &Json) -> bool {
@@ -348,11 +358,11 @@ fn is_explicit_null_branch(node: &Json) -> bool {
 ///
 /// This module provides cached schema generation for MCP:
 /// - JSON Schema Draft 2020-12 (MCP protocol requirement)
-/// - `Option<T>` object properties are emitted as optional-but-non-nullable at
-///   the property root while preserving inner item/value nullability
+/// - `Option<T>` object properties remain nullable and are normalized to place
+///   `null` first while preserving inner item/value nullability
 /// - Thread-local caching keyed by TypeId for performance
 pub mod mcp_schema {
-    use super::StripNullFromOptional;
+    use super::NullFirstOptional;
     use schemars::JsonSchema;
     use schemars::Schema;
     use schemars::generate::SchemaSettings;
@@ -368,13 +378,9 @@ pub mod mcp_schema {
     }
 
     fn settings() -> SchemaSettings {
-        // NOTE: StripNullFromOptional also affects output schemas generated by
-        // this shared path. Accepted debt: some output structs may still
-        // serialize Option<T> fields as null until follow-up work aligns
-        // serialization with schema via skip_serializing_if.
         SchemaSettings::draft2020_12()
             .with_transform(RestrictFormats::default())
-            .with_transform(StripNullFromOptional)
+            .with_transform(NullFirstOptional)
     }
 
     /// Generate a cached schema for type T using Draft 2020-12.
@@ -525,8 +531,9 @@ mod tests {
 
     mod mcp_schema_tests {
         use super::Json;
+        use super::NullFirstOptional;
+        use super::OPTIONAL_PROPERTY_GUIDANCE;
         use super::Schema;
-        use super::StripNullFromOptional;
         use super::mcp_schema;
         use schemars::transform::Transform;
         use serde::Serialize;
@@ -544,20 +551,28 @@ mod tests {
                 .collect()
         }
 
+        fn assert_optional_guidance(schema: &Json, name: &str) {
+            assert_eq!(
+                property(schema, name).get("description"),
+                Some(&Json::String(OPTIONAL_PROPERTY_GUIDANCE.to_string()))
+            );
+        }
+
         #[derive(schemars::JsonSchema, Serialize)]
         struct WithOption {
             a: Option<String>,
         }
 
         #[test]
-        fn test_option_string_is_optional_non_nullable() {
+        fn test_option_string_is_optional_nullable_with_null_first() {
             let root = mcp_schema::cached_schema_for::<WithOption>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let a = property(&v, "a");
 
-            assert_eq!(a.get("type"), Some(&serde_json::json!("string")));
+            assert_eq!(a.get("type"), Some(&serde_json::json!(["null", "string"])));
             assert!(a.get("nullable").is_none());
             assert!(required_names(&v).is_empty());
+            assert_optional_guidance(&v, "a");
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -627,13 +642,16 @@ mod tests {
         }
 
         #[test]
-        fn test_option_enum_collapses_to_non_nullable_ref() {
+        fn test_option_enum_keeps_any_of_with_null_first() {
             let root = mcp_schema::cached_schema_for::<HasOptEnum>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let e = property(&v, "e");
+            let any_of = e["anyOf"].as_array().expect("Option enum should use anyOf");
 
-            assert!(e.get("anyOf").is_none());
-            assert!(e.get("$ref").is_some());
+            assert_eq!(any_of.len(), 2);
+            assert_eq!(any_of[0], serde_json::json!({ "type": "null" }));
+            assert!(any_of[1].get("$ref").is_some());
+            assert_optional_guidance(&v, "e");
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -675,16 +693,17 @@ mod tests {
         }
 
         #[test]
-        fn test_option_string_stays_non_nullable_without_nullable_keyword() {
+        fn test_option_string_uses_null_first_without_nullable_keyword() {
             let root = mcp_schema::cached_schema_for::<HasOptString>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let s = property(&v, "s");
 
-            assert_eq!(s.get("type"), Some(&serde_json::json!("string")));
+            assert_eq!(s.get("type"), Some(&serde_json::json!(["null", "string"])));
             assert!(
                 s.get("nullable").is_none(),
                 "Option<String> should not have nullable keyword"
             );
+            assert_optional_guidance(&v, "s");
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -698,13 +717,17 @@ mod tests {
         }
 
         #[test]
-        fn test_nested_optional_properties_are_rewritten_recursively() {
+        fn test_nested_optional_properties_are_normalized_recursively() {
             let root = mcp_schema::cached_schema_for::<NestedOuter>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let nested = property(&v, "nested");
+            let nested_any_of = nested["anyOf"]
+                .as_array()
+                .expect("Nested option should keep anyOf branches");
 
-            assert!(nested.get("anyOf").is_none());
-            assert!(nested.get("$ref").is_some());
+            assert_eq!(nested_any_of[0], serde_json::json!({ "type": "null" }));
+            assert!(nested_any_of[1].get("$ref").is_some());
+            assert_optional_guidance(&v, "nested");
 
             let defs = v["$defs"]
                 .as_object()
@@ -716,7 +739,11 @@ mod tests {
 
             assert_eq!(
                 inner["properties"]["leaf"]["type"],
-                serde_json::json!("string")
+                serde_json::json!(["null", "string"])
+            );
+            assert_eq!(
+                inner["properties"]["leaf"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
             );
         }
 
@@ -726,13 +753,17 @@ mod tests {
         }
 
         #[test]
-        fn test_option_vec_property_loses_outer_nullability() {
+        fn test_option_vec_property_keeps_outer_nullability_with_null_first() {
             let root = mcp_schema::cached_schema_for::<HasOptVec>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
             let values = property(&v, "values");
 
-            assert_eq!(values.get("type"), Some(&serde_json::json!("array")));
+            assert_eq!(
+                values.get("type"),
+                Some(&serde_json::json!(["null", "array"]))
+            );
             assert_eq!(values["items"]["type"], serde_json::json!("string"));
+            assert_optional_guidance(&v, "values");
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -749,9 +780,13 @@ mod tests {
                 .as_array()
                 .expect("Inner Option<String> should remain nullable");
 
-            assert_eq!(values.get("type"), Some(&serde_json::json!("array")));
+            assert_eq!(
+                values.get("type"),
+                Some(&serde_json::json!(["null", "array"]))
+            );
             assert!(item_type.contains(&serde_json::json!("string")));
             assert!(item_type.contains(&serde_json::json!("null")));
+            assert_optional_guidance(&v, "values");
         }
 
         #[test]
@@ -766,7 +801,7 @@ mod tests {
             }))
             .unwrap();
 
-            StripNullFromOptional.transform(&mut schema);
+            NullFirstOptional.transform(&mut schema);
 
             let v = serde_json::to_value(&schema).unwrap();
             let required_type = v["properties"]["required_field"]["type"]
@@ -777,7 +812,101 @@ mod tests {
             assert!(required_type.contains(&serde_json::json!("null")));
             assert_eq!(
                 v["properties"]["optional_field"]["type"],
-                serde_json::json!("string")
+                serde_json::json!(["null", "string"])
+            );
+            assert_eq!(
+                v["properties"]["optional_field"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
+            );
+            assert!(
+                v["properties"]["required_field"]
+                    .get("description")
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn test_manual_any_of_null_branch_moves_to_front() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional_field": {
+                        "anyOf": [
+                            { "type": "string" },
+                            { "type": "integer" },
+                            { "type": "null" }
+                        ]
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert_eq!(
+                v["properties"]["optional_field"]["anyOf"],
+                serde_json::json!([
+                    { "type": "null" },
+                    { "type": "string" },
+                    { "type": "integer" }
+                ])
+            );
+            assert_eq!(
+                v["properties"]["optional_field"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
+            );
+        }
+
+        #[test]
+        fn test_manual_enum_null_moves_to_front() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional_field": {
+                        "enum": ["alpha", null, "beta"]
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert_eq!(
+                v["properties"]["optional_field"]["enum"],
+                serde_json::json!([null, "alpha", "beta"])
+            );
+            assert_eq!(
+                v["properties"]["optional_field"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
+            );
+        }
+
+        #[test]
+        fn test_existing_description_appends_guidance_once() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional_field": {
+                        "description": "Existing description.",
+                        "type": ["string", "null"]
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert_eq!(
+                v["properties"]["optional_field"]["description"],
+                serde_json::json!("Existing description.\n\nOptional; omit or use null.")
+            );
+            assert_eq!(
+                v["properties"]["optional_field"]["type"],
+                serde_json::json!(["null", "string"])
             );
         }
     }

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -195,17 +195,21 @@ fn normalize_optional_properties(node: &mut Json) {
         for (property_name, property_schema) in properties {
             if !required.contains(property_name.as_str()) {
                 normalize_known_nullable_shapes(property_schema);
-                annotate_optional_property(property_schema);
+                if explicitly_allows_null(property_schema) {
+                    annotate_optional_property(property_schema);
+                }
             }
             normalize_optional_properties(property_schema);
         }
     }
 
+    recurse_object_entries(obj, "dependentSchemas");
     recurse_object_entries(obj, "patternProperties");
     recurse_schema_entry(obj, "additionalProperties");
     recurse_schema_entry(obj, "propertyNames");
     recurse_schema_entry(obj, "unevaluatedProperties");
     recurse_schema_entry(obj, "items");
+    recurse_schema_entry(obj, "unevaluatedItems");
     recurse_schema_entry(obj, "contains");
     recurse_schema_array_entry(obj, "prefixItems");
     recurse_schema_array_entry(obj, "allOf");
@@ -259,6 +263,37 @@ fn normalize_known_nullable_shapes(node: &mut Json) {
     move_null_to_front_in_type_array(node);
     move_null_to_front_in_enum_values(node);
     move_null_to_front_in_any_of(node);
+}
+
+fn explicitly_allows_null(node: &Json) -> bool {
+    type_array_contains_null(node)
+        || enum_values_contain_null(node)
+        || any_of_contains_explicit_null_branch(node)
+}
+
+fn type_array_contains_null(node: &Json) -> bool {
+    node.as_object()
+        .and_then(|obj| obj.get("type"))
+        .and_then(Json::as_array)
+        .is_some_and(|type_values| {
+            type_values
+                .iter()
+                .any(|value| value == &Json::String("null".into()))
+        })
+}
+
+fn enum_values_contain_null(node: &Json) -> bool {
+    node.as_object()
+        .and_then(|obj| obj.get("enum"))
+        .and_then(Json::as_array)
+        .is_some_and(|enum_values| enum_values.iter().any(Json::is_null))
+}
+
+fn any_of_contains_explicit_null_branch(node: &Json) -> bool {
+    node.as_object()
+        .and_then(|obj| obj.get("anyOf"))
+        .and_then(Json::as_array)
+        .is_some_and(|any_of| any_of.iter().any(is_explicit_null_branch))
 }
 
 fn move_null_to_front_in_type_array(node: &mut Json) {
@@ -909,6 +944,89 @@ mod tests {
             assert_eq!(
                 v["properties"]["optional_field"]["type"],
                 serde_json::json!(["null", "string"])
+            );
+        }
+
+        #[test]
+        fn test_non_nullable_optional_property_does_not_get_null_guidance() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional_field": {
+                        "type": "string"
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert!(
+                v["properties"]["optional_field"]
+                    .get("description")
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn test_dependent_schemas_are_normalized_recursively() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "trigger": { "type": "boolean" }
+                },
+                "dependentSchemas": {
+                    "trigger": {
+                        "type": "object",
+                        "properties": {
+                            "nested_optional": {
+                                "type": ["string", "null"]
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert_eq!(
+                v["dependentSchemas"]["trigger"]["properties"]["nested_optional"]["type"],
+                serde_json::json!(["null", "string"])
+            );
+            assert_eq!(
+                v["dependentSchemas"]["trigger"]["properties"]["nested_optional"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
+            );
+        }
+
+        #[test]
+        fn test_unevaluated_items_are_normalized_recursively() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "array",
+                "unevaluatedItems": {
+                    "type": "object",
+                    "properties": {
+                        "nested_optional": {
+                            "type": ["string", "null"]
+                        }
+                    }
+                }
+            }))
+            .unwrap();
+
+            NullFirstOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            assert_eq!(
+                v["unevaluatedItems"]["properties"]["nested_optional"]["type"],
+                serde_json::json!(["null", "string"])
+            );
+            assert_eq!(
+                v["unevaluatedItems"]["properties"]["nested_optional"]["description"],
+                serde_json::json!(OPTIONAL_PROPERTY_GUIDANCE)
             );
         }
     }

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -3,6 +3,7 @@
 use schemars::Schema;
 use serde_json::Value as Json;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 /// Field-level constraint to apply to a schema.
 #[derive(Clone, Debug)]
@@ -168,6 +169,177 @@ impl SchemaEngine {
     }
 }
 
+#[derive(Clone, Default)]
+struct StripNullFromOptional;
+
+impl schemars::transform::Transform for StripNullFromOptional {
+    fn transform(&mut self, schema: &mut Schema) {
+        let mut value = serde_json::to_value(&*schema).expect("serialize schema");
+        strip_nulls_from_optional_properties(&mut value);
+        *schema =
+            Schema::try_from(value).expect("StripNullFromOptional must preserve schema validity");
+    }
+}
+
+fn strip_nulls_from_optional_properties(node: &mut Json) {
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+
+    recurse_object_entries(obj, "$defs");
+    recurse_object_entries(obj, "definitions");
+
+    let required = required_property_names(obj.get("required"));
+    if let Some(properties) = obj.get_mut("properties").and_then(Json::as_object_mut) {
+        for (property_name, property_schema) in properties {
+            if !required.contains(property_name.as_str()) {
+                strip_known_nullable_shapes(property_schema);
+            }
+            strip_nulls_from_optional_properties(property_schema);
+        }
+    }
+
+    recurse_object_entries(obj, "patternProperties");
+    recurse_schema_entry(obj, "additionalProperties");
+    recurse_schema_entry(obj, "propertyNames");
+    recurse_schema_entry(obj, "unevaluatedProperties");
+    recurse_schema_entry(obj, "items");
+    recurse_schema_entry(obj, "contains");
+    recurse_schema_array_entry(obj, "prefixItems");
+    recurse_schema_array_entry(obj, "allOf");
+    recurse_schema_array_entry(obj, "anyOf");
+    recurse_schema_array_entry(obj, "oneOf");
+    recurse_schema_entry(obj, "if");
+    recurse_schema_entry(obj, "then");
+    recurse_schema_entry(obj, "else");
+    recurse_schema_entry(obj, "not");
+}
+
+fn recurse_object_entries(obj: &mut serde_json::Map<String, Json>, key: &str) {
+    let Some(entries) = obj.get_mut(key).and_then(Json::as_object_mut) else {
+        return;
+    };
+
+    for value in entries.values_mut() {
+        strip_nulls_from_optional_properties(value);
+    }
+}
+
+fn recurse_schema_entry(obj: &mut serde_json::Map<String, Json>, key: &str) {
+    let Some(value) = obj.get_mut(key) else {
+        return;
+    };
+
+    strip_nulls_from_optional_properties(value);
+}
+
+fn recurse_schema_array_entry(obj: &mut serde_json::Map<String, Json>, key: &str) {
+    let Some(values) = obj.get_mut(key).and_then(Json::as_array_mut) else {
+        return;
+    };
+
+    for value in values {
+        strip_nulls_from_optional_properties(value);
+    }
+}
+
+fn required_property_names(required: Option<&Json>) -> HashSet<String> {
+    required
+        .and_then(Json::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Json::as_str)
+        .map(str::to_owned)
+        .collect()
+}
+
+fn strip_known_nullable_shapes(node: &mut Json) {
+    strip_null_from_type_array(node);
+    strip_null_from_enum_values(node);
+    strip_null_from_any_of(node);
+}
+
+fn strip_null_from_type_array(node: &mut Json) {
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+
+    let Some(type_values) = obj.get_mut("type").and_then(Json::as_array_mut) else {
+        return;
+    };
+
+    let filtered: Vec<_> = type_values
+        .iter()
+        .filter(|value| *value != &Json::String("null".into()))
+        .cloned()
+        .collect();
+
+    match filtered.as_slice() {
+        [] => {}
+        [single] => {
+            obj.insert("type".to_string(), single.clone());
+        }
+        _ => {
+            obj.insert("type".to_string(), Json::Array(filtered));
+        }
+    }
+}
+
+fn strip_null_from_enum_values(node: &mut Json) {
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+
+    let Some(enum_values) = obj.get_mut("enum").and_then(Json::as_array_mut) else {
+        return;
+    };
+
+    enum_values.retain(|value| !value.is_null());
+}
+
+fn strip_null_from_any_of(node: &mut Json) {
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+
+    let Some(any_of) = obj.get("anyOf").and_then(Json::as_array) else {
+        return;
+    };
+
+    let non_null_branches: Vec<Json> = any_of
+        .iter()
+        .filter(|branch| !is_explicit_null_branch(branch))
+        .cloned()
+        .collect();
+
+    if non_null_branches.len() == any_of.len() || non_null_branches.is_empty() {
+        return;
+    }
+
+    if non_null_branches.len() == 1 {
+        let remaining_branch = non_null_branches.into_iter().next().unwrap();
+        obj.remove("anyOf");
+
+        if let Some(branch_obj) = remaining_branch.as_object() {
+            for (key, value) in branch_obj {
+                obj.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        } else {
+            obj.insert("anyOf".to_string(), Json::Array(vec![remaining_branch]));
+        }
+        return;
+    }
+
+    obj.insert("anyOf".to_string(), Json::Array(non_null_branches));
+}
+
+fn is_explicit_null_branch(node: &Json) -> bool {
+    matches!(
+        node,
+        Json::Object(obj) if obj.get("type") == Some(&Json::String("null".into()))
+    )
+}
+
 // ============================================================================
 // Centralized Draft 2020-12 Generator for MCP + Registry
 // ============================================================================
@@ -176,10 +348,11 @@ impl SchemaEngine {
 ///
 /// This module provides cached schema generation for MCP:
 /// - JSON Schema Draft 2020-12 (MCP protocol requirement)
-/// - `Option<T>` fields include `null` in schema shape (for example, `type`
-///   arrays for simple scalar cases and `anyOf`/`$ref` forms for complex types)
+/// - `Option<T>` object properties are emitted as optional-but-non-nullable at
+///   the property root while preserving inner item/value nullability
 /// - Thread-local caching keyed by TypeId for performance
 pub mod mcp_schema {
+    use super::StripNullFromOptional;
     use schemars::JsonSchema;
     use schemars::Schema;
     use schemars::generate::SchemaSettings;
@@ -195,7 +368,13 @@ pub mod mcp_schema {
     }
 
     fn settings() -> SchemaSettings {
-        SchemaSettings::draft2020_12().with_transform(RestrictFormats::default())
+        // NOTE: StripNullFromOptional also affects output schemas generated by
+        // this shared path. Accepted debt: some output structs may still
+        // serialize Option<T> fields as null until follow-up work aligns
+        // serialization with schema via skip_serializing_if.
+        SchemaSettings::draft2020_12()
+            .with_transform(RestrictFormats::default())
+            .with_transform(StripNullFromOptional)
     }
 
     /// Generate a cached schema for type T using Draft 2020-12.
@@ -345,8 +524,25 @@ mod tests {
     // ========================================================================
 
     mod mcp_schema_tests {
+        use super::Json;
+        use super::Schema;
+        use super::StripNullFromOptional;
         use super::mcp_schema;
+        use schemars::transform::Transform;
         use serde::Serialize;
+
+        fn property<'a>(schema: &'a Json, name: &str) -> &'a Json {
+            &schema["properties"][name]
+        }
+
+        fn required_names(schema: &Json) -> Vec<&str> {
+            schema["required"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Json::as_str)
+                .collect()
+        }
 
         #[derive(schemars::JsonSchema, Serialize)]
         struct WithOption {
@@ -354,18 +550,14 @@ mod tests {
         }
 
         #[test]
-        fn test_option_generates_type_array() {
+        fn test_option_string_is_optional_non_nullable() {
             let root = mcp_schema::cached_schema_for::<WithOption>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
-            let a = &v["properties"]["a"];
-            // Option<String> should produce {"type": ["string", "null"]}
-            let ty = a
-                .get("type")
-                .and_then(|v| v.as_array())
-                .expect("Option<T> should emit a type array");
-            assert!(ty.contains(&serde_json::json!("string")));
-            assert!(ty.contains(&serde_json::json!("null")));
-            assert_eq!(ty.len(), 2, "Option<T> should contain only string|null");
+            let a = property(&v, "a");
+
+            assert_eq!(a.get("type"), Some(&serde_json::json!("string")));
+            assert!(a.get("nullable").is_none());
+            assert!(required_names(&v).is_empty());
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -435,30 +627,13 @@ mod tests {
         }
 
         #[test]
-        fn test_option_enum_anyof_null_branch_has_type() {
+        fn test_option_enum_collapses_to_non_nullable_ref() {
             let root = mcp_schema::cached_schema_for::<HasOptEnum>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
-            let any_of = v["properties"]["e"]["anyOf"]
-                .as_array()
-                .expect("Option<Enum> should generate anyOf");
+            let e = property(&v, "e");
 
-            // There must be a branch with explicit type "null"
-            assert!(
-                any_of
-                    .iter()
-                    .any(|b| b.get("type") == Some(&serde_json::json!("null"))),
-                "anyOf for Option<Enum> must include a branch with type:\"null\""
-            );
-
-            // No branch should have nullable:true without a type
-            for branch in any_of {
-                let has_nullable = branch.get("nullable") == Some(&serde_json::json!(true));
-                let has_type = branch.get("type").is_some() || branch.get("$ref").is_some();
-                assert!(
-                    !has_nullable || has_type,
-                    "No branch may contain nullable:true without a type or $ref"
-                );
-            }
+            assert!(e.get("anyOf").is_none());
+            assert!(e.get("$ref").is_some());
         }
 
         #[derive(schemars::JsonSchema, Serialize)]
@@ -500,27 +675,109 @@ mod tests {
         }
 
         #[test]
-        fn test_option_string_uses_type_array() {
+        fn test_option_string_stays_non_nullable_without_nullable_keyword() {
             let root = mcp_schema::cached_schema_for::<HasOptString>();
             let v = serde_json::to_value(root.as_ref()).unwrap();
-            let s = &v["properties"]["s"];
+            let s = property(&v, "s");
 
-            // Option<String> should produce {"type": ["string", "null"]}
-            let ty = s
-                .get("type")
-                .and_then(|v| v.as_array())
-                .expect("Option<String> should emit a type array");
-            assert!(ty.contains(&serde_json::json!("string")));
-            assert!(ty.contains(&serde_json::json!("null")));
-            assert_eq!(
-                ty.len(),
-                2,
-                "Option<String> should contain only string|null"
-            );
-            // Should NOT have nullable keyword (that was from AddNullable)
+            assert_eq!(s.get("type"), Some(&serde_json::json!("string")));
             assert!(
                 s.get("nullable").is_none(),
                 "Option<String> should not have nullable keyword"
+            );
+        }
+
+        #[derive(schemars::JsonSchema, Serialize)]
+        struct NestedInner {
+            leaf: Option<String>,
+        }
+
+        #[derive(schemars::JsonSchema, Serialize)]
+        struct NestedOuter {
+            nested: Option<NestedInner>,
+        }
+
+        #[test]
+        fn test_nested_optional_properties_are_rewritten_recursively() {
+            let root = mcp_schema::cached_schema_for::<NestedOuter>();
+            let v = serde_json::to_value(root.as_ref()).unwrap();
+            let nested = property(&v, "nested");
+
+            assert!(nested.get("anyOf").is_none());
+            assert!(nested.get("$ref").is_some());
+
+            let defs = v["$defs"]
+                .as_object()
+                .expect("Nested type should use $defs");
+            let inner = defs
+                .values()
+                .find(|schema| schema["properties"].get("leaf").is_some())
+                .expect("NestedInner schema should exist in $defs");
+
+            assert_eq!(
+                inner["properties"]["leaf"]["type"],
+                serde_json::json!("string")
+            );
+        }
+
+        #[derive(schemars::JsonSchema, Serialize)]
+        struct HasOptVec {
+            values: Option<Vec<String>>,
+        }
+
+        #[test]
+        fn test_option_vec_property_loses_outer_nullability() {
+            let root = mcp_schema::cached_schema_for::<HasOptVec>();
+            let v = serde_json::to_value(root.as_ref()).unwrap();
+            let values = property(&v, "values");
+
+            assert_eq!(values.get("type"), Some(&serde_json::json!("array")));
+            assert_eq!(values["items"]["type"], serde_json::json!("string"));
+        }
+
+        #[derive(schemars::JsonSchema, Serialize)]
+        struct HasNestedOptionalItems {
+            values: Option<Vec<Option<String>>>,
+        }
+
+        #[test]
+        fn test_inner_nullability_is_preserved() {
+            let root = mcp_schema::cached_schema_for::<HasNestedOptionalItems>();
+            let v = serde_json::to_value(root.as_ref()).unwrap();
+            let values = property(&v, "values");
+            let item_type = values["items"]["type"]
+                .as_array()
+                .expect("Inner Option<String> should remain nullable");
+
+            assert_eq!(values.get("type"), Some(&serde_json::json!("array")));
+            assert!(item_type.contains(&serde_json::json!("string")));
+            assert!(item_type.contains(&serde_json::json!("null")));
+        }
+
+        #[test]
+        fn test_required_fields_remain_unchanged() {
+            let mut schema = Schema::try_from(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "required_field": { "type": ["string", "null"] },
+                    "optional_field": { "type": ["string", "null"] }
+                },
+                "required": ["required_field"]
+            }))
+            .unwrap();
+
+            StripNullFromOptional.transform(&mut schema);
+
+            let v = serde_json::to_value(&schema).unwrap();
+            let required_type = v["properties"]["required_field"]["type"]
+                .as_array()
+                .expect("Required field should keep nullable type array");
+
+            assert!(required_type.contains(&serde_json::json!("string")));
+            assert!(required_type.contains(&serde_json::json!("null")));
+            assert_eq!(
+                v["properties"]["optional_field"]["type"],
+                serde_json::json!("string")
             );
         }
     }

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -309,7 +309,9 @@ fn annotate_optional_property(node: &mut Json) {
                 description.push_str(OPTIONAL_PROPERTY_GUIDANCE);
             }
         }
-        Some(_) => {}
+        Some(_) => {
+            // Preserve non-string descriptions as-is; appending guidance only works for strings.
+        }
         None => {
             obj.insert(
                 "description".to_string(),

--- a/crates/agentic-tools/mcp/src/server.rs
+++ b/crates/agentic-tools/mcp/src/server.rs
@@ -60,6 +60,7 @@ pub struct RegistryServer {
     registry: Arc<ToolRegistry>,
     allowlist: Option<HashSet<String>>,
     output_mode: OutputMode,
+    text_options: TextOptions,
     name: String,
     version: String,
 }
@@ -71,6 +72,7 @@ impl RegistryServer {
             registry,
             allowlist: None,
             output_mode: OutputMode::default(),
+            text_options: TextOptions::default(),
             name: "agentic-tools".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
         }
@@ -87,6 +89,12 @@ impl RegistryServer {
     /// Set the output mode for tool results.
     pub fn with_output_mode(mut self, mode: OutputMode) -> Self {
         self.output_mode = mode;
+        self
+    }
+
+    /// Set text formatting options for tool results.
+    pub fn with_text_options(mut self, text_options: TextOptions) -> Self {
+        self.text_options = text_options;
         self
     }
 
@@ -207,7 +215,7 @@ impl ServerHandler for RegistryServer {
 
             let args = serde_json::Value::Object(req.arguments.unwrap_or_default());
             let ctx = ToolContext::default();
-            let text_opts = TextOptions::default();
+            let text_opts = self.text_options.clone();
 
             match self
                 .registry
@@ -368,6 +376,21 @@ mod tests {
     use agentic_tools_core::fmt::TextFormat;
     use futures::future::BoxFuture;
 
+    async fn dispatch_text_for_test(server: &RegistryServer, tool_name: &str) -> String {
+        let ctx = ToolContext::default();
+        let result = server
+            .registry
+            .dispatch_json_formatted(
+                tool_name,
+                serde_json::json!(null),
+                &ctx,
+                &server.text_options,
+            )
+            .await
+            .unwrap();
+        result.text.unwrap()
+    }
+
     #[test]
     fn test_registry_server_allowlist() {
         let registry = Arc::new(ToolRegistry::builder().finish());
@@ -433,6 +456,39 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct TestTextOptionsTool;
+
+    #[derive(
+        serde::Serialize, serde::Deserialize, schemars::JsonSchema, Clone, Debug, PartialEq,
+    )]
+    struct TestTextOptionsOut;
+
+    impl TextFormat for TestTextOptionsOut {
+        fn fmt_text(&self, opts: &TextOptions) -> String {
+            if opts.suppress_search_reminder {
+                "suppressed".to_string()
+            } else {
+                "default".to_string()
+            }
+        }
+    }
+
+    impl Tool for TestTextOptionsTool {
+        type Input = ();
+        type Output = TestTextOptionsOut;
+        const NAME: &'static str = "test_text_options_tool";
+        const DESCRIPTION: &'static str = "outputs text that depends on text options";
+
+        fn call(
+            &self,
+            _input: (),
+            _ctx: &ToolContext,
+        ) -> BoxFuture<'static, Result<TestTextOptionsOut, ToolError>> {
+            Box::pin(async move { Ok(TestTextOptionsOut) })
+        }
+    }
+
     #[test]
     fn test_structured_mode_output_schema_gating() {
         // Build registry with TestObjTool
@@ -494,6 +550,28 @@ mod tests {
 
         // In Structured mode with has_schema=true, structured_content would be Some(result.data)
         // In Text mode or has_schema=false, structured_content would be None
+    }
+
+    #[tokio::test]
+    async fn test_registry_server_uses_stored_text_options() {
+        let registry = Arc::new(
+            ToolRegistry::builder()
+                .register::<TestTextOptionsTool, ()>(TestTextOptionsTool)
+                .finish(),
+        );
+
+        let default_server = RegistryServer::new(registry.clone());
+        let suppressed_server = RegistryServer::new(registry)
+            .with_text_options(TextOptions::default().with_suppress_search_reminder(true));
+
+        assert_eq!(
+            dispatch_text_for_test(&default_server, "test_text_options_tool").await,
+            "default"
+        );
+        assert_eq!(
+            dispatch_text_for_test(&suppressed_server, "test_text_options_tool").await,
+            "suppressed"
+        );
     }
 
     #[test]

--- a/crates/tools/coding-agent-tools/src/agent/config.rs
+++ b/crates/tools/coding-agent-tools/src/agent/config.rs
@@ -329,7 +329,7 @@ mod tests {
     fn test_compose_prompt_analyzer_web() {
         let prompt = compose_prompt(AgentType::Analyzer, AgentLocation::Web);
         assert!(prompt.contains("understanding HOW"));
-        assert!(prompt.contains("WebFetch"));
+        assert!(prompt.contains("web_fetch"));
     }
 
     #[test]

--- a/crates/tools/coding-agent-tools/src/agent/config.rs
+++ b/crates/tools/coding-agent-tools/src/agent/config.rs
@@ -52,55 +52,54 @@ pub fn enabled_tools_for(agent_type: AgentType, location: AgentLocation) -> Vec<
     match (agent_type, location) {
         (Locator, Codebase) => vec![
             "mcp__agentic-mcp__cli_ls".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
         ],
         (Locator, Thoughts) => vec![
             "mcp__agentic-mcp__cli_ls".into(),
             "mcp__agentic-mcp__thoughts_list_documents".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
         ],
         (Locator, References) => vec![
             "mcp__agentic-mcp__cli_ls".into(),
             "mcp__agentic-mcp__thoughts_list_references".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
         ],
-        // TODO(3): Replace Claude Code built-in WebSearch/WebFetch with our MCP tools:
-        // - mcp__agentic-mcp__web_search
-        // - mcp__agentic-mcp__web_fetch
-        // This will require updating config tests once the migration happens.
-        (Locator, Web) => vec!["WebSearch".into(), "WebFetch".into()],
+        (Locator, Web) => vec![
+            "mcp__agentic-mcp__web_search".into(),
+            "mcp__agentic-mcp__web_fetch".into(),
+        ],
         (Analyzer, Codebase) => vec![
             "Read".into(),
             "mcp__agentic-mcp__cli_ls".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
             "TodoWrite".into(),
         ],
         (Analyzer, Thoughts) => vec![
             "Read".into(),
             "mcp__agentic-mcp__cli_ls".into(),
             "mcp__agentic-mcp__thoughts_list_documents".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
         ],
         (Analyzer, References) => vec![
             "Read".into(),
             "mcp__agentic-mcp__cli_ls".into(),
             "mcp__agentic-mcp__thoughts_list_references".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
             "TodoWrite".into(),
         ],
         (Analyzer, Web) => vec![
-            "WebSearch".into(),
-            "WebFetch".into(),
+            "mcp__agentic-mcp__web_search".into(),
+            "mcp__agentic-mcp__web_fetch".into(),
             "TodoWrite".into(),
             "Read".into(),
-            "Grep".into(),
-            "Glob".into(),
+            "mcp__agentic-mcp__cli_grep".into(),
+            "mcp__agentic-mcp__cli_glob".into(),
             "mcp__agentic-mcp__cli_ls".into(),
         ],
     }
@@ -151,7 +150,11 @@ pub fn build_mcp_config(_location: AgentLocation, enabled_tools: &[String]) -> M
     }
 
     // Use --allow "tool1,tool2" (no "mcp" subcommand, no individual flags)
-    let args = vec!["--allow".to_string(), allowlist.join(",")];
+    let args = vec![
+        "--allow".to_string(),
+        allowlist.join(","),
+        "--suppress-search-reminder".to_string(),
+    ];
 
     servers.insert(
         "agentic-mcp".to_string(),
@@ -230,8 +233,8 @@ mod tests {
     fn test_enabled_tools_locator_codebase() {
         let tools = enabled_tools_for(AgentType::Locator, AgentLocation::Codebase);
         assert!(tools.contains(&"mcp__agentic-mcp__cli_ls".to_string()));
-        assert!(tools.contains(&"Grep".to_string()));
-        assert!(tools.contains(&"Glob".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_grep".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_glob".to_string()));
         assert!(!tools.contains(&"Read".to_string())); // Locator doesn't read deeply
     }
 
@@ -240,8 +243,8 @@ mod tests {
         let tools = enabled_tools_for(AgentType::Analyzer, AgentLocation::Codebase);
         assert!(tools.contains(&"Read".to_string())); // Analyzer can read
         assert!(tools.contains(&"mcp__agentic-mcp__cli_ls".to_string()));
-        assert!(tools.contains(&"Grep".to_string()));
-        assert!(tools.contains(&"Glob".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_grep".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_glob".to_string()));
     }
 
     #[test]
@@ -263,8 +266,8 @@ mod tests {
         assert!(tools.contains(&"mcp__agentic-mcp__cli_ls".to_string()));
         assert!(tools.contains(&"mcp__agentic-mcp__thoughts_list_documents".to_string()));
         assert!(tools.contains(&"Read".to_string()));
-        assert!(tools.contains(&"Grep".to_string()));
-        assert!(tools.contains(&"Glob".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_grep".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_glob".to_string()));
     }
 
     #[test]
@@ -273,34 +276,40 @@ mod tests {
         assert!(tools.contains(&"mcp__agentic-mcp__cli_ls".to_string()));
         assert!(tools.contains(&"mcp__agentic-mcp__thoughts_list_references".to_string()));
         assert!(tools.contains(&"Read".to_string()));
-        assert!(tools.contains(&"Grep".to_string()));
-        assert!(tools.contains(&"Glob".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_grep".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__cli_glob".to_string()));
         assert!(tools.contains(&"TodoWrite".to_string()));
     }
 
     #[test]
     fn test_enabled_tools_locator_web() {
         let tools = enabled_tools_for(AgentType::Locator, AgentLocation::Web);
-        assert_eq!(tools, vec!["WebSearch".to_string(), "WebFetch".to_string()]);
+        assert_eq!(
+            tools,
+            vec![
+                "mcp__agentic-mcp__web_search".to_string(),
+                "mcp__agentic-mcp__web_fetch".to_string()
+            ]
+        );
     }
 
     #[test]
     fn test_enabled_tools_analyzer_web() {
         let tools = enabled_tools_for(AgentType::Analyzer, AgentLocation::Web);
-        assert!(tools.contains(&"WebSearch".to_string()));
-        assert!(tools.contains(&"WebFetch".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__web_search".to_string()));
+        assert!(tools.contains(&"mcp__agentic-mcp__web_fetch".to_string()));
     }
 
     #[test]
     fn test_enabled_tools_analyzer_web_full_set() {
         let tools = enabled_tools_for(AgentType::Analyzer, AgentLocation::Web);
         let expected = [
-            "WebSearch",
-            "WebFetch",
+            "mcp__agentic-mcp__web_search",
+            "mcp__agentic-mcp__web_fetch",
             "TodoWrite",
             "Read",
-            "Grep",
-            "Glob",
+            "mcp__agentic-mcp__cli_grep",
+            "mcp__agentic-mcp__cli_glob",
             "mcp__agentic-mcp__cli_ls",
         ];
         for t in expected {
@@ -401,60 +410,91 @@ mod tests {
     fn test_agentic_mcp_allowlist_locator_codebase() {
         let enabled = enabled_tools_for(AgentType::Locator, AgentLocation::Codebase);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls"]);
+        assert_eq!(list, vec!["cli_glob", "cli_grep", "cli_ls"]);
     }
 
     #[test]
-    fn test_agentic_mcp_allowlist_locator_web_empty_and_no_server() {
+    fn test_agentic_mcp_allowlist_locator_web_and_server_present() {
         let enabled = enabled_tools_for(AgentType::Locator, AgentLocation::Web);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert!(list.is_empty());
+        assert_eq!(list, vec!["web_fetch", "web_search"]);
 
         let cfg = build_mcp_config(AgentLocation::Web, &enabled);
-        assert!(!cfg.mcp_servers.contains_key("agentic-mcp"));
-        assert_eq!(cfg.mcp_servers.len(), 0);
+        assert!(cfg.mcp_servers.contains_key("agentic-mcp"));
+        assert_eq!(cfg.mcp_servers.len(), 1);
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_locator_thoughts() {
         let enabled = enabled_tools_for(AgentType::Locator, AgentLocation::Thoughts);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls", "thoughts_list_documents"]);
+        assert_eq!(
+            list,
+            vec!["cli_glob", "cli_grep", "cli_ls", "thoughts_list_documents"]
+        );
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_locator_references() {
         let enabled = enabled_tools_for(AgentType::Locator, AgentLocation::References);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls", "thoughts_list_references"]);
+        assert_eq!(
+            list,
+            vec!["cli_glob", "cli_grep", "cli_ls", "thoughts_list_references"]
+        );
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_analyzer_codebase() {
         let enabled = enabled_tools_for(AgentType::Analyzer, AgentLocation::Codebase);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls"]);
+        assert_eq!(list, vec!["cli_glob", "cli_grep", "cli_ls"]);
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_analyzer_thoughts() {
         let enabled = enabled_tools_for(AgentType::Analyzer, AgentLocation::Thoughts);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls", "thoughts_list_documents"]);
+        assert_eq!(
+            list,
+            vec!["cli_glob", "cli_grep", "cli_ls", "thoughts_list_documents"]
+        );
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_analyzer_references() {
         let enabled = enabled_tools_for(AgentType::Analyzer, AgentLocation::References);
         let list = agentic_mcp_allowlist_from(&enabled);
-        assert_eq!(list, vec!["cli_ls", "thoughts_list_references"]);
+        assert_eq!(
+            list,
+            vec!["cli_glob", "cli_grep", "cli_ls", "thoughts_list_references"]
+        );
     }
 
     #[test]
     fn test_agentic_mcp_allowlist_analyzer_web() {
         let enabled = enabled_tools_for(AgentType::Analyzer, AgentLocation::Web);
         let list = agentic_mcp_allowlist_from(&enabled);
-        // Analyzer+Web includes cli_ls
-        assert_eq!(list, vec!["cli_ls"]);
+        assert_eq!(
+            list,
+            vec!["cli_glob", "cli_grep", "cli_ls", "web_fetch", "web_search"]
+        );
+    }
+
+    #[test]
+    fn test_build_mcp_config_includes_suppress_search_reminder_flag() {
+        let enabled = enabled_tools_for(AgentType::Locator, AgentLocation::Codebase);
+        let config = build_mcp_config(AgentLocation::Codebase, &enabled);
+        let Some(server) = config.mcp_servers.get("agentic-mcp") else {
+            panic!("expected agentic-mcp server to be configured");
+        };
+
+        match server {
+            MCPServer::Stdio { command, args, .. } => {
+                assert_eq!(command, "agentic-mcp");
+                assert!(args.contains(&"--suppress-search-reminder".to_string()));
+            }
+            MCPServer::Http { .. } => panic!("expected stdio MCP server"),
+        }
     }
 }

--- a/crates/tools/coding-agent-tools/src/agent/prompts.rs
+++ b/crates/tools/coding-agent-tools/src/agent/prompts.rs
@@ -15,7 +15,7 @@ Core behaviors:
 - Find by names, keywords, and directory patterns
 - Categorize findings (implementation, tests, config, docs, types, examples)
 - Return structured locations (full paths) and clusters
-- Do not read files deeply (use grep/glob/ls/web search as appropriate)
+- Do not read files deeply (use cli_grep/cli_glob/cli_ls/web_search as appropriate)
 - Output MUST follow the Output Format section exactly
 
 What NOT to do:
@@ -62,7 +62,7 @@ Context: Thought documents (active branch).
 Working directory: THOUGHTS_BASE env or ./thoughts/<branch_or_week>.
 
 Guidelines:
-- Use mcp__agentic-mcp__thoughts_list_documents to identify thought docs, then grep/glob/read within the base
+- Use mcp__agentic-mcp__thoughts_list_documents to identify thought docs, then cli_grep/cli_glob/Read within the base
 - Keep citations and paths relative to the thoughts base
 ";
 
@@ -75,8 +75,8 @@ CRITICAL: Reference Directory Structure
 - Actual files live at `references/{org}/{repo}/...`.
 
 Examples:
-- Grep pattern="error" path="references/dtolnay/thiserror/src"
-- Glob pattern="references/getsentry/sentry-rust/**/*.rs"
+- cli_grep pattern="error" path="references/dtolnay/thiserror/src"
+- cli_glob pattern="references/getsentry/sentry-rust/**/*.rs"
 - Read file_path="references/dtolnay/thiserror/README.md"
 
 Guidelines:
@@ -143,8 +143,8 @@ pub const STRATEGY_LOCATOR_CODEBASE: &str = r"
 - Consider language-specific naming conventions
 
 ### Step 2: Broad Scan
-- Grep for keywords across: src/, lib/, pkg/, internal/, cmd/, components/, pages/, api/
-- Glob for typical names: *service*, *handler*, *controller*, *route*, *model*, *store*, *util*
+- Use cli_grep for keywords across: src/, lib/, pkg/, internal/, cmd/, components/, pages/, api/
+- Use cli_glob for typical names: *service*, *handler*, *controller*, *route*, *model*, *store*, *util*
 
 ### Step 3: Refine by Language
 - **JavaScript/TypeScript**: src/, lib/, components/, pages/, api/
@@ -261,7 +261,7 @@ pub const STRATEGY_LOCATOR_THOUGHTS: &str = r#"
 - **artifact** (artifacts/): Tickets, specs, generated outputs
 
 ### Fallback Strategy
-- If MCP list doesn't surface expected docs, use Grep/Glob
+- If MCP list doesn't surface expected docs, use cli_grep/cli_glob
 - Ask before searching historical/archived branches
 - Default to active branch only
 "#;
@@ -358,9 +358,9 @@ pub const STRATEGY_LOCATOR_REFERENCES: &str = r"
 - Select top 2-3 most relevant for focus
 
 ### Step 2: Survey Each Reference
-- Use ls/Glob to map directory structure: README.md, docs/, examples/, src/
+- Use cli_ls/cli_glob to map directory structure: README.md, docs/, examples/, src/
 - Identify high-value locations (docs, examples, main source)
-- Use Grep to search for topic keywords
+- Use cli_grep to search for topic keywords
 
 ### Step 3: Cluster Results
 - Group by reference repo
@@ -402,7 +402,7 @@ pub const STRATEGY_ANALYZER_REFERENCES: &str = r#"
 ### Step 1: Discover and Select
 - Call `mcp__agentic-mcp__thoughts_list_references` to enumerate references
 - Select top 2-3 most relevant for deep analysis
-- Use ls to verify structure exists
+- Use cli_ls to verify structure exists
 
 ### Step 2: Read High-Value Files First
 - README.md and top-level overviews
@@ -419,7 +419,7 @@ pub const STRATEGY_ANALYZER_REFERENCES: &str = r#"
 
 ### Efficiency
 - Don't exhaustively scan entire repos
-- Use Grep to target keywords before reading files
+- Use cli_grep to target keywords before reading files
 - Stop once you have well-cited coverage
 "#;
 
@@ -507,7 +507,7 @@ pub const STRATEGY_ANALYZER_WEB: &str = r"
 - Refine based on initial results
 
 ### Step 3: Fetch and Analyze Content
-- Use WebFetch to retrieve full content from promising results
+- Use web_fetch to retrieve full content from promising results
 - Prioritize official documentation and authoritative sources
 - Extract specific quotes and relevant sections
 - Note publication dates to ensure currency
@@ -625,7 +625,7 @@ mod tests {
     fn test_compose_prompt_analyzer() {
         let prompt = compose_prompt_impl(AgentType::Analyzer, AgentLocation::Web);
         assert!(prompt.contains(ANALYZER_BASE_PROMPT.trim()));
-        assert!(prompt.contains("WebFetch"));
+        assert!(prompt.contains("web_fetch"));
     }
 
     #[test]

--- a/crates/tools/coding-agent-tools/src/agent/prompts.rs
+++ b/crates/tools/coding-agent-tools/src/agent/prompts.rs
@@ -15,7 +15,7 @@ Core behaviors:
 - Find by names, keywords, and directory patterns
 - Categorize findings (implementation, tests, config, docs, types, examples)
 - Return structured locations (full paths) and clusters
-- Do not read files deeply (use cli_grep/cli_glob/cli_ls/web_search as appropriate)
+- Do not read files deeply (use the available discovery tools appropriate to the current location)
 - Output MUST follow the Output Format section exactly
 
 What NOT to do:
@@ -62,27 +62,27 @@ Context: Thought documents (active branch).
 Working directory: THOUGHTS_BASE env or ./thoughts/<branch_or_week>.
 
 Guidelines:
-- Use mcp__agentic-mcp__thoughts_list_documents to identify thought docs, then cli_grep/cli_glob/Read within the base
+- Use the available document-listing and search capabilities, and read documents only when a read tool is available
 - Keep citations and paths relative to the thoughts base
 ";
 
-pub const REFERENCES_OVERLAY: &str = r#"
+pub const REFERENCES_OVERLAY: &str = r"
 Context: Reference repositories (mirrored into local filesystem).
 Working directory: REFERENCES_BASE env or ./references.
 
 CRITICAL: Reference Directory Structure
-- mcp__agentic-mcp__thoughts_list_references returns lines like `{org}/{repo}`.
+- Reference listings return entries like `{org}/{repo}`.
 - Actual files live at `references/{org}/{repo}/...`.
 
 Examples:
-- cli_grep pattern="error" path="references/dtolnay/thiserror/src"
-- cli_glob pattern="references/getsentry/sentry-rust/**/*.rs"
-- Read file_path="references/dtolnay/thiserror/README.md"
+- Search for `error` under `references/dtolnay/thiserror/src`
+- Find Rust files under `references/getsentry/sentry-rust/`
+- Locate `references/dtolnay/thiserror/README.md`
 
 Guidelines:
 - Always include precise citations using references/org/repo/path:lines
 - Be selective; go deep on 2-3 relevant references
-"#;
+";
 
 pub const WEB_OVERLAY: &str = r"
 Context: The web.
@@ -641,6 +641,22 @@ mod tests {
         assert!(THOUGHTS_OVERLAY.contains("Context: Thought documents"));
         assert!(REFERENCES_OVERLAY.contains("Context: Reference repositories"));
         assert!(WEB_OVERLAY.contains("Context: The web"));
+    }
+
+    #[test]
+    fn test_shared_sections_use_capability_based_language() {
+        assert!(!LOCATOR_BASE_PROMPT.contains("cli_grep/cli_glob/cli_ls/web_search"));
+        assert!(!THOUGHTS_OVERLAY.contains("thoughts_list_documents"));
+        assert!(!THOUGHTS_OVERLAY.contains("Read within the base"));
+        assert!(!REFERENCES_OVERLAY.contains("thoughts_list_references"));
+        assert!(!REFERENCES_OVERLAY.contains("cli_grep pattern"));
+        assert!(!REFERENCES_OVERLAY.contains("Read file_path"));
+        assert!(!REFERENCES_OVERLAY.contains("Read `references/"));
+
+        assert!(LOCATOR_BASE_PROMPT.contains("available discovery tools"));
+        assert!(THOUGHTS_OVERLAY.contains("read documents only when a read tool is available"));
+        assert!(REFERENCES_OVERLAY.contains("Reference listings return entries"));
+        assert!(REFERENCES_OVERLAY.contains("Locate `references/dtolnay/thiserror/README.md`"));
     }
 
     #[test]

--- a/crates/tools/coding-agent-tools/src/types.rs
+++ b/crates/tools/coding-agent-tools/src/types.rs
@@ -304,7 +304,7 @@ pub struct GrepOutput {
 }
 
 impl TextFormat for GrepOutput {
-    fn fmt_text(&self, _opts: &TextOptions) -> String {
+    fn fmt_text(&self, opts: &TextOptions) -> String {
         use std::fmt::Write;
         let mut out = String::new();
 
@@ -339,8 +339,9 @@ impl TextFormat for GrepOutput {
             let _ = writeln!(out, "Note: {w}");
         }
 
-        // Required REMINDER footer on every call
-        let _ = writeln!(out, "{SEARCH_REMINDER}");
+        if !opts.suppress_search_reminder {
+            let _ = writeln!(out, "{SEARCH_REMINDER}");
+        }
 
         out.trim_end().to_string()
     }
@@ -360,7 +361,7 @@ pub struct GlobOutput {
 }
 
 impl TextFormat for GlobOutput {
-    fn fmt_text(&self, _opts: &TextOptions) -> String {
+    fn fmt_text(&self, opts: &TextOptions) -> String {
         use std::fmt::Write;
         let mut out = String::new();
 
@@ -380,7 +381,9 @@ impl TextFormat for GlobOutput {
             let _ = writeln!(out, "Note: {w}");
         }
 
-        let _ = writeln!(out, "{SEARCH_REMINDER}");
+        if !opts.suppress_search_reminder {
+            let _ = writeln!(out, "{SEARCH_REMINDER}");
+        }
 
         out.trim_end().to_string()
     }
@@ -456,5 +459,61 @@ mod tests {
             serde_json::to_string(&AgentLocation::Web).unwrap(),
             "\"web\""
         );
+    }
+
+    #[test]
+    fn grep_fmt_text_includes_search_reminder_by_default() {
+        let output = GrepOutput {
+            root: "/tmp/repo".into(),
+            mode: OutputMode::Files,
+            lines: vec!["src/lib.rs".into()],
+            has_more: false,
+            warnings: vec![],
+            summary: None,
+        };
+
+        let text = output.fmt_text(&TextOptions::default());
+        assert!(text.contains(SEARCH_REMINDER));
+    }
+
+    #[test]
+    fn grep_fmt_text_suppresses_search_reminder_when_opt_set() {
+        let output = GrepOutput {
+            root: "/tmp/repo".into(),
+            mode: OutputMode::Files,
+            lines: vec!["src/lib.rs".into()],
+            has_more: false,
+            warnings: vec![],
+            summary: None,
+        };
+
+        let text = output.fmt_text(&TextOptions::new().with_suppress_search_reminder(true));
+        assert!(!text.contains(SEARCH_REMINDER));
+    }
+
+    #[test]
+    fn glob_fmt_text_includes_search_reminder_by_default() {
+        let output = GlobOutput {
+            root: "/tmp/repo".into(),
+            entries: vec!["src/lib.rs".into()],
+            has_more: false,
+            warnings: vec![],
+        };
+
+        let text = output.fmt_text(&TextOptions::default());
+        assert!(text.contains(SEARCH_REMINDER));
+    }
+
+    #[test]
+    fn glob_fmt_text_suppresses_search_reminder_when_opt_set() {
+        let output = GlobOutput {
+            root: "/tmp/repo".into(),
+            entries: vec!["src/lib.rs".into()],
+            has_more: false,
+            warnings: vec![],
+        };
+
+        let text = output.fmt_text(&TextOptions::new().with_suppress_search_reminder(true));
+        assert!(!text.contains(SEARCH_REMINDER));
     }
 }


### PR DESCRIPTION
## What problem(s) was I solving?

Rust `Option<T>` fields in MCP tool input schemas produce **optional + nullable** schemas (`type: ["string", "null"]`, not in `required`). This creates behavioral issues with LLM models:

1. **OpenAI models over-fill optional params**: Rather than omitting fields or using null, models behaviorally prefer to fill in values
2. **The original "strip null" approach backfired**: Stripping null caused OpenAI models to send empty strings `""` instead of omitting fields—worse than the original problem
3. **Schema hints matter for model behavior**: Research suggests null-first ordering (`["null", "string"]`) and explicit description guidance can influence model behavior toward appropriate use of null/omission

Research documents:
- `thoughts/odd_nullable_stuff/research/option-nullable-mcp-tools-comprehensive.md`
- `thoughts/odd_nullable_stuff/research/optional-non-nullable-protocol-safety.md`

## What user-facing changes did I ship?

- **Null-first type arrays**: Optional properties now use `["null", "string"]` ordering instead of `["string", "null"]`
- **Null-first anyOf branches**: `anyOf` arrays with a null branch now place it first (no longer collapsed)
- **Null-first enum values**: Enum arrays containing `null` now place it first (no longer removed)
- **Description guidance**: Optional properties gain `"Optional; omit or use null."` appended to their description

## How I implemented it

Added a `NullFirstOptional` transform to the centralized MCP schema generation path in `crates/agentic-tools/core/src/schema.rs`.

The transform handles three nullable patterns produced by schemars:
1. **Type arrays with null**: `["string", "null"]` → `["null", "string"]`
2. **anyOf with null branch**: Reorders null branch to front (preserves all branches)
3. **Enum values containing null**: Reorders `null` to front of enum array

Key design decisions:
- **Only normalizes optional properties**: Properties in the `required` array remain unchanged
- **Preserves nullability**: Unlike the original approach, this doesn't strip null—just reorders
- **Recursive traversal**: Handles nested objects, `$defs`, `allOf/anyOf/oneOf`, array items, etc.
- **Preserves inner nullability**: `Option<Vec<Option<String>>>` normalizes outer property but keeps inner item nullability intact
- **Description enhancement**: Adds explicit guidance for models about optional field handling

Affects both `agentic-mcp` and `opencode-orchestrator-mcp` through the shared `mcp_schema` module.

Removed the TODO entry about output serialization alignment since we no longer strip null from schemas.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog

Use null-first ordering for optional properties in MCP input schemas: type arrays, anyOf branches, and enum values now place null first, and optional properties receive "Optional; omit or use null." description guidance. This replaces the previous null-stripping approach which caused OpenAI models to send empty strings.


<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

**Schema nullability and LLM behavior:**
Rust `Option<T>` fields in MCP tool input schemas produce **optional + nullable** schemas (`type: ["string", "null"]`, not in `required`). This creates behavioral issues with LLM models:

1. **OpenAI models over-fill optional params**: Rather than omitting fields or using null, models behaviorally prefer to fill in values
2. **The original "strip null" approach backfired**: Stripping null caused OpenAI models to send empty strings `""` instead of omitting fields—worse than the original problem
3. **Schema hints matter for model behavior**: Research suggests null-first ordering (`["null", "string"]`) and explicit description guidance can influence model behavior toward appropriate use of null/omission

**Subagent tool availability:**
Sub-agents (locator/analyzer) were requesting Claude Code built-in tools (Grep, Glob, WebSearch, WebFetch) that can be denied by settings inheritance, leaving these agents without search or web access in certain configurations.

Research documents:
- `thoughts/odd_nullable_stuff/research/option-nullable-mcp-tools-comprehensive.md`
- `thoughts/odd_nullable_stuff/research/optional-non-nullable-protocol-safety.md`

## What user-facing changes did I ship?

**Schema changes:**
- **Null-first type arrays**: Optional properties now use `["null", "string"]` ordering instead of `["string", "null"]`
- **Null-first anyOf branches**: `anyOf` arrays with a null branch now place it first (no longer collapsed)
- **Null-first enum values**: Enum arrays containing `null` now place it first (no longer removed)
- **Description guidance**: Optional nullable properties gain `"Optional; omit or use null."` appended to their description (only if the schema explicitly allows null)

**Subagent reliability:**
- Sub-agents now use internal MCP tools (`cli_grep`, `cli_glob`, `web_search`, `web_fetch`) instead of Claude Code built-ins
- Search reminder footer is suppressed for sub-agent MCP servers to reduce noise in agent responses

## How I implemented it

**Schema transform (`NullFirstOptional`):**
Added a `NullFirstOptional` transform to the centralized MCP schema generation path in `crates/agentic-tools/core/src/schema.rs`.

The transform handles three nullable patterns produced by schemars:
1. **Type arrays with null**: `["string", "null"]` → `["null", "string"]`
2. **anyOf with null branch**: Reorders null branch to front (preserves all branches)
3. **Enum values containing null**: Reorders `null` to front of enum array

Key design decisions:
- **Only normalizes optional properties**: Properties in the `required` array remain unchanged
- **Only annotates nullable optionals**: The "Optional; omit or use null." guidance is only added to properties that explicitly allow null in their schema
- **Preserves nullability**: Unlike the original approach, this doesn't strip null—just reorders
- **Recursive traversal**: Handles nested objects, `$defs`, `dependentSchemas`, `unevaluatedItems`, `allOf/anyOf/oneOf`, array items, etc.
- **Preserves inner nullability**: `Option<Vec<Option<String>>>` normalizes outer property but keeps inner item nullability intact
- **Idempotent description enhancement**: Won't duplicate guidance if transform runs multiple times

Affects both `agentic-mcp` and `opencode-orchestrator-mcp` through the shared `mcp_schema` module.

**Subagent tool routing:**
- Updated `enabled_tools_for()` in `coding_agent_tools` to use MCP tool names instead of Claude Code built-ins
- Added `--suppress-search-reminder` flag to agentic-mcp CLI
- Added `TextOptions::suppress_search_reminder` field and `RegistryServer::with_text_options()` builder method
- Updated `GrepOutput` and `GlobOutput` `TextFormat` implementations to conditionally omit the search reminder
- Updated all subagent prompts to use capability-based language (e.g., "use the available discovery tools") rather than tool-specific names in shared sections

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog

Use null-first ordering for optional properties in MCP input schemas: type arrays, anyOf branches, and enum values now place null first, and optional nullable properties receive "Optional; omit or use null." description guidance. Route subagent search and web tools through internal MCP tools instead of Claude Code built-ins for improved reliability across permission configurations.
<!-- END:describe_pr:autogen -->
