### PR TITLE
Fix redundant search ignore checks

### DIFF
--- a/crates/tools/coding-agent-tools/src/glob.rs
+++ b/crates/tools/coding-agent-tools/src/glob.rs
@@ -2,7 +2,6 @@
 
 use crate::types::GlobOutput;
 use crate::types::SortOrder;
-use crate::walker::BUILTIN_IGNORES;
 use crate::walker::{self};
 use agentic_tools_core::ToolError;
 use globset::Glob;
@@ -103,20 +102,8 @@ pub fn run(cfg: GlobConfig) -> Result<GlobOutput, ToolError> {
                     |p| p.to_string_lossy().replace('\\', "/"),
                 );
 
-                // Double-check against ignore patterns
+                // Built-in ignores are already part of `ignore_gs`; keep this per-entry check cheap.
                 if ignore_gs.is_match(&rel_path) {
-                    continue;
-                }
-
-                // Check against builtin ignores
-                let matches_builtin = BUILTIN_IGNORES.iter().any(|pattern| {
-                    if let Ok(g) = Glob::new(pattern) {
-                        g.compile_matcher().is_match(&rel_path)
-                    } else {
-                        false
-                    }
-                });
-                if matches_builtin {
                     continue;
                 }
 

--- a/crates/tools/coding-agent-tools/src/glob.rs
+++ b/crates/tools/coding-agent-tools/src/glob.rs
@@ -74,7 +74,6 @@ pub fn run(cfg: GlobConfig) -> Result<GlobOutput, ToolError> {
 
     // Apply custom ignore filter
     let root_clone = root_path.to_path_buf();
-    let gs_clone = ignore_gs.clone();
     builder.filter_entry(move |entry| {
         let rel = entry
             .path()
@@ -84,7 +83,7 @@ pub fn run(cfg: GlobConfig) -> Result<GlobOutput, ToolError> {
         if rel.is_empty() {
             return true;
         }
-        !gs_clone.is_match(&rel)
+        !ignore_gs.is_match(&rel)
     });
 
     for result in builder.build() {
@@ -101,11 +100,6 @@ pub fn run(cfg: GlobConfig) -> Result<GlobOutput, ToolError> {
                     |_| path.to_string_lossy().to_string(),
                     |p| p.to_string_lossy().replace('\\', "/"),
                 );
-
-                // Built-in ignores are already part of `ignore_gs`; keep this per-entry check cheap.
-                if ignore_gs.is_match(&rel_path) {
-                    continue;
-                }
 
                 // Check if path matches the glob pattern
                 if !pattern_matcher.is_match(&rel_path) {

--- a/crates/tools/coding-agent-tools/src/grep.rs
+++ b/crates/tools/coding-agent-tools/src/grep.rs
@@ -2,7 +2,6 @@
 
 use crate::types::GrepOutput;
 use crate::types::OutputMode;
-use crate::walker::BUILTIN_IGNORES;
 use crate::walker::{self};
 use agentic_tools_core::ToolError;
 use globset::Glob;
@@ -309,20 +308,8 @@ pub fn run(cfg: GrepConfig) -> Result<GrepOutput, ToolError> {
                         |p| p.to_string_lossy().replace('\\', "/"),
                     );
 
-                    // Double-check against ignore patterns
+                    // Built-in ignores are already part of `ignore_gs`; keep this per-file check cheap.
                     if ignore_gs.is_match(&rel_path) {
-                        continue;
-                    }
-
-                    // Check against builtin ignores
-                    let matches_builtin = BUILTIN_IGNORES.iter().any(|pattern| {
-                        if let Ok(g) = Glob::new(pattern) {
-                            g.compile_matcher().is_match(&rel_path)
-                        } else {
-                            false
-                        }
-                    });
-                    if matches_builtin {
                         continue;
                     }
 

--- a/crates/tools/coding-agent-tools/src/grep.rs
+++ b/crates/tools/coding-agent-tools/src/grep.rs
@@ -280,7 +280,6 @@ pub fn run(cfg: GrepConfig) -> Result<GrepOutput, ToolError> {
 
         // Apply custom ignore filter
         let root_clone = root_path.to_path_buf();
-        let gs_clone = ignore_gs.clone();
         builder.filter_entry(move |entry| {
             let rel = entry
                 .path()
@@ -290,7 +289,7 @@ pub fn run(cfg: GrepConfig) -> Result<GrepOutput, ToolError> {
             if rel.is_empty() {
                 return true;
             }
-            !gs_clone.is_match(&rel)
+            !ignore_gs.is_match(&rel)
         });
 
         for result in builder.build() {
@@ -307,11 +306,6 @@ pub fn run(cfg: GrepConfig) -> Result<GrepOutput, ToolError> {
                         |_| path.to_string_lossy().to_string(),
                         |p| p.to_string_lossy().replace('\\', "/"),
                     );
-
-                    // Built-in ignores are already part of `ignore_gs`; keep this per-file check cheap.
-                    if ignore_gs.is_match(&rel_path) {
-                        continue;
-                    }
 
                     // Check include patterns
                     if let Some(ref inc_gs) = include_gs


### PR DESCRIPTION
## Summary
- Remove duplicate built-in ignore glob recompilation from `cli_glob` and `cli_grep` scans.
- Rely on the existing combined ignore `GlobSet`, which already includes the built-in ignore patterns.

## Testing
- `just crate-check coding_agent_tools`
- `just crate-test coding_agent_tools`