### PR TITLE
Allison eng 279 document thoughts setup and usage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__orchestrator__run",
+      "mcp__orchestrator__list_sessions",
+      "mcp__orchestrator__list_commands",
+      "mcp__orchestrator__get_session_state",
+      "mcp__orchestrator__respond_permission",
+      "mcp__orchestrator__respond_question"
+    ],
+    "deny": [
+      "Bash",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Agent",
+      "Skill",
+      "EnterWorktree",
+      "ExitWorktree",
+      "CronDelete",
+      "CronList",
+      "CronCreate",
+      "ScheduleWakeup",
+      "Monitor",
+      "TaskStop",
+      "WebSearch",
+      "WebFetch",
+      "NotebookEdit",
+      "RemoteTrigger",
+      "PushNotification",
+      "ToolSearch",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskOutput",
+      "TaskUpdate",
+      "EnterPlanMode",
+      "ExitPlanMode",
+      "AskUserQuestion"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Thumbs.db
 
 # Claude settings quarantine backups (auto-pruned)
 /.claude/settings.local.json.malformed.*.bak
+
+doc_updates.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 .env.local
 
-# No more claude (except we have the settings.json committed now)
+# Claude settings: keep the shared MCP config, ignore local overrides and generated files
 .claude/settings.local.json
 .claude/agents/**/*.md
 .claude/commands/**/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 .env
 .env.local
 
-# No more claude
-.claude/settings.json
+# No more claude (except we have the settings.json committed now)
 .claude/settings.local.json
 .claude/agents/**/*.md
 .claude/commands/**/*.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "orchestrator": {
+      "type": "stdio",
+      "command": "opencode-orchestrator-mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Development tools and libraries for agentic workflows (MCP, CLIs, and Rust SDKs)
 
 OpenCode is supported as a first-class workflow in this repo. The codebase uses `just` for task automation and `xtask` for repository maintenance. AI-assisted development is facilitated through per-crate `CLAUDE.md` files containing context and commands.
 
+## Why this is different
+
+This repo treats MCP as the transport layer, not the product: it ships an opinionated harness for agentic workflows with orchestrated sessions, constrained agent roles, scoped tool access, and supporting CLIs like `thoughts`.
+
+For the short version, see [`docs/why_this_stack.md`](./docs/why_this_stack.md). For the full architecture map, see [`workflow.md`](./workflow.md).
+
+## Docs / Setup
+
+- Start here: [`docs/index.md`](./docs/index.md)
+- Setup paths: [`docs/setup/README.md`](./docs/setup/README.md)
+- Troubleshooting: [`docs/troubleshooting.md`](./docs/troubleshooting.md)
+
 ## Primary Tools
 
 ### [`agentic-mcp`](apps/agentic-mcp/)

--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ The core ENG-454 issues have been addressed. Remaining follow-up work:
   there should be a "no-template" option or something. For scenarios like the last turn of create_plan_final where it asks if you want to
   persist it and really all you need to say is "yes". I think the same style of functionality as claude code, where the final assistance
   response is returned back, makes sense to me. We can probably continue that trend. I think all of our "final assistant responses" are
-  already setup to be clear of what happened and such. - I *THINK* this is done.
+  already setup to be clear of what happened and such. Status: needs verification.
 - Ambient git repo detection failures should be handled consistently across tool registries (TODO(2)):
   avoid empty owner/repo fallbacks; prefer clear, fast errors and consider a shared override mechanism.
 - README.md could use a huge refresh. We'll be at the point where we can have all-inclusive instructions for setting up for any repo soon. Would be a lot better than just "Here is a list of tools" if we mentioned how they are used and what they are for and how to do the entire setup.

--- a/TODO.md
+++ b/TODO.md
@@ -30,12 +30,7 @@ These items have dependencies and should be done in order.
 
 ## To plan/design:
 
-### Configuration system (should come first - unblocks big lifts)
-- Need to develop a configuration system so everything can be configurable. Need heavy inspiration from opencode. E.g. similar "here is the schema" header stuff as their config and similar granularity of configurable options available.
-- This absolutely needs to come before any "big lifts" or "large changes" (e.g. before database or before doing more agent work).
-- Will provide proper place to specify: thoughts root, clones dir, DB path, profiles, etc.
-
-### SQLite migration for thoughts (blocked by: config system)
+### SQLite migration for thoughts (blocked by: config system, which is mostly done now)
 - Current file-based structure (thoughts/{branch}/ with research/, plans/, artifacts/, logs/) would become database tables. Key questions:
   - Schema design: documents table, tool_calls table, branches table?
   - Sync strategy without git (SQLite replication? export/import?)
@@ -44,7 +39,7 @@ These items have dependencies and should be done in order.
   - I'm also considering postgres. Some deeper thoughts around postgres vs sqlite and the full agent setup come to mind.
 - Note: The "Unified Canonical Identity System" for references (full repos.json migration) should be folded into this work - canonical identity becomes a DB column with unique index, repos.json deleted entirely.
 
-### Thoughts setup experience + v1 removal (after config system)
+### Thoughts setup experience + v1 removal (after config system - I think this is done now)
 - Re-look at the brand-new thoughts setup experience. How can we make that more streamlined?
 - Should enforce/require a primary "thoughts" repo, and have an initial setup command that populates it with everything it needs.
 - Currently initializes the old v1 config - that's not used anywhere anymore.
@@ -113,7 +108,7 @@ The core ENG-454 issues have been addressed. Remaining follow-up work:
   there should be a "no-template" option or something. For scenarios like the last turn of create_plan_final where it asks if you want to
   persist it and really all you need to say is "yes". I think the same style of functionality as claude code, where the final assistance
   response is returned back, makes sense to me. We can probably continue that trend. I think all of our "final assistant responses" are
-  already setup to be clear of what happened and such.
+  already setup to be clear of what happened and such. - I *THINK* this is done.
 - Ambient git repo detection failures should be handled consistently across tool registries (TODO(2)):
   avoid empty owner/repo fallbacks; prefer clear, fast errors and consider a shared override mechanism.
 - README.md could use a huge refresh. We'll be at the point where we can have all-inclusive instructions for setting up for any repo soon. Would be a lot better than just "Here is a list of tools" if we mentioned how they are used and what they are for and how to do the entire setup.

--- a/TODO.md
+++ b/TODO.md
@@ -132,6 +132,12 @@ project. Either than or tooling for interacting with cargo cache
 in a clean/streamlined abstraction. Probably both would be ideal
 long term.
 
+- `gpt5_reasoner`: `reasoning.api_base_url` / `AGENTIC_REASONING_API_BASE_URL` exists in config but the client hardcodes OpenRouter base URL (see `crates/tools/gpt5-reasoner/src/client.rs`).
+- `thoughts`: `status --detailed` flag is accepted but currently has no effect (unused parameter in `apps/thoughts/src/commands/status.rs`).
+- `thoughts`: `sync` code comment claims "repository-aware sync" but behavior does not filter by repo (see `apps/thoughts/src/commands/sync.rs`).
+- `agentic-bin`: missing `[package.metadata.binstall]` unlike other shipped binaries (see `apps/agentic/Cargo.toml`).
+- `opencode-orchestrator-mcp`: stale "five tools" comment despite six tools being registered (see `apps/opencode-orchestrator-mcp/src/main.rs` vs registry).
+
 ## To validate:
 - ENG-397: Linear MCP should return issue URL after creation. May already be implemented - needs verification.
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,7 @@ These items have dependencies and should be done in order.
 ## To plan/design:
 
 ### SQLite migration for thoughts (blocked by: config system, which is mostly done now)
+
 - Current file-based structure (thoughts/{branch}/ with research/, plans/, artifacts/, logs/) would become database tables. Key questions:
   - Schema design: documents table, tool_calls table, branches table?
   - Sync strategy without git (SQLite replication? export/import?)
@@ -132,11 +133,11 @@ project. Either than or tooling for interacting with cargo cache
 in a clean/streamlined abstraction. Probably both would be ideal
 long term.
 
-- `gpt5_reasoner`: `reasoning.api_base_url` / `AGENTIC_REASONING_API_BASE_URL` exists in config but the client hardcodes OpenRouter base URL (see `crates/tools/gpt5-reasoner/src/client.rs`).
-- `thoughts`: `status --detailed` flag is accepted but currently has no effect (unused parameter in `apps/thoughts/src/commands/status.rs`).
-- `thoughts`: `sync` code comment claims "repository-aware sync" but behavior does not filter by repo (see `apps/thoughts/src/commands/sync.rs`).
-- `agentic-bin`: missing `[package.metadata.binstall]` unlike other shipped binaries (see `apps/agentic/Cargo.toml`).
-- `opencode-orchestrator-mcp`: stale "five tools" comment despite six tools being registered (see `apps/opencode-orchestrator-mcp/src/main.rs` vs registry).
+- TODO(2): `gpt5_reasoner`: `reasoning.api_base_url` / `AGENTIC_REASONING_API_BASE_URL` exists in config but the client hardcodes OpenRouter base URL (see `crates/tools/gpt5-reasoner/src/client.rs`).
+- TODO(2): `thoughts`: `status --detailed` flag is accepted but currently has no effect (unused parameter in `apps/thoughts/src/commands/status.rs`).
+- TODO(2): `thoughts`: `sync` code comment claims "repository-aware sync" but behavior does not filter by repo (see `apps/thoughts/src/commands/sync.rs`).
+- TODO(2): `agentic-bin`: missing `[package.metadata.binstall]` unlike other shipped binaries (see `apps/agentic/Cargo.toml`).
+- TODO(2): `opencode-orchestrator-mcp`: stale "five tools" comment despite six tools being registered (see `apps/opencode-orchestrator-mcp/src/main.rs` vs registry).
 
 ## To validate:
 - ENG-397: Linear MCP should return issue URL after creation. May already be implemented - needs verification.

--- a/apps/agentic/Cargo.toml
+++ b/apps/agentic/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/allisoneer/agentic_auxilary"
 description = "Agentic unified CLI for configuration management"
+publish = true
 
 [package.metadata.repo]
 role = "app"
@@ -14,6 +15,12 @@ family = "tools"
 mcp = false
 logging = false
 napi = false
+
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/{name}-v{version}/{name}-{target}.tar.xz"
+pkg-fmt = "txz"
+bin-dir = "{name}-{target}/{bin}{binary-ext}"
+disabled-strategies = ["quick-install", "compile"]
 
 [[bin]]
 name = "agentic"

--- a/crates/infra/thoughts-core/README.md
+++ b/crates/infra/thoughts-core/README.md
@@ -149,7 +149,11 @@ thoughts [COMMAND] [OPTIONS]
 
 ## Configuration
 
-Thoughts Tool uses a repository-based configuration system with automatic v1 to v2 migration support.
+Thoughts Tool uses a v2 repository configuration file at `.thoughts/config.json`.
+
+- Current runtime expects `version: "2.0"`.
+- Older v1 configs are not supported by the current runtime.
+- For user-facing setup, configuration, and troubleshooting docs, see [`../../../docs/index.md`](../../../docs/index.md).
 
 ### Configuration Structure
 
@@ -194,26 +198,6 @@ The configuration file (`.thoughts/config.json`) defines:
 }
 ```
 
-### Migration from v1
-
-**Automatic migration happens on the first write operation** (e.g., `thoughts init`, `thoughts mount add`, `thoughts references add`):
-
-- V1 configs are automatically converted to v2 format
-- A timestamped backup is created if you have non-empty mounts or rules (`.thoughts/config.v1.bak-*.json`)
-- Migration rules:
-  - Mounts with `sync: none` or paths starting with `references/` → become references
-  - Other mounts → become context mounts
-  - Rules field → dropped (preserved in backup only)
-- One-line message confirms migration with link to full guide
-
-You can also explicitly migrate with:
-```bash
-thoughts config migrate-to-v2 --dry-run  # Preview
-thoughts config migrate-to-v2 --yes      # Execute
-```
-
-For detailed migration instructions, see [MIGRATION_V1_TO_V2.md](./MIGRATION_V1_TO_V2.md).
-
 ## Architecture
 
 ### Three-Space Design
@@ -243,7 +227,7 @@ The tool automatically detects your platform and uses the appropriate mount tech
 1. Uses type-safe `MountSpace` enum for mount identification
 2. Resolves to unique paths under `.thoughts-data/`
 3. Handles automatic cloning for missing repositories
-4. Maintains mappings in `~/.thoughts/repos.json`
+4. Maintains mappings in `~/.config/agentic/repos.json` (legacy input: `~/.thoughts/repos.json`)
 
 ### Git Integration
 - Full support for worktrees (see Git Worktree Support section)

--- a/crates/infra/thoughts-core/README.md
+++ b/crates/infra/thoughts-core/README.md
@@ -1,6 +1,6 @@
 # Thoughts Tool v2
 
-A flexible thought management tool that helps developers organize notes and documentation across git repositories using filesystem mounts (mergerfs on Linux, fuse-t on macOS) with a three-space architecture.
+A flexible thought management tool that helps developers organize notes and documentation across git repositories using filesystem mounts (mergerfs on Linux; FUSE-T or macFUSE plus unionfs-fuse on macOS) with a three-space architecture.
 
 ## What is Thoughts Tool?
 
@@ -13,14 +13,14 @@ It automatically mounts and syncs git-backed directories, allowing you to access
 
 ## Key Features
 
-- 🗂️ **Three-Space Architecture**: Organized separation of thoughts, context, and references
-- 🔄 **Automatic Git Sync**: Keep your documentation synchronized across repositories
-- 🖥️ **Cross-Platform**: Works on Linux (mergerfs) and macOS (fuse-t)
-- 📚 **Reference Management**: Read-only mounts for external code repositories
-- 🌿 **Branch-Based Work Organization**: Automatic directory structure based on current branch
-- 🔧 **Repository Integration**: Seamlessly integrates with existing git workflows
-- 🎯 **Worktree Support**: Full support for git worktrees
-- 🚀 **Auto-Mount System**: Automatic mount management for all three spaces
+- **Three-Space Architecture**: Organized separation of thoughts, context, and references
+- **Automatic Git Sync**: Keep your documentation synchronized across repositories
+- **Cross-Platform**: Works on Linux (mergerfs) and macOS (FUSE-T or macFUSE, with `unionfs-fuse` for the union layer)
+- **Reference Management**: Read-only mounts for external code repositories
+- **Branch-Based Work Organization**: Automatic directory structure based on current branch
+- **Repository Integration**: Seamlessly integrates with existing git workflows
+- **Worktree Support**: Full support for git worktrees
+- **Auto-Mount System**: Automatic mount management for all three spaces
 
 ## Installation
 
@@ -32,7 +32,9 @@ It automatically mounts and syncs git-backed directories, allowing you to access
 - Git installed
 
 #### macOS
-- fuse-t installed (`brew install macos-fuse-t/homebrew-cask/fuse-t`)
+- FUSE-T (preferred) installed (`brew install macos-fuse-t/homebrew-cask/fuse-t`)
+- Or macFUSE installed as the alternative backend
+- `unionfs-fuse` installed for the union layer
 - Git installed
 
 ### Building from Source
@@ -221,7 +223,7 @@ The tool organizes all mounts into three distinct spaces:
 ### Platform Abstraction
 The tool automatically detects your platform and uses the appropriate mount technology:
 - **Linux**: Uses mergerfs for high-performance union filesystem
-- **macOS**: Uses fuse-t for FUSE support on Apple Silicon and Intel Macs
+- **macOS**: Uses FUSE-T or macFUSE (prefers FUSE-T when both are present), plus `unionfs-fuse` for the union layer
 
 ### Mount Resolution
 1. Uses type-safe `MountSpace` enum for mount identification
@@ -435,7 +437,7 @@ If you encounter permission errors:
 ### Platform Detection Failed
 The tool will inform you if required mount utilities are missing:
 - Linux: Install mergerfs
-- macOS: Install fuse-t via Homebrew
+- macOS: Install FUSE-T via Homebrew (preferred) or macFUSE, and make sure `unionfs-fuse` is installed too
 
 ### Git Sync Conflicts
 When sync conflicts occur:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,27 @@
+# Authentication
+
+Most credentials are read from environment variables inside the tool and service crates. If you run tools through MCP, set env vars in the MCP client's server configuration so they are present in the spawned `agentic-mcp` or `opencode-orchestrator-mcp` subprocess environment.
+
+## Auth matrix (implemented behavior)
+
+| Service / Tooling | Primary env var | Alternative path(s) | Implementation location |
+|---|---|---|---|
+| GitHub (PR comments) | `GH_TOKEN` | `GITHUB_TOKEN`, then gh CLI stored auth state | `crates/tools/pr-comments/src/lib.rs` |
+| Linear | `LINEAR_API_KEY` | Any bearer-style token passed via `LINEAR_API_KEY` | `crates/linear/tools/src/http.rs` |
+| Exa | `EXA_API_KEY` | None found in tool usage | `crates/services/exa-async/src/config.rs` |
+| OpenRouter (`gpt5_reasoner`) | `OPENROUTER_API_KEY` | None found | `crates/tools/gpt5-reasoner/src/client.rs` |
+| Anthropic (SDK) | `ANTHROPIC_API_KEY` | `ANTHROPIC_AUTH_TOKEN`, or both headers together | `crates/services/anthropic-async/src/config.rs` |
+| web-retrieval summarizer | `ANTHROPIC_API_KEY` | Fallback to Anthropic provider key discovered from OpenCode | `crates/tools/web-retrieval/src/haiku.rs` |
+
+## Notes
+
+- `agentic.toml` intentionally does not store API keys.
+- `pr_comments` checks `GH_TOKEN` before `GITHUB_TOKEN`, then falls back to gh CLI auth state.
+- `gpt5_reasoner` currently uses OpenRouter-only auth and hardcodes the OpenRouter base URL.
+- Some auth behavior, such as Claude Code login and OpenCode account state, is handled by external CLIs that this repo launches or interoperates with.
+
+## Related docs
+
+- Setup flows: [`./setup/README.md`](./setup/README.md)
+- Configuration reference: [`./config.md`](./config.md)
+- Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Most credentials are read from environment variables inside the tool and service crates. If you run tools through MCP, set env vars in the MCP client's server configuration so they are present in the spawned `agentic-mcp` or `opencode-orchestrator-mcp` subprocess environment.
+The auth model here is intentionally boring: `agentic.toml` stores non-secret config, while secrets live in environment variables. MCP clients launch `agentic-mcp` or `opencode-orchestrator-mcp` as subprocesses, so if you want those tools to see credentials, you inject the env vars into the subprocess config for that client.
 
 ## Auth matrix (implemented behavior)
 
@@ -13,15 +13,73 @@ Most credentials are read from environment variables inside the tool and service
 | Anthropic (SDK) | `ANTHROPIC_API_KEY` | `ANTHROPIC_AUTH_TOKEN`, or both headers together | `crates/services/anthropic-async/src/config.rs` |
 | web-retrieval summarizer | `ANTHROPIC_API_KEY` | Fallback to Anthropic provider key discovered from OpenCode | `crates/tools/web-retrieval/src/haiku.rs` |
 
+## Injecting env vars via MCP client config
+
+### OpenCode local MCP server
+
+OpenCode's local MCP server entries support an `environment` map. That map is applied to the spawned server process, which is exactly what you want for secrets.
+
+```json
+{
+  "mcp": {
+    "tools": {
+      "type": "local",
+      "command": ["agentic-mcp"],
+      "environment": {
+        "GH_TOKEN": "set-me-here",
+        "EXA_API_KEY": "set-me-here",
+        "OPENROUTER_API_KEY": "set-me-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+The important bit is the `environment` object, not the exact set of keys above. Put the credentials there for whichever tools you actually enabled.
+
+### Claude Code per-server MCP env
+
+Claude Code's MCP config supports an `env` object on each `mcpServers` entry.
+
+```json
+{
+  "mcpServers": {
+    "agentic-tools": {
+      "command": "agentic-mcp",
+      "args": [],
+      "env": {
+        "GH_TOKEN": "${GH_TOKEN}",
+        "EXA_API_KEY": "${EXA_API_KEY}",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Claude Code also supports `${VAR}` expansion in that file, so you can keep the real secrets in your shell/session environment and pass them through cleanly.
+
+### Claude Code session-level settings env
+
+If you want variables applied to the whole Claude Code session instead of one MCP server, `settings.json` has a top-level `env` key too.
+
+```json
+{
+  "env": {
+    "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+    "EXA_API_KEY": "${EXA_API_KEY}"
+  }
+}
+```
+
+That is broader than the per-server `env` block, so I would only use it when that scope is what you actually intend.
+
 ## Notes
 
 - `agentic.toml` intentionally does not store API keys.
 - `pr_comments` checks `GH_TOKEN` before `GITHUB_TOKEN`, then falls back to gh CLI auth state.
 - `gpt5_reasoner` currently uses OpenRouter-only auth and hardcodes the OpenRouter base URL.
-- Some auth behavior, such as Claude Code login and OpenCode account state, is handled by external CLIs that this repo launches or interoperates with.
+- Claude Code and OpenCode keep their own login/account state; this repo mostly consumes that state rather than replacing it.
 
-## Related docs
-
-- Setup flows: [`./setup/README.md`](./setup/README.md)
-- Configuration reference: [`./config.md`](./config.md)
-- Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)
+If you are still in initial setup mode, go back to [`./setup/README.md`](./setup/README.md). If auth looks fine but tools still fail, the next stop is [`./troubleshooting.md`](./troubleshooting.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,67 @@
+# Configuration
+
+This repo uses a mix of per-project config and global config. Internal links below are relative so they work on GitHub and locally.
+
+## `agentic.toml` (global + local)
+
+- Global: `~/.config/agentic/agentic.toml`
+- Local (project): `./agentic.toml`
+
+Precedence (lowest to highest):
+
+1. Defaults
+2. Global file
+3. Local file
+4. Environment variables
+
+Create, edit, and validate:
+
+```bash
+agentic config init
+agentic config edit
+agentic config validate
+```
+
+See the full example file: [`../agentic.toml.example`](../agentic.toml.example)
+
+## Thoughts repo config: `.thoughts/config.json` (v2 only)
+
+- Location: `<repo>/.thoughts/config.json`
+- Current runtime expects `version: "2.0"`.
+- Older v1 configs are not supported by the current runtime.
+
+Useful commands:
+
+```bash
+thoughts config show
+thoughts config edit
+thoughts config validate
+```
+
+High-level shape:
+
+- `version`
+- `mount_dirs`
+- `thoughts_mount`
+- `context_mounts`
+- `references`
+
+## Repo mapping file: `~/.config/agentic/repos.json`
+
+Thoughts maintains a URL-to-local-path mapping file here:
+
+- Canonical path: `~/.config/agentic/repos.json`
+- Legacy input (migration only): `~/.thoughts/repos.json`
+
+High-level shape:
+
+- `version`
+- `mappings` keyed by repo identity to `{ path, auto_managed, last_sync? }`
+
+`auto_managed` indicates whether tooling owns lifecycle updates for that mapping.
+
+## Related docs
+
+- Setup flows: [`./setup/README.md`](./setup/README.md)
+- Authentication reference: [`./auth.md`](./auth.md)
+- Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,8 @@ There are three config surfaces worth caring about here: `agentic.toml` for non-
 
 `agentic.toml` is the non-secret config layer used by `agentic-mcp`, the reasoning tool, the orchestrator, and a few other pieces. The merge order is defaults → global `~/.config/agentic/agentic.toml` → local `./agentic.toml` → environment variables.
 
+These commands come from the `agentic` binary specifically, and today they are focused on managing this config surface:
+
 Useful commands:
 
 ```bash
@@ -34,7 +36,7 @@ Think of this as orientation and defaults, not secret storage. Models, base URLs
 
 ## `.thoughts/config.json` (per repo, v2 only)
 
-This file lives at `<repo>/.thoughts/config.json` and tells `thoughts` what the repo wants mounted. Current runtime expects `version: "2.0"`; older v1 configs are not supported anymore.
+This file lives at `<repo>/.thoughts/config.json` and tells `thoughts` what the repo wants to mount. Current runtime expects `version: "2.0"`; older v1 configs are not supported anymore.
 
 Useful commands:
 
@@ -56,9 +58,13 @@ Minimal shape:
 
 The real file can also include `mount_dirs` and `references`, but the shape above is the part most people need to orient themselves: one optional thoughts repo, zero or more context repos, then a reference list.
 
+`thoughts config edit` is a thin wrapper around editing this file directly: it opens `<repo>/.thoughts/config.json` in `VISUAL`, then `EDITOR`, then `vi`; after you exit, it validates the file, rewrites it in normalized JSON, and updates active mounts.
+
 ## `~/.config/agentic/repos.json` (repo mappings)
 
 This is the canonical mapping file for repo URLs to local paths. `~/.thoughts/repos.json` is only legacy input now, not the current home for the file.
+
+This file is intentionally local and context-specific: different developers can map the same canonical repo identity to different clone paths on their own machines. By contrast, `agentic.toml` and `.thoughts/config.json` are the shareable, team-oriented layers that describe defaults and mount intent rather than one person's filesystem layout.
 
 Minimal shape:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,20 +1,12 @@
 # Configuration
 
-This repo uses a mix of per-project config and global config. Internal links below are relative so they work on GitHub and locally.
+There are three config surfaces worth caring about here: `agentic.toml` for non-secret agent/tool settings, `.thoughts/config.json` for per-repo mount intent, and `~/.config/agentic/repos.json` for URL-to-local-path mappings. They do different jobs, which is good, because mixing them would be worse.
 
 ## `agentic.toml` (global + local)
 
-- Global: `~/.config/agentic/agentic.toml`
-- Local (project): `./agentic.toml`
+`agentic.toml` is the non-secret config layer used by `agentic-mcp`, the reasoning tool, the orchestrator, and a few other pieces. The merge order is defaults → global `~/.config/agentic/agentic.toml` → local `./agentic.toml` → environment variables.
 
-Precedence (lowest to highest):
-
-1. Defaults
-2. Global file
-3. Local file
-4. Environment variables
-
-Create, edit, and validate:
+Useful commands:
 
 ```bash
 agentic config init
@@ -22,13 +14,27 @@ agentic config edit
 agentic config validate
 ```
 
-See the full example file: [`../agentic.toml.example`](../agentic.toml.example)
+Minimal shape, trimmed from [`../agentic.toml.example`](../agentic.toml.example):
 
-## Thoughts repo config: `.thoughts/config.json` (v2 only)
+```toml
+[subagents]
+locator_model = "claude-haiku-4-5"
 
-- Location: `<repo>/.thoughts/config.json`
-- Current runtime expects `version: "2.0"`.
-- Older v1 configs are not supported by the current runtime.
+[reasoning]
+executor_model = "openai/gpt-5.2"
+
+[services.anthropic]
+base_url = "https://api.anthropic.com"
+
+[logging]
+level = "info"
+```
+
+Think of this as orientation and defaults, not secret storage. Models, base URLs, timeouts, and logging belong here; API keys do not.
+
+## `.thoughts/config.json` (per repo, v2 only)
+
+This file lives at `<repo>/.thoughts/config.json` and tells `thoughts` what the repo wants mounted. Current runtime expects `version: "2.0"`; older v1 configs are not supported anymore.
 
 Useful commands:
 
@@ -38,30 +44,33 @@ thoughts config edit
 thoughts config validate
 ```
 
-High-level shape:
+Minimal shape:
 
-- `version`
-- `mount_dirs`
-- `thoughts_mount`
-- `context_mounts`
-- `references`
+```json
+{
+  "version": "2.0",
+  "thoughts_mount": { "remote": "git@github.com:user/thoughts.git", "sync": "auto" },
+  "context_mounts": [{ "remote": "https://github.com/team/docs.git", "mount_path": "team-docs", "sync": "auto" }]
+}
+```
 
-## Repo mapping file: `~/.config/agentic/repos.json`
+The real file can also include `mount_dirs` and `references`, but the shape above is the part most people need to orient themselves: one optional thoughts repo, zero or more context repos, then a reference list.
 
-Thoughts maintains a URL-to-local-path mapping file here:
+## `~/.config/agentic/repos.json` (repo mappings)
 
-- Canonical path: `~/.config/agentic/repos.json`
-- Legacy input (migration only): `~/.thoughts/repos.json`
+This is the canonical mapping file for repo URLs to local paths. `~/.thoughts/repos.json` is only legacy input now, not the current home for the file.
 
-High-level shape:
+Minimal shape:
 
-- `version`
-- `mappings` keyed by repo identity to `{ path, auto_managed, last_sync? }`
+```json
+{
+  "version": "1.0",
+  "mappings": {
+    "github.com/org/repo": { "path": "/path/to/repo", "auto_managed": false }
+  }
+}
+```
 
-`auto_managed` indicates whether tooling owns lifecycle updates for that mapping.
+`auto_managed` is the part that usually matters in practice. `true` means the tooling created/owns that clone path; `false` means you pointed the system at a repo you manage yourself.
 
-## Related docs
-
-- Setup flows: [`./setup/README.md`](./setup/README.md)
-- Authentication reference: [`./auth.md`](./auth.md)
-- Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)
+If you came here from setup, the next useful stop is usually [`./auth.md`](./auth.md) for secrets or [`./troubleshooting.md`](./troubleshooting.md) when a mapping exists but the mount still is not doing what you expected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,18 @@
 # User docs
 
-These docs cover setup, configuration, auth, troubleshooting, and a short "why this stack" overview.
+If you're trying to get running, start with setup and branch out from there. The rest of this directory is the supporting material: what to edit, where auth lives, what to check when mounts go sideways, and why the stack is built this way in the first place.
 
-- Setup: [`docs/setup/README.md`](./setup/README.md)
-- Configuration: [`docs/config.md`](./config.md)
-- Authentication: [`docs/auth.md`](./auth.md)
-- Troubleshooting: [`docs/troubleshooting.md`](./troubleshooting.md)
-- Why this stack: [`docs/why_this_stack.md`](./why_this_stack.md)
+## Start here
 
-## Supported platforms
-
-- Linux and macOS are supported.
-- Windows is not supported.
+- Setup paths: [`./setup/README.md`](./setup/README.md)
+- Configuration: [`./config.md`](./config.md)
+- Authentication: [`./auth.md`](./auth.md)
+- Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)
+- Why this stack: [`./why_this_stack.md`](./why_this_stack.md)
 
 ## Setup paths
 
-- Fresh install (new machine): [`docs/setup/fresh_install.md`](./setup/fresh_install.md)
-- Existing repo (already has Thoughts config): [`docs/setup/existing_repo.md`](./setup/existing_repo.md)
-- New repo (first time adding Thoughts): [`docs/setup/new_repo.md`](./setup/new_repo.md)
-- After reboot (remount): [`docs/setup/reboot.md`](./setup/reboot.md)
+- Fresh install on a new machine: [`./setup/fresh_install.md`](./setup/fresh_install.md)
+- Existing repo that already has `.thoughts/config.json`: [`./setup/existing_repo.md`](./setup/existing_repo.md)
+- New repo with no Thoughts setup yet: [`./setup/new_repo.md`](./setup/new_repo.md)
+- Reboot/remount recovery: [`./setup/reboot.md`](./setup/reboot.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# User docs
+
+These docs cover setup, configuration, auth, troubleshooting, and a short "why this stack" overview.
+
+- Setup: [`docs/setup/README.md`](./setup/README.md)
+- Configuration: [`docs/config.md`](./config.md)
+- Authentication: [`docs/auth.md`](./auth.md)
+- Troubleshooting: [`docs/troubleshooting.md`](./troubleshooting.md)
+- Why this stack: [`docs/why_this_stack.md`](./why_this_stack.md)
+
+## Supported platforms
+
+- Linux and macOS are supported.
+- Windows is not supported.
+
+## Setup paths
+
+- Fresh install (new machine): [`docs/setup/fresh_install.md`](./setup/fresh_install.md)
+- Existing repo (already has Thoughts config): [`docs/setup/existing_repo.md`](./setup/existing_repo.md)
+- New repo (first time adding Thoughts): [`docs/setup/new_repo.md`](./setup/new_repo.md)
+- After reboot (remount): [`docs/setup/reboot.md`](./setup/reboot.md)

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,10 +1,10 @@
 # Setup
 
-Pick the path that matches your situation:
+Pick the path that matches the repo and machine you actually have.
 
-1. Fresh install (new machine): [`fresh_install.md`](./fresh_install.md)
-2. Existing repo (repo already has `.thoughts/config.json`): [`existing_repo.md`](./existing_repo.md)
-3. New repo (no Thoughts setup yet): [`new_repo.md`](./new_repo.md)
-4. After reboot / mounts missing: [`reboot.md`](./reboot.md)
+1. **Fresh install** — new machine, or at least a machine that does not have the tooling yet: [`./fresh_install.md`](./fresh_install.md)
+2. **Existing repo** — the repo already contains `.thoughts/config.json`, and you mostly need to bring local state into line: [`./existing_repo.md`](./existing_repo.md)
+3. **New repo** — you want to add Thoughts to a repo for the first time: [`./new_repo.md`](./new_repo.md)
+4. **After reboot** — the config still exists, but the mounts vanished because the machine restarted: [`./reboot.md`](./reboot.md)
 
-If you get stuck, see [`../troubleshooting.md`](../troubleshooting.md).
+If one of those paths ends with "why is this still broken," jump to [`../troubleshooting.md`](../troubleshooting.md).

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,0 +1,10 @@
+# Setup
+
+Pick the path that matches your situation:
+
+1. Fresh install (new machine): [`fresh_install.md`](./fresh_install.md)
+2. Existing repo (repo already has `.thoughts/config.json`): [`existing_repo.md`](./existing_repo.md)
+3. New repo (no Thoughts setup yet): [`new_repo.md`](./new_repo.md)
+4. After reboot / mounts missing: [`reboot.md`](./reboot.md)
+
+If you get stuck, see [`../troubleshooting.md`](../troubleshooting.md).

--- a/docs/setup/existing_repo.md
+++ b/docs/setup/existing_repo.md
@@ -1,38 +1,55 @@
 # Existing repo setup (repo already has Thoughts config)
 
-Use this path if the repository already contains `.thoughts/config.json` and you're setting up a new machine or a new checkout.
+Use this path when the repo already has `.thoughts/config.json` and you mostly need local state to catch up.
 
-## Steps
+One nuance that matters more than it first appears: a lot of people do **not** want every thoughts/context/reference repo auto-managed for them. If you cloned something yourself because you want to edit it directly, inspect `git status`, keep it private, or just control where it lives, register that local clone **before** you run commands that auto-clone missing repos. The auto-clone paths are `thoughts references sync` and `thoughts mount update`; if there is no mapping yet, those commands will use the managed clone location under `~/.thoughts/clones/...` and record it as auto-managed in `~/.config/agentic/repos.json`.
 
-1. Ensure you are inside a git repository.
-   - If you run `thoughts init` outside a git repo, you'll see:
-     `Not in a git repository. Run 'git init' first.`
+For local context repos, `thoughts mount add /path/to/repo <mount_path>` is the clean CLI path: it records the local path with `auto_managed=false` and adds the mount to `.thoughts/config.json`. The broader rule is simple even if your setup is a little weirder than that: get your local mapping in place first, then let the sync/update commands reconcile around it.
 
-2. Initialize Thoughts in the repo:
+## Setup steps
 
-```bash
-thoughts init
-```
+1. Make sure you are inside the repo you actually want to use.
 
-3. Reconcile or remount configured mounts:
+   `thoughts init` only works inside a git repository; outside one it fails with `Not in a git repository. Run 'git init' first.`
 
-```bash
-thoughts mount update
-```
+2. Initialize the local checkout.
 
-4. Sync git-backed mounts if needed. This is not the remount command:
+   ```bash
+   thoughts init
+   ```
 
-```bash
-thoughts sync --all
-```
+   This refreshes the local Thoughts scaffolding for the repo and makes sure the symlinks and control state are in place for your current checkout.
 
-5. If references are configured, ensure they are cloned, then remount:
+3. If you already cloned a context repo yourself and want to keep using that clone, register it before any auto-clone command runs.
 
-```bash
-thoughts references sync
-thoughts mount update
-```
+   ```bash
+   thoughts mount add /path/to/repo <mount_path>
+   ```
 
-6. For configuration details, see [`../config.md`](../config.md).
+   This adds the context mount to config and stores the repo mapping as user-managed instead of auto-managed.
 
-If something fails, see [`../troubleshooting.md`](../troubleshooting.md).
+4. Sync configured references.
+
+   ```bash
+   thoughts references sync
+   ```
+
+   This clones or fast-forwards the configured reference repos and writes auto-managed mappings for anything it had to manage itself.
+
+5. Reconcile the live mounts.
+
+   ```bash
+   thoughts mount update
+   ```
+
+   This is the FUSE reconciliation step: it compares desired state to active mounts, remounts what is missing, and is also the command you need after a reboot.
+
+6. Optionally sync the git-backed thoughts/context mounts.
+
+   ```bash
+   thoughts sync --all
+   ```
+
+   This does git sync for auto-sync mounts. It is useful, but it is not a substitute for `thoughts mount update`.
+
+If you need to change what is mounted, not just bring it up, read [`../config.md`](../config.md). If something still looks wrong after that, go straight to [`../troubleshooting.md`](../troubleshooting.md).

--- a/docs/setup/existing_repo.md
+++ b/docs/setup/existing_repo.md
@@ -1,0 +1,38 @@
+# Existing repo setup (repo already has Thoughts config)
+
+Use this path if the repository already contains `.thoughts/config.json` and you're setting up a new machine or a new checkout.
+
+## Steps
+
+1. Ensure you are inside a git repository.
+   - If you run `thoughts init` outside a git repo, you'll see:
+     `Not in a git repository. Run 'git init' first.`
+
+2. Initialize Thoughts in the repo:
+
+```bash
+thoughts init
+```
+
+3. Reconcile or remount configured mounts:
+
+```bash
+thoughts mount update
+```
+
+4. Sync git-backed mounts if needed. This is not the remount command:
+
+```bash
+thoughts sync --all
+```
+
+5. If references are configured, ensure they are cloned, then remount:
+
+```bash
+thoughts references sync
+thoughts mount update
+```
+
+6. For configuration details, see [`../config.md`](../config.md).
+
+If something fails, see [`../troubleshooting.md`](../troubleshooting.md).

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -1,0 +1,184 @@
+# Fresh install (new machine)
+
+## Supported platforms
+
+- Linux and macOS are supported.
+- Windows is not supported.
+
+## System prerequisites
+
+### Linux
+
+- Git
+- FUSE support
+- `mergerfs`
+
+### macOS (FUSE-T first)
+
+Install **FUSE-T** (preferred), plus `unionfs-fuse`:
+
+- FUSE-T (preferred)
+- `unionfs-fuse`
+
+**Alternative:** macFUSE (if you can't use FUSE-T), plus `unionfs-fuse`.
+
+> If both FUSE-T and macFUSE are installed, the code prefers FUSE-T.
+
+## Install the binaries
+
+Choose one approach:
+
+### A) Install from source (workspace)
+
+```bash
+cargo install --path apps/thoughts
+cargo install --path apps/agentic-mcp
+cargo install --path apps/opencode-orchestrator-mcp
+cargo install --path apps/agentic
+```
+
+### B) Install via cargo-binstall (where supported)
+
+- `thoughts-bin`
+- `agentic-mcp`
+- `opencode-orchestrator-mcp`
+
+> Note: `agentic-bin` currently does not ship binstall metadata, so `cargo binstall` may not work for it.
+
+### C) GitHub Releases
+
+This repo publishes release artifacts; download the appropriate binary for your platform.
+
+## OpenCode version pin (orchestrator)
+
+`opencode-orchestrator-mcp` expects OpenCode **v1.3.17**. A mismatched OpenCode version will fail startup.
+
+If you need launcher mode, the orchestrator supports:
+
+- `OPENCODE_BINARY`
+- `OPENCODE_BINARY_ARGS`
+
+## Next steps
+
+- If you are setting up an existing repository, continue with [`existing_repo.md`](./existing_repo.md).
+- If you are adding Thoughts to a repository for the first time, continue with [`new_repo.md`](./new_repo.md).
+- For config details, see [`../config.md`](../config.md).
+- For auth details, see [`../auth.md`](../auth.md).
+
+## MCP wiring examples (copy/paste)
+
+### OpenCode (`opencode.json`) — exact block from this repo
+
+```json
+  "mcp": {
+    "tools": {
+      "type": "local",
+      "command": [
+        "agentic-mcp"
+      ],
+      "enabled": true
+    },
+    "orchestrator": {
+      "type": "local",
+      "command": [
+        "opencode-orchestrator-mcp"
+      ],
+      "enabled": true
+    },
+    "playwright": {
+      "type": "local",
+      "command": [
+        "npx",
+        "@playwright/mcp@latest"
+      ],
+      "enabled": true
+    }
+  },
+```
+
+Key fields:
+
+- `mcp.tools`: runs `agentic-mcp`.
+- `mcp.orchestrator`: runs `opencode-orchestrator-mcp`.
+- `type: "local"` with `command: [...]`: OpenCode's local MCP server shape.
+- `enabled: true`: enables each configured server.
+
+> Note: This block includes the trailing comma because the source block sits inside a larger JSON file.
+
+### Minimal stdio MCP config (`.mcp.json`) — exact file example
+
+```json
+{
+  "mcpServers": {
+    "orchestrator": {
+      "type": "stdio",
+      "command": "opencode-orchestrator-mcp"
+    }
+  }
+}
+```
+
+Key fields:
+
+- `mcpServers`: map of named servers.
+- `type: "stdio"`: launches the MCP server as a subprocess over stdin/stdout.
+- `command`: binary to execute.
+
+### Claude Code permissions example (`.claude/settings.json`) — exact file example
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__orchestrator__run",
+      "mcp__orchestrator__list_sessions",
+      "mcp__orchestrator__list_commands",
+      "mcp__orchestrator__get_session_state",
+      "mcp__orchestrator__respond_permission",
+      "mcp__orchestrator__respond_question"
+    ],
+    "deny": [
+      "Bash",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Agent",
+      "Skill",
+      "EnterWorktree",
+      "ExitWorktree",
+      "CronDelete",
+      "CronList",
+      "CronCreate",
+      "ScheduleWakeup",
+      "Monitor",
+      "TaskStop",
+      "WebSearch",
+      "WebFetch",
+      "NotebookEdit",
+      "RemoteTrigger",
+      "PushNotification",
+      "ToolSearch",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskOutput",
+      "TaskUpdate",
+      "EnterPlanMode",
+      "ExitPlanMode",
+      "AskUserQuestion"
+    ]
+  }
+}
+```
+
+Key fields:
+
+- `permissions.allow`: explicitly allowed tool IDs.
+- `permissions.deny`: explicitly denied built-ins and tools.
+
+## Quick verification
+
+- `agentic-mcp --list-tools` prints to **stderr**, so do not rely on stdout capture.
+- In a git repo, `thoughts init` should succeed. Outside a git repo it errors with `Not in a git repository. Run 'git init' first.`
+- If mounts disappear after reboot, use [`reboot.md`](./reboot.md), not `thoughts sync`.

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -39,6 +39,8 @@ There are four binaries in the usual setup story here: `thoughts`, `agentic-mcp`
 
 ### `cargo install` works for all four
 
+These commands install from the current repo checkout; published crates and release artifacts can lag behind it.
+
 ```bash
 cargo install --path apps/thoughts
 cargo install --path apps/agentic-mcp
@@ -54,7 +56,7 @@ cargo binstall agentic-mcp
 cargo binstall opencode-orchestrator-mcp
 ```
 
-`agentic-bin` does not currently publish binstall metadata, so use `cargo install` or a release artifact for that one.
+`agentic-bin` binstall support is release-dependent: it will work once a released `agentic-bin` version includes binstall metadata. Until then, use `cargo install --path apps/agentic` or a GitHub Release artifact.
 
 ### GitHub Releases are also valid
 

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -177,7 +177,8 @@ If you use Claude Code this way, the interesting bit is `permissions.allow`: it 
 ## Quick verification
 
 - `agentic-mcp --list-tools` prints to **stderr**, so do not judge success by stdout alone.
-- In a git repo, `thoughts init` should work. Outside one, it fails with `Not in a git repository. Run 'git init' first.`
+- In a git repo, `thoughts init` should work. Outside one, it fails with `Not in a git repository. Run 'git init' first.` It only needs a git repo for that step, not an existing remote.
+- If you later register an already-cloned repo by local path (for example `thoughts mount add /path/to/repo ...`), that local repo needs an `origin` remote so Thoughts can record the canonical repo mapping.
 - If mounts vanish after a reboot, use [`./reboot.md`](./reboot.md). `thoughts sync` is not the remount command.
 
 ## Next steps

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -1,34 +1,43 @@
 # Fresh install (new machine)
 
-## Supported platforms
+This is the from-zero path: machine first, repo second. Linux and macOS are supported here; Windows is not.
 
-- Linux and macOS are supported.
-- Windows is not supported.
+## Install the OS-level tools first
 
-## System prerequisites
+Do these in this order. It saves a little backtracking later.
 
-### Linux
+1. Install **bun** with your preferred method. I treat this as base machine setup because OpenCode depends on it.
+2. Install **rustup** if you want `cargo install` / `cargo binstall`, then set the default toolchain:
 
-- Git
-- FUSE support
-- `mergerfs`
+   ```bash
+   rustup default stable
+   ```
 
-### macOS (FUSE-T first)
+3. Optionally install **cargo-binstall**. It is not required, just nicer for the binaries that publish binstall metadata.
+4. Install the platform-specific mount tooling:
 
-Install **FUSE-T** (preferred), plus `unionfs-fuse`:
+   - **Linux:** install `mergerfs`, make sure FUSE support is enabled, and keep Git available. Allison's own notes call out mergerfs `2.41.1`; if Ubuntu makes this annoying, check [issue #2](https://github.com/allisoneer/agentic_auxilary/issues/2).
+   - **macOS:** install **FUSE-T** first if you can:
 
-- FUSE-T (preferred)
-- `unionfs-fuse`
+     ```bash
+     brew install macos-fuse-t/homebrew-cask/fuse-t
+     ```
 
-**Alternative:** macFUSE (if you can't use FUSE-T), plus `unionfs-fuse`.
+     `unionfs-fuse` is also required on macOS. If you already use **macFUSE**, that works too; when both are present, the runtime prefers FUSE-T.
 
-> If both FUSE-T and macFUSE are installed, the code prefers FUSE-T.
+5. Install **OpenCode** at the version this repo currently expects:
 
-## Install the binaries
+   ```bash
+   bun install -g opencode-ai@1.3.17
+   ```
 
-Choose one approach:
+6. Install **Claude Code** with whatever install method you already trust. The official docs are here: <https://code.claude.com/docs/en/authentication.md>.
 
-### A) Install from source (workspace)
+## Install the Rust binaries
+
+There are four binaries in the usual setup story here: `thoughts`, `agentic-mcp`, `opencode-orchestrator-mcp`, and `agentic`.
+
+### `cargo install` works for all four
 
 ```bash
 cargo install --path apps/thoughts
@@ -37,75 +46,68 @@ cargo install --path apps/opencode-orchestrator-mcp
 cargo install --path apps/agentic
 ```
 
-### B) Install via cargo-binstall (where supported)
+### `cargo binstall` works where metadata exists
 
-- `thoughts-bin`
-- `agentic-mcp`
-- `opencode-orchestrator-mcp`
+```bash
+cargo binstall thoughts-bin
+cargo binstall agentic-mcp
+cargo binstall opencode-orchestrator-mcp
+```
 
-> Note: `agentic-bin` currently does not ship binstall metadata, so `cargo binstall` may not work for it.
+`agentic-bin` does not currently publish binstall metadata, so use `cargo install` or a release artifact for that one.
 
-### C) GitHub Releases
+### GitHub Releases are also valid
 
-This repo publishes release artifacts; download the appropriate binary for your platform.
+If you prefer prebuilt binaries, this repo publishes release artifacts. Grab the right one for your platform and put it somewhere on `PATH`.
+
+## Log into Claude Code and OpenCode
+
+Do this before you start blaming MCP wiring.
+
+- **Claude Code:** launch `claude` and complete auth with your preferred method. The documented first-run path opens a browser login and can fall back to a pasted code flow. On macOS, credentials live in Keychain; on Linux they live in `~/.claude/.credentials.json`.
+- **OpenCode:** launch `opencode` and make sure the providers you plan to use are authenticated there. OpenCode keeps config under `~/.config/opencode/`; provider auth state lives in its `auth.json` data file.
 
 ## OpenCode version pin (orchestrator)
 
-`opencode-orchestrator-mcp` expects OpenCode **v1.3.17**. A mismatched OpenCode version will fail startup.
+`opencode-orchestrator-mcp` validates against OpenCode **v1.3.17**. If you point it at another version, startup can fail.
 
-If you need launcher mode, the orchestrator supports:
+You usually do not need extra env vars here. `OPENCODE_BINARY` and `OPENCODE_BINARY_ARGS` are only for cases where the default pinned binary path or the plain `opencode` on `PATH` is not the one you want.
 
-- `OPENCODE_BINARY`
-- `OPENCODE_BINARY_ARGS`
+## MCP wiring examples
 
-## Next steps
+This is the part people usually want to copy-paste, so it belongs before the cheerful "you're done" section.
 
-- If you are setting up an existing repository, continue with [`existing_repo.md`](./existing_repo.md).
-- If you are adding Thoughts to a repository for the first time, continue with [`new_repo.md`](./new_repo.md).
-- For config details, see [`../config.md`](../config.md).
-- For auth details, see [`../auth.md`](../auth.md).
+### OpenCode (`opencode.json`)
 
-## MCP wiring examples (copy/paste)
-
-### OpenCode (`opencode.json`) — exact block from this repo
+This is the same `mcp` block shape used in this repo, just lifted as a standalone snippet so it pastes cleanly:
 
 ```json
+{
   "mcp": {
     "tools": {
       "type": "local",
-      "command": [
-        "agentic-mcp"
-      ],
+      "command": ["agentic-mcp"],
       "enabled": true
     },
     "orchestrator": {
       "type": "local",
-      "command": [
-        "opencode-orchestrator-mcp"
-      ],
+      "command": ["opencode-orchestrator-mcp"],
       "enabled": true
     },
     "playwright": {
       "type": "local",
-      "command": [
-        "npx",
-        "@playwright/mcp@latest"
-      ],
+      "command": ["npx", "@playwright/mcp@latest"],
       "enabled": true
     }
-  },
+  }
+}
 ```
 
-Key fields:
+`mcp.tools` runs `agentic-mcp`, `mcp.orchestrator` runs `opencode-orchestrator-mcp`, and `type: "local"` tells OpenCode to launch each one as a local subprocess.
 
-- `mcp.tools`: runs `agentic-mcp`.
-- `mcp.orchestrator`: runs `opencode-orchestrator-mcp`.
-- `type: "local"` with `command: [...]`: OpenCode's local MCP server shape.
-- `enabled: true`: enables each configured server.
+### Minimal stdio MCP config (`.mcp.json`)
 
-> Note: This block includes the trailing comma because the source block sits inside a larger JSON file.
-
-### Minimal stdio MCP config (`.mcp.json`) — exact file example
+If you want the smallest possible stdio example, this repo also includes one:
 
 ```json
 {
@@ -118,13 +120,11 @@ Key fields:
 }
 ```
 
-Key fields:
+That is just a named server map plus the binary to execute. Good enough for sanity-checking a client before you layer on more config.
 
-- `mcpServers`: map of named servers.
-- `type: "stdio"`: launches the MCP server as a subprocess over stdin/stdout.
-- `command`: binary to execute.
+### Claude Code permissions example (`.claude/settings.json`)
 
-### Claude Code permissions example (`.claude/settings.json`) — exact file example
+This repo's Claude settings are intentionally narrow. The point is to allow only the orchestrator tools and deny a pile of built-ins.
 
 ```json
 {
@@ -172,13 +172,14 @@ Key fields:
 }
 ```
 
-Key fields:
-
-- `permissions.allow`: explicitly allowed tool IDs.
-- `permissions.deny`: explicitly denied built-ins and tools.
+If you use Claude Code this way, the interesting bit is `permissions.allow`: it whitelists the orchestrator namespace explicitly instead of letting the session wander into everything else.
 
 ## Quick verification
 
-- `agentic-mcp --list-tools` prints to **stderr**, so do not rely on stdout capture.
-- In a git repo, `thoughts init` should succeed. Outside a git repo it errors with `Not in a git repository. Run 'git init' first.`
-- If mounts disappear after reboot, use [`reboot.md`](./reboot.md), not `thoughts sync`.
+- `agentic-mcp --list-tools` prints to **stderr**, so do not judge success by stdout alone.
+- In a git repo, `thoughts init` should work. Outside one, it fails with `Not in a git repository. Run 'git init' first.`
+- If mounts vanish after a reboot, use [`./reboot.md`](./reboot.md). `thoughts sync` is not the remount command.
+
+## Next steps
+
+If the repo already has `.thoughts/config.json`, continue with [`./existing_repo.md`](./existing_repo.md). If you're adding Thoughts to a repo for the first time, continue with [`./new_repo.md`](./new_repo.md). When you need the file-level details, jump to [`../config.md`](../config.md) and [`../auth.md`](../auth.md).

--- a/docs/setup/new_repo.md
+++ b/docs/setup/new_repo.md
@@ -10,7 +10,7 @@ This is the path for a repo that does **not** have `.thoughts/config.json` yet.
    git init
    ```
 
-   `thoughts init` requires a git repo. If you skip this, it fails immediately and tells you to run `git init` first.
+   `thoughts init` requires a git repo. If you skip this, it fails immediately and tells you to run `git init` first. That step does not require a remote yet.
 
 2. Initialize Thoughts.
 
@@ -26,15 +26,15 @@ This is the path for a repo that does **not** have `.thoughts/config.json` yet.
    thoughts config edit
    ```
 
-   This is where you set `thoughts_mount`, `context_mounts`, and `references`. If you want the file shapes and precedence rules first, read [`../config.md`](../config.md).
+   This opens `.thoughts/config.json` in `VISUAL`, then `EDITOR`, then `vi`. When you exit, `thoughts` validates the file, rewrites it in normalized JSON, and updates mounts. If you prefer, you can edit `.thoughts/config.json` manually and then run `thoughts config validate` or `thoughts mount update` yourself. If you want the file shapes and precedence rules first, read [`../config.md`](../config.md).
 
 4. Add context mounts.
 
    ```bash
-   thoughts mount add <url-or-path> <mount_path>
+   thoughts mount add https://github.com/team/docs.git <mount_path>
    ```
 
-   This is the easiest way to add a team/shared repo to the `context/` tree while also recording its repo mapping.
+   This is the easiest way to add a team/shared repo to the `context/` tree while also recording its repo mapping. If you use a local path instead (for example `thoughts mount add /path/to/repo <mount_path>`), that local repo must already have an `origin` remote. Missing mappings can be created automatically later for URL-backed mounts, but local-path registration is keyed from the repo's canonical remote identity.
 
 5. Add reference repos and make sure they exist locally.
 
@@ -43,7 +43,7 @@ This is the path for a repo that does **not** have `.thoughts/config.json` yet.
    thoughts references sync
    ```
 
-   `references add` records what you want, and `references sync` clones or updates the configured references so there is something to mount.
+   `references add` records what you want, and `references sync` clones or updates the configured references so there is something to mount. If you use `thoughts references add /path/to/repo` instead of a URL, that local repo also needs an `origin` remote.
 
 6. Bring the mounts up.
 

--- a/docs/setup/new_repo.md
+++ b/docs/setup/new_repo.md
@@ -1,0 +1,42 @@
+# New repo setup (first time adding Thoughts)
+
+## Steps
+
+1. Ensure the repo is a git repository:
+
+```bash
+git init
+```
+
+2. Initialize Thoughts:
+
+```bash
+thoughts init
+```
+
+3. Edit config (v2 only) as needed:
+
+```bash
+thoughts config edit
+```
+
+4. Add context mounts:
+
+```bash
+thoughts mount add <url-or-path> <mount_path>
+```
+
+5. Add references and clone them:
+
+```bash
+thoughts references add <repo-url>
+thoughts references sync
+```
+
+6. Mount everything:
+
+```bash
+thoughts mount update
+```
+
+For configuration details, see [`../config.md`](../config.md).

--- a/docs/setup/new_repo.md
+++ b/docs/setup/new_repo.md
@@ -1,42 +1,54 @@
 # New repo setup (first time adding Thoughts)
 
-## Steps
+This is the path for a repo that does **not** have `.thoughts/config.json` yet.
 
-1. Ensure the repo is a git repository:
+## Setup steps
 
-```bash
-git init
-```
+1. Make the repo a git repository first.
 
-2. Initialize Thoughts:
+   ```bash
+   git init
+   ```
 
-```bash
-thoughts init
-```
+   `thoughts init` requires a git repo. If you skip this, it fails immediately and tells you to run `git init` first.
 
-3. Edit config (v2 only) as needed:
+2. Initialize Thoughts.
 
-```bash
-thoughts config edit
-```
+   ```bash
+   thoughts init
+   ```
 
-4. Add context mounts:
+   This creates the local Thoughts control files and the `thoughts/`, `context/`, and `references/` symlinks for the repo.
 
-```bash
-thoughts mount add <url-or-path> <mount_path>
-```
+3. Edit the v2 config for the mounts you actually want.
 
-5. Add references and clone them:
+   ```bash
+   thoughts config edit
+   ```
 
-```bash
-thoughts references add <repo-url>
-thoughts references sync
-```
+   This is where you set `thoughts_mount`, `context_mounts`, and `references`. If you want the file shapes and precedence rules first, read [`../config.md`](../config.md).
 
-6. Mount everything:
+4. Add context mounts.
 
-```bash
-thoughts mount update
-```
+   ```bash
+   thoughts mount add <url-or-path> <mount_path>
+   ```
 
-For configuration details, see [`../config.md`](../config.md).
+   This is the easiest way to add a team/shared repo to the `context/` tree while also recording its repo mapping.
+
+5. Add reference repos and make sure they exist locally.
+
+   ```bash
+   thoughts references add <repo-url>
+   thoughts references sync
+   ```
+
+   `references add` records what you want, and `references sync` clones or updates the configured references so there is something to mount.
+
+6. Bring the mounts up.
+
+   ```bash
+   thoughts mount update
+   ```
+
+   This reconciles desired state against the live FUSE mounts and is the command that actually makes the spaces appear in the repo.

--- a/docs/setup/reboot.md
+++ b/docs/setup/reboot.md
@@ -1,6 +1,8 @@
 # After reboot: remounting and recovery
 
-## The important distinction
+The short version is that FUSE mounts are process-level state. They do not survive a reboot just because the config file still exists. `thoughts mount update` re-establishes the live mounts from the desired state on disk.
+
+## `mount update` vs `sync`
 
 - `thoughts mount update`
   - reconciles desired state versus active mounts
@@ -11,18 +13,18 @@
   - performs git sync for auto-sync mounts
   - does not recreate FUSE mounts
 
-## Steps after reboot
+## After-reboot flow
 
-1. Recreate mounts:
+1. Recreate the mounts.
 
-```bash
-thoughts mount update
-```
+   ```bash
+   thoughts mount update
+   ```
 
-2. Optional: sync git-backed mounts:
+2. If you also want the git-backed thoughts/context repos refreshed, do that separately.
 
-```bash
-thoughts sync --all
-```
+   ```bash
+   thoughts sync --all
+   ```
 
-If mounts fail to come up, see [`../troubleshooting.md`](../troubleshooting.md).
+If `mount update` still leaves things empty, head to [`../troubleshooting.md`](../troubleshooting.md). That is usually a mount/backend issue, not a sync issue.

--- a/docs/setup/reboot.md
+++ b/docs/setup/reboot.md
@@ -1,0 +1,28 @@
+# After reboot: remounting and recovery
+
+## The important distinction
+
+- `thoughts mount update`
+  - reconciles desired state versus active mounts
+  - mounts what is missing and unmounts what was removed
+  - this is the after-reboot command
+
+- `thoughts sync`
+  - performs git sync for auto-sync mounts
+  - does not recreate FUSE mounts
+
+## Steps after reboot
+
+1. Recreate mounts:
+
+```bash
+thoughts mount update
+```
+
+2. Optional: sync git-backed mounts:
+
+```bash
+thoughts sync --all
+```
+
+If mounts fail to come up, see [`../troubleshooting.md`](../troubleshooting.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,69 @@
+# Troubleshooting
+
+## Thoughts: mounts missing (often after reboot)
+
+**Symptom:** `thoughts/`, `context/`, or `references/` look empty or missing.
+
+**Fix:**
+
+```bash
+thoughts mount update
+```
+
+`thoughts sync` does git sync. It does not recreate mounts.
+
+## Thoughts: `Not in a git repository`
+
+**Symptom:** `thoughts init` fails with `Not in a git repository. Run 'git init' first.`
+
+**Fix:**
+
+```bash
+git init
+thoughts init
+```
+
+## References: repos not mounted
+
+**Fix:**
+
+```bash
+thoughts references sync
+thoughts mount update
+```
+
+## References mapping cleanup
+
+If reference mappings are stale or duplicated:
+
+```bash
+thoughts references doctor
+thoughts references doctor --fix
+```
+
+`doctor --fix` cleans stale auto-managed mappings, but it does not delete clone directories.
+
+## agentic-mcp: `--list-tools` shows nothing
+
+**Gotcha:** `agentic-mcp --list-tools` prints to **stderr**, not stdout.
+
+Try:
+
+```bash
+agentic-mcp --list-tools 2>&1 | sed -n '1,120p'
+```
+
+## Orchestrator: OpenCode version mismatch
+
+`opencode-orchestrator-mcp` expects OpenCode v1.3.17.
+
+If you are not using the default pinned binary path, set:
+
+- `OPENCODE_BINARY`
+- `OPENCODE_BINARY_ARGS`
+
+## More docs
+
+- Setup entrypoint: [`./setup/README.md`](./setup/README.md)
+- Configuration: [`./config.md`](./config.md)
+- Authentication: [`./auth.md`](./auth.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,7 +56,9 @@ If you want to keep a repo in your own directory, register that local path befor
 thoughts mount add /path/to/repo <mount_path>
 ```
 
-The mapping then lands in `~/.config/agentic/repos.json` with `auto_managed=false`.
+That local repo needs an `origin` remote so Thoughts can key the mapping by canonical repo identity. When the command succeeds, the mapping lands in `~/.config/agentic/repos.json` with `auto_managed=false`.
+
+If the same canonical repo was already mapped somewhere else, `thoughts mount add` replaces that old `repos.json` mapping with the new path. What it does **not** replace is a duplicate `mount_path` in `.thoughts/config.json`; if that alias already exists, the command errors and you need to choose a different mount name or edit the config first.
 
 ## `thoughts init` says you're not in a git repo
 
@@ -67,7 +69,7 @@ git init
 thoughts init
 ```
 
-`thoughts init` requires a git repository. No repo, no setup.
+`thoughts init` requires a git repository. No repo, no setup. It does **not** require a remote just to initialize the repo, but later local-path helper flows such as `thoughts mount add /path/to/repo ...` and `thoughts references add /path/to/repo` do expect that local repo to have an `origin` remote.
 
 ## `agentic-mcp --list-tools` looks empty
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,69 +1,110 @@
 # Troubleshooting
 
-## Thoughts: mounts missing (often after reboot)
+This is the practical version. The goal here is not "list every flag," it is "get you back to a working state without guessing."
 
-**Symptom:** `thoughts/`, `context/`, or `references/` look empty or missing.
+## Mounts are missing (usually after reboot)
 
-**Fix:**
+If `thoughts/`, `context/`, or `references/` are empty or gone after a restart, run:
 
 ```bash
 thoughts mount update
 ```
 
-`thoughts sync` does git sync. It does not recreate mounts.
+`thoughts sync` only does git sync for auto-sync mounts. It does **not** recreate the FUSE mounts.
 
-## Thoughts: `Not in a git repository`
+## Inspecting mount state with `thoughts mount debug`
 
-**Symptom:** `thoughts init` fails with `Not in a git repository. Run 'git init' first.`
+When `mount update` is not enough, use the debug subcommands instead of poking blind.
 
-**Fix:**
+```bash
+thoughts mount debug info <target>
+thoughts mount debug command <mount_name>
+thoughts mount debug remount <mount_name>
+```
+
+- `debug info` shows what the tool thinks is mounted, along with backend/mount metadata.
+- `debug command` prints the exact mount command it would run for that mount.
+- `debug remount` does the blunt thing: unmount, then mount again for one target.
+
+If you just want to see the full surface first, `thoughts mount debug --help` is worth a quick glance.
+
+## Reference clone failures vs mapping issues
+
+These are two different classes of failure, and the commands are different too.
+
+- `thoughts references sync` is where clone/update failures show up. If the repo cannot be cloned because of network, auth, or remote access problems, the command reports that inline as `Failed to clone` or `Failed to update`.
+- `thoughts references doctor` is for local state problems after the fact: stale mappings, missing paths, non-directories, non-git directories, or origin mismatches.
+
+Typical sequence:
+
+```bash
+thoughts references sync
+thoughts references doctor
+thoughts references doctor --fix
+thoughts mount update
+```
+
+`doctor --fix` only applies safe local fixes. It can prune stale auto-managed mappings, but it does not fix a bad network connection and it does not delete clone directories for you.
+
+## You wanted your own clone, but Thoughts made one anyway
+
+That usually means the repo URL had no local mapping yet, so `references sync` or `mount update` fell back to the managed clone path under `~/.thoughts/clones/...`.
+
+If you want to keep a repo in your own directory, register that local path before the auto-clone commands run. For local context repos, the documented CLI path is:
+
+```bash
+thoughts mount add /path/to/repo <mount_path>
+```
+
+The mapping then lands in `~/.config/agentic/repos.json` with `auto_managed=false`.
+
+## `thoughts init` says you're not in a git repo
+
+The error is literal:
 
 ```bash
 git init
 thoughts init
 ```
 
-## References: repos not mounted
+`thoughts init` requires a git repository. No repo, no setup.
 
-**Fix:**
+## `agentic-mcp --list-tools` looks empty
 
-```bash
-thoughts references sync
-thoughts mount update
-```
-
-## References mapping cleanup
-
-If reference mappings are stale or duplicated:
+The gotcha here is simple: `agentic-mcp --list-tools` writes to **stderr**, not stdout.
 
 ```bash
-thoughts references doctor
-thoughts references doctor --fix
+agentic-mcp --list-tools 2>&1
 ```
 
-`doctor --fix` cleans stale auto-managed mappings, but it does not delete clone directories.
+If config loading produced warnings, those are also printed to stderr before startup.
 
-## agentic-mcp: `--list-tools` shows nothing
+## Log locations and levels
 
-**Gotcha:** `agentic-mcp --list-tools` prints to **stderr**, not stdout.
+There are a few layers here.
 
-Try:
+- `RUST_LOG` works directly for `agentic-mcp` because it uses `tracing_subscriber`'s normal env-driven setup.
+- `AGENTIC_LOG_LEVEL` and `AGENTIC_LOG_JSON` are config env overrides for the `agentic.toml` logging section.
+- `OPENCODE_ORCHESTRATOR_LOG_DIR` tells `opencode-orchestrator-mcp` exactly where to write its JSONL/markdown tool-call logs.
+
+Examples:
 
 ```bash
-agentic-mcp --list-tools 2>&1 | sed -n '1,120p'
+RUST_LOG=debug agentic-mcp --list-tools 2>&1
+AGENTIC_LOG_LEVEL=debug AGENTIC_LOG_JSON=1 agentic-mcp --list-tools 2>&1
+OPENCODE_ORCHESTRATOR_LOG_DIR=/tmp/opencode-orchestrator-logs opencode-orchestrator-mcp
 ```
 
-## Orchestrator: OpenCode version mismatch
+If `OPENCODE_ORCHESTRATOR_LOG_DIR` is unset, the orchestrator falls back to the active Thoughts logs directory when one is available.
 
-`opencode-orchestrator-mcp` expects OpenCode v1.3.17.
+## Orchestrator says OpenCode version is wrong
 
-If you are not using the default pinned binary path, set:
+`opencode-orchestrator-mcp` expects OpenCode `v1.3.17`.
 
-- `OPENCODE_BINARY`
-- `OPENCODE_BINARY_ARGS`
+If the binary on `PATH` is not the one you want, set `OPENCODE_BINARY`. If you are using launcher mode (for example `bunx --yes opencode-ai@1.3.17`), also set `OPENCODE_BINARY_ARGS`.
 
-## More docs
+## One small gotcha worth knowing
 
-- Setup entrypoint: [`./setup/README.md`](./setup/README.md)
-- Configuration: [`./config.md`](./config.md)
-- Authentication: [`./auth.md`](./auth.md)
+`thoughts status --detailed` currently does not add extra detail beyond `thoughts status`, so do not burn time expecting hidden output there.
+
+If you need the setup flow again, go back to [`./setup/README.md`](./setup/README.md). If the problem is clearly credentials rather than mounts or mappings, jump to [`./auth.md`](./auth.md).

--- a/docs/why_this_stack.md
+++ b/docs/why_this_stack.md
@@ -1,0 +1,23 @@
+# Why this stack (short version)
+
+## MCP is the transport, not the product
+
+This repo uses MCP to connect tools to clients, but the differentiator is the harness design: orchestrator sessions, constrained agent roles, and scoped tool surfaces.
+
+For the detailed architecture, see [`../workflow.md`](../workflow.md).
+
+## Designed constraints, not tool bloat
+
+Key themes:
+
+- Scoped tool allowlists and role-specific agents
+- Structured `just` workflows instead of default shell access
+- Review tooling isolation and explicit session orchestration
+
+See the diagrams and tool matrices in [`../workflow.md`](../workflow.md).
+
+## A practical loop: research -> plan -> implement
+
+The repo's workflow is encoded as explicit stages rather than ad hoc prompting.
+
+Start with [`../workflow.md`](../workflow.md) for the full map.

--- a/docs/why_this_stack.md
+++ b/docs/why_this_stack.md
@@ -12,7 +12,7 @@ It is not the interesting part by itself.
 
 Yes, the tools speak MCP. That part is deliberately portable.
 
-The interesting part is everything built behind that interface: an orchestrator layer that manages long-lived OpenCode sessions, primary work agents with different permission and tool profiles, and an explicit locator/analyzer × codebase/thoughts/references/web sub-agent matrix instead of a vague "go spawn a helper if you feel like it" story.
+The interesting part is everything built behind that interface: an orchestrator layer that manages long-lived OpenCode sessions, primary work agents with different permission and tool profiles, reasoning-model calls for deep passes, and an explicit locator/analyzer × codebase/thoughts/references/web sub-agent matrix instead of a vague "go spawn a helper if you feel like it" story.
 
 That design shows up in a few concrete ways.
 
@@ -20,13 +20,17 @@ There is a dedicated orchestrator MCP server because session work is not just a 
 
 There is a unified `agentic-mcp` entry point because the repo is trying to expose a shaped tool surface, not a pile of unrelated binaries.
 
-And there is `--allow` scoping because being able to narrow the server to exactly the tools a role should see is part of the safety model, not an afterthought.
+And there is `--allow` scoping because the single `agentic-mcp` binary is meant to be portable and highly configurable: the same entry point can expose a deliberately narrow tool surface for a given client or role.
+
+The safety/control story is adjacent but separate: tools are grouped into explicit namespaces, and sub-agents run with strict MCP config plus preselected tool sets instead of inheriting a giant ambient surface.
 
 This is also why the repo has an actual agent hierarchy instead of one mega-agent with everything attached.
 
 There is orchestration-level control.
 
 There are primary work agents.
+
+There are reasoning-model calls that sit alongside the sub-agent system.
 
 There are sub-agents that are split by role and location on purpose.
 
@@ -62,6 +66,8 @@ Thin wrappers are easy to make.
 
 The hard and useful part is deciding what an agent should be allowed to do, how it should discover information, when it should ask for help, and what work should be mechanically separated instead of prompt-separated.
 
+That also shows up in tool shape: the repo prefers fewer tools, fewer required parameters, and low-ceremony interfaces so context goes to the task instead of the call surface. `cli_ls` doubles as both an `ls` and a tree via `depth`, some tools paginate implicitly when repeating the same request is the cleanest shape, and others use explicit `head_limit`/`offset` when a stateless scan is the better fit.
+
 ## The workflow is explicit: research, then plan, then implement
 
 The command surface in this repo encodes an actual working loop.
@@ -76,13 +82,13 @@ That same design philosophy shows up in the model split too.
 
 There are distinct agent variants for Claude and GPT-5.4-oriented workflows.
 
-The reasoner tool itself is two-phase: first optimize what context matters, then run the expensive reasoning pass.
+The reasoner tool itself is two-phase: first do GPT-specific prompt optimization over the available context, then run the expensive reasoning pass.
 
 Even the existence of a separate Bash agent follows the same pattern — shell access is available when it is truly the right tool, but it is not the default shape of every session.
 
 The repo is trying to make good workflows easier to repeat.
 
-It is not trying to make ad hoc prompting feel magical.
+Ad hoc prompting can still feel pretty magical here; the point is that explicit workflows are what make long-tail work repeatable instead of relying on a great one-off prompt.
 
 So the short version is: this repo uses MCP everywhere, but it is not "just MCP." It is a constrained Rust agent stack built around session control, scoped tools, specialized sub-agents, structured execution, and an explicit research → plan → implement loop.
 

--- a/docs/why_this_stack.md
+++ b/docs/why_this_stack.md
@@ -1,23 +1,89 @@
-# Why this stack (short version)
+# Why this stack
 
-## MCP is the transport, not the product
+If all you need is a thin MCP wrapper around an API, this repo is overbuilt for that purpose. That is not me being coy; it really is aimed at a different problem.
 
-This repo uses MCP to connect tools to clients, but the differentiator is the harness design: orchestrator sessions, constrained agent roles, and scoped tool surfaces.
+The point here is not "have some tools available over MCP." The point is to build a harness where orchestration, tool scoping, review boundaries, and repeatable workflows are part of the product instead of prompt folklore.
 
-For the detailed architecture, see [`../workflow.md`](../workflow.md).
+MCP matters because it keeps the pieces portable.
 
-## Designed constraints, not tool bloat
+It is not the interesting part by itself.
 
-Key themes:
+## MCP is the transport, the harness is the product
 
-- Scoped tool allowlists and role-specific agents
-- Structured `just` workflows instead of default shell access
-- Review tooling isolation and explicit session orchestration
+Yes, the tools speak MCP. That part is deliberately portable.
 
-See the diagrams and tool matrices in [`../workflow.md`](../workflow.md).
+The interesting part is everything built behind that interface: an orchestrator layer that manages long-lived OpenCode sessions, primary work agents with different permission and tool profiles, and an explicit locator/analyzer × codebase/thoughts/references/web sub-agent matrix instead of a vague "go spawn a helper if you feel like it" story.
 
-## A practical loop: research -> plan -> implement
+That design shows up in a few concrete ways.
 
-The repo's workflow is encoded as explicit stages rather than ad hoc prompting.
+There is a dedicated orchestrator MCP server because session work is not just a single prompt/response round-trip; sessions can pause on permissions, surface questions, and be resumed later.
 
-Start with [`../workflow.md`](../workflow.md) for the full map.
+There is a unified `agentic-mcp` entry point because the repo is trying to expose a shaped tool surface, not a pile of unrelated binaries.
+
+And there is `--allow` scoping because being able to narrow the server to exactly the tools a role should see is part of the safety model, not an afterthought.
+
+This is also why the repo has an actual agent hierarchy instead of one mega-agent with everything attached.
+
+There is orchestration-level control.
+
+There are primary work agents.
+
+There are sub-agents that are split by role and location on purpose.
+
+That is a harness decision, not a transport decision.
+
+## Tool design here is mostly about removing bad choices up front
+
+A lot of agent setups keep adding more tools and hope the model becomes wise enough to pick the good ones.
+
+I do not think that scales especially well.
+
+This repo goes the other direction: shape the tool surface so the bad steering paths are less available in the first place.
+
+That is why review tooling lives in its own isolated namespace instead of being mixed into the normal coding flow.
+
+It is why sub-agents are launched with strict MCP config and no permission-asking path, which forces the parent workflow to choose the right scoped helper ahead of time.
+
+It is why normal work leans on `just` recipes and dedicated CLI tools rather than default bash access everywhere.
+
+The repo absolutely can use shell access when it is the right tool.
+
+It just does not assume shell should be the default answer to every problem.
+
+That detail matters more than it sounds like it should.
+
+If an agent can solve most routine work through structured tools and `just` recipes, you get repeatability and narrower failure modes almost for free.
+
+The result is a stack that is a little more opinionated and a lot less likely to drift into random nonsense just because the model had too many doors open.
+
+This is also the reason the repo does not really line up with the "just generate MCP tools from APIs" mindset.
+
+Thin wrappers are easy to make.
+
+The hard and useful part is deciding what an agent should be allowed to do, how it should discover information, when it should ask for help, and what work should be mechanically separated instead of prompt-separated.
+
+## The workflow is explicit: research, then plan, then implement
+
+The command surface in this repo encodes an actual working loop.
+
+Research commands produce grounded artifacts.
+
+Planning commands resolve open questions and turn them into requirements plus an implementation plan.
+
+Implementation commands then consume those artifacts and run through the work with verification gates instead of pretending the earlier context never mattered.
+
+That same design philosophy shows up in the model split too.
+
+There are distinct agent variants for Claude and GPT-5.4-oriented workflows.
+
+The reasoner tool itself is two-phase: first optimize what context matters, then run the expensive reasoning pass.
+
+Even the existence of a separate Bash agent follows the same pattern — shell access is available when it is truly the right tool, but it is not the default shape of every session.
+
+The repo is trying to make good workflows easier to repeat.
+
+It is not trying to make ad hoc prompting feel magical.
+
+So the short version is: this repo uses MCP everywhere, but it is not "just MCP." It is a constrained Rust agent stack built around session control, scoped tools, specialized sub-agents, structured execution, and an explicit research → plan → implement loop.
+
+If you want the full map, including the agent hierarchy and tool matrices, read [`../workflow.md`](../workflow.md).

--- a/opencode.json
+++ b/opencode.json
@@ -87,7 +87,6 @@
       }
     },
     "Bash": {
-      "prompt": "{file:./.opencode/sysprompt.md}",
       "mode": "primary",
       "permission": {
         "bash": {


### PR DESCRIPTION
## My Notes (preserved)

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

Users did not have one current, navigable place to learn how to set up Thoughts and the surrounding MCP/orchestrator workflow. The relevant information was scattered across the root README, the `thoughts-core` README, config behavior, and repo-local examples, which made common cases like fresh install, existing-repo bootstrap, auth wiring, and post-reboot remount recovery harder than they needed to be.

This PR turns that scattered setup knowledge into a user-facing docs flow and updates the repo entry points so people can find it. It also documents a few important pieces of current behavior more explicitly, including v2-only Thoughts config support, the canonical repo-mapping file location, and the orchestrator's OpenCode version requirement.

## What user-facing changes did I ship?

- Added a new `docs/` docs hub with focused pages for setup, configuration, authentication, troubleshooting, and architecture.
- Added scenario-based setup guides for:
  - fresh machine install
  - existing repo with `.thoughts/config.json`
  - new repo with no Thoughts config yet
  - reboot/remount recovery
- Added copy-pasteable MCP/client config examples for OpenCode, `.mcp.json`, and Claude Code permissions/env injection.
- Clarified practical behavior that tends to trip people up, including:
  - `thoughts mount update` vs `thoughts sync`
  - v2-only `.thoughts/config.json`
  - `~/.config/agentic/repos.json` as the canonical repo mapping file
  - auth env vars by tool/service
  - the OpenCode `v1.3.17` requirement for `opencode-orchestrator-mcp`
- Updated the root README to surface the new docs, and refreshed the `thoughts-core` README so it points readers at the user-facing setup/config/troubleshooting docs.

## How I implemented it

- Added `docs/index.md` plus a setup path chooser in `docs/setup/README.md`, then split setup instructions into separate guides under `docs/setup/` so the flow matches the user's actual starting point instead of one mixed document.
- Wrote dedicated `docs/config.md` and `docs/auth.md` pages that map current runtime behavior to concrete files, commands, and environment variables.
- Added `docs/troubleshooting.md` to focus on operational recovery and common gotchas, especially around remounting, clone-vs-mapping failures, stderr output, and orchestrator logging/version expectations.
- Added `docs/why_this_stack.md` so the README can explain the repo's opinionated architecture without overloading the landing page.
- Checked in `.claude/settings.json` and `.mcp.json` as concrete local config examples, updated `.gitignore` accordingly, and removed the Bash prompt override from `opencode.json` so the repo-local examples stay aligned.
- Refreshed `crates/infra/thoughts-core/README.md` for current platform/config behavior and removed outdated v1 migration guidance that no longer reflects the current runtime.
- Added follow-up notes to `TODO.md` for a few code/docs mismatches discovered while documenting the current setup.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- Manual/optional: skim the docs flow from `docs/index.md` and spot-check the rendered Markdown links/snippets in GitHub.

## Description for the changelog

Add a user-facing Thoughts/MCP documentation hub with setup, config, auth, troubleshooting, and architecture guides, and link it from the root README. Also refresh the `thoughts-core` README and repo-local config examples so the documented setup matches current behavior.
<!-- END:describe_pr:autogen -->

