### PR TITLE
fix: remove redundant doc comment on doc_type field to avoid JSON schema $ref conflict

### DIFF
--- a/crates/tools/thoughts-mcp-tools/src/tools.rs
+++ b/crates/tools/thoughts-mcp-tools/src/tools.rs
@@ -57,7 +57,6 @@ fn map_anyhow_to_tool_error(e: anyhow::Error) -> ToolError {
 /// Input for the write_document tool.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct WriteDocumentInput {
-    /// Document type categories for thoughts workspace.
     pub doc_type: DocumentType,
     /// Filename for the document.
     pub filename: String,


### PR DESCRIPTION
Moonshot's API validator rejects tool schemas where a \`description\` keyword appears alongside \`\$ref\` on the same property:

\`\`\`
Invalid request: tools.function.parameters is not a valid moonshot flavored json schema
At path 'properties.doc_type': conflicting keywords found after \$ref expansion: description
\`\`\`

The \`WriteDocumentInput.doc_type\` field had a doc comment identical to the one on the \`DocumentType\` enum itself. \`schemars\` emitted that comment as a \`description\` on the property, producing:

\`\`\`json
"doc_type": {
  "description": "Document type categories for thoughts workspace.",
  "\$ref": "#\$defs/DocumentType"
}
\`\`\`

Removing the doc comment from the field eliminates the conflict while preserving the description on the \`\$defs/DocumentType\` definition.

**Checklist**
- [x] Bug fix (non-breaking change which fixes a functionality issue)

**Testing**
- Verified via \`schemars\` output that the generated schema no longer includes \`description\` on the \`\$ref\` property.