### PR TITLE
Fix claudecode process lifecycle cleanup

### DIFF
--- a/crates/services/claudecode-rs/src/process.rs
+++ b/crates/services/claudecode-rs/src/process.rs
@@ -4,13 +4,116 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 use tokio::io::BufReader;
 use tokio::process::Child;
 use tokio::process::Command;
 use which::which;
 
+const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProcessControl {
+    pid: Option<u32>,
+    #[cfg(unix)]
+    process_group_id: Option<i32>,
+    exited: Arc<AtomicBool>,
+}
+
+impl ProcessControl {
+    fn new(pid: Option<u32>) -> Self {
+        Self {
+            pid,
+            #[cfg(unix)]
+            process_group_id: pid.and_then(|pid| i32::try_from(pid).ok()),
+            exited: Arc::new(AtomicBool::new(pid.is_none())),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self::new(None)
+    }
+
+    pub(crate) fn id(&self) -> Option<u32> {
+        if self.is_exited() { None } else { self.pid }
+    }
+
+    pub(crate) fn is_exited(&self) -> bool {
+        self.exited.load(Ordering::Acquire)
+    }
+
+    fn mark_exited(&self) {
+        self.exited.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn interrupt(&self) -> Result<()> {
+        self.signal(libc::SIGINT, false)?;
+        Ok(())
+    }
+
+    pub(crate) fn start_kill(&self) -> Result<()> {
+        self.signal(libc::SIGKILL, false)?;
+        Ok(())
+    }
+
+    pub(crate) async fn terminate_with_grace(&self) -> Result<()> {
+        self.signal(libc::SIGTERM, true)?;
+        tokio::time::sleep(PROCESS_TERMINATION_GRACE).await;
+        self.signal(libc::SIGKILL, true)?;
+        Ok(())
+    }
+
+    fn signal(&self, signal: libc::c_int, include_exited: bool) -> std::io::Result<()> {
+        if !include_exited && self.is_exited() {
+            return Ok(());
+        }
+
+        #[cfg(unix)]
+        if let Some(process_group_id) = self.process_group_id {
+            return signal_process_group(process_group_id, signal);
+        }
+
+        if let Some(pid) = self.pid.and_then(|pid| i32::try_from(pid).ok()) {
+            signal_process(pid, signal)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_group_id: i32, signal: libc::c_int) -> std::io::Result<()> {
+    if process_group_id <= 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("refusing to signal unsafe process group {process_group_id}"),
+        ));
+    }
+
+    signal_process(-process_group_id, signal)
+}
+
+fn signal_process(pid: i32, signal: libc::c_int) -> std::io::Result<()> {
+    let result = unsafe { libc::kill(pid, signal) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
 pub struct ProcessHandle {
     child: Child,
+    control: ProcessControl,
     stdout_reader: Option<BufReader<tokio::process::ChildStdout>>,
     stderr_reader: Option<BufReader<tokio::process::ChildStderr>>,
 }
@@ -35,6 +138,9 @@ impl ProcessHandle {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+
+        #[cfg(unix)]
+        cmd.process_group(0);
 
         // Set working directory if specified
         if let Some(dir) = working_dir {
@@ -70,28 +176,43 @@ impl ProcessHandle {
                 message: "Failed to capture stderr".to_string(),
             })?;
 
+        let control = ProcessControl::new(child.id());
+
         Ok(ProcessHandle {
             child,
+            control,
             stdout_reader: Some(BufReader::new(stdout)),
             stderr_reader: Some(BufReader::new(stderr)),
         })
     }
 
     pub async fn wait(mut self) -> Result<std::process::ExitStatus> {
-        Ok(self.child.wait().await?)
+        let status = self.child.wait().await?;
+        self.control.mark_exited();
+        Ok(status)
     }
 
     pub async fn kill(&mut self) -> Result<()> {
-        self.child.kill().await?;
+        self.control.terminate_with_grace().await?;
+        self.child.wait().await?;
+        self.control.mark_exited();
         Ok(())
     }
 
     pub fn id(&self) -> Option<u32> {
-        self.child.id()
+        self.control.id()
+    }
+
+    pub(crate) fn control(&self) -> ProcessControl {
+        self.control.clone()
     }
 
     pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
-        Ok(self.child.try_wait()?)
+        let status = self.child.try_wait()?;
+        if status.is_some() {
+            self.control.mark_exited();
+        }
+        Ok(status)
     }
 
     pub(crate) fn take_stdout(&mut self) -> Option<BufReader<tokio::process::ChildStdout>> {
@@ -100,6 +221,19 @@ impl ProcessHandle {
 
     pub(crate) fn take_stderr(&mut self) -> Option<BufReader<tokio::process::ChildStderr>> {
         self.stderr_reader.take()
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        if !self.control.is_exited() {
+            if let Err(error) = self.control.start_kill() {
+                tracing::warn!("failed to signal Claude process group on drop: {error}");
+            }
+            if let Err(error) = self.child.start_kill() {
+                tracing::warn!("failed to kill Claude process on drop: {error}");
+            }
+        }
     }
 }
 

--- a/crates/services/claudecode-rs/src/session.rs
+++ b/crates/services/claudecode-rs/src/session.rs
@@ -1,6 +1,7 @@
 use crate::config::SessionConfig;
 use crate::error::ClaudeError;
 use crate::error::Result;
+use crate::process::ProcessControl;
 use crate::process::ProcessHandle;
 use crate::stream::JsonStreamParser;
 use crate::stream::SingleJsonParser;
@@ -28,6 +29,7 @@ pub struct Session {
 
     // Process handle
     process: Arc<Mutex<Option<ProcessHandle>>>,
+    process_control: ProcessControl,
 
     // Event channel for streaming
     events_tx: Option<mpsc::UnboundedSender<Event>>,
@@ -63,6 +65,7 @@ impl Session {
             _ => (None, None),
         };
 
+        let process_control = process.control();
         let process = Arc::new(Mutex::new(Some(process)));
         let result = Arc::new(RwLock::new(None));
         let error = Arc::new(RwLock::new(None));
@@ -72,6 +75,7 @@ impl Session {
             config: config.clone(),
             start_time: Utc::now(),
             process: process.clone(),
+            process_control,
             events_tx,
             events,
             tasks: Vec::new(),
@@ -145,12 +149,14 @@ impl Session {
         result_arc: Arc<RwLock<Option<ClaudeResult>>>,
         error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<()> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
+        let mut process = {
+            let mut process_guard = process.lock().await;
+            process_guard
+                .take()
+                .ok_or_else(|| ClaudeError::SessionError {
+                    message: "Process already taken".to_string(),
+                })?
+        };
 
         let stdout = process
             .take_stdout()
@@ -247,12 +253,14 @@ impl Session {
         process: Arc<Mutex<Option<ProcessHandle>>>,
         _error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<ClaudeResult> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
+        let mut process = {
+            let mut process_guard = process.lock().await;
+            process_guard
+                .take()
+                .ok_or_else(|| ClaudeError::SessionError {
+                    message: "Process already taken".to_string(),
+                })?
+        };
 
         let stdout = process
             .take_stdout()
@@ -285,12 +293,14 @@ impl Session {
         process: Arc<Mutex<Option<ProcessHandle>>>,
         _error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<ClaudeResult> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
+        let mut process = {
+            let mut process_guard = process.lock().await;
+            process_guard
+                .take()
+                .ok_or_else(|| ClaudeError::SessionError {
+                    message: "Process already taken".to_string(),
+                })?
+        };
 
         let stdout = process
             .take_stdout()
@@ -321,10 +331,7 @@ impl Session {
 
     /// Wait for the session to complete and return the result
     pub async fn wait(mut self) -> Result<ClaudeResult> {
-        // Wait for all tasks to complete
-        for task in self.tasks.drain(..) {
-            let _ = task.await;
-        }
+        self.wait_for_tasks().await;
 
         // Check for errors first - preserve original error variant (e.g., ProcessFailed{stderr})
         if let Some(error) = self.error.write().await.take() {
@@ -341,11 +348,21 @@ impl Session {
             })
     }
 
+    async fn wait_for_tasks(&mut self) {
+        while !self.tasks.is_empty() {
+            let _ = (&mut self.tasks[0]).await;
+            self.tasks.remove(0);
+        }
+    }
+
     /// Kill the Claude process
     pub async fn kill(&mut self) -> Result<()> {
         if let Some(mut process) = self.process.lock().await.take() {
             process.kill().await?;
+        } else {
+            self.process_control.terminate_with_grace().await?;
         }
+        self.wait_for_tasks().await;
         Ok(())
     }
 
@@ -353,23 +370,13 @@ impl Session {
     ///
     /// On Unix systems, this sends SIGINT which allows graceful shutdown.
     pub async fn interrupt(&mut self) -> Result<()> {
-        if let Some(process) = self.process.lock().await.as_mut()
-            && let Some(pid) = process.id()
-        {
-            // Send SIGINT for graceful shutdown
-            unsafe {
-                let result = libc::kill(pid as i32, libc::SIGINT);
-                if result == 0 {
-                    return Ok(());
-                } else {
-                    return Err(ClaudeError::SessionError {
-                        message: format!(
-                            "Failed to send interrupt signal: {}",
-                            std::io::Error::last_os_error()
-                        ),
-                    });
-                }
-            }
+        if self.process_control.id().is_some() {
+            return self
+                .process_control
+                .interrupt()
+                .map_err(|error| ClaudeError::SessionError {
+                    message: format!("Failed to send interrupt signal: {error}"),
+                });
         }
         Err(ClaudeError::SessionError {
             message: "Process not found or already terminated".to_string(),
@@ -388,12 +395,7 @@ impl Session {
 
     /// Check if session is still running
     pub async fn is_running(&self) -> bool {
-        if let Some(ref _process) = *self.process.lock().await {
-            // Process is still held, might be running
-            true
-        } else {
-            false
-        }
+        !self.process_control.is_exited()
     }
 
     /// Take the event stream receiver
@@ -409,6 +411,10 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
+        if let Err(error) = self.process_control.start_kill() {
+            warn!("failed to signal Claude process group on session drop: {error}");
+        }
+
         // Ensure all tasks are aborted on drop
         for task in &self.tasks {
             task.abort();
@@ -419,9 +425,231 @@ impl Drop for Session {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::Client;
     use crate::config::SessionConfig;
     use crate::error::ClaudeError;
     use crate::types::OutputFormat;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use tokio::time::Instant;
+    use tokio::time::sleep;
+
+    const FAKE_CLAUDE_PID_FILE: &str = "FAKE_CLAUDE_PID_FILE";
+    const FAKE_CLAUDE_PGID_FILE: &str = "FAKE_CLAUDE_PGID_FILE";
+    const FAKE_CLAUDE_CHILD_PID_FILE: &str = "FAKE_CLAUDE_CHILD_PID_FILE";
+    const FAKE_CLAUDE_CHILD_PGID_FILE: &str = "FAKE_CLAUDE_CHILD_PGID_FILE";
+    const FAKE_CLAUDE_READY_FILE: &str = "FAKE_CLAUDE_READY_FILE";
+
+    struct FakeClaude {
+        _temp_dir: TempDir,
+        script_path: PathBuf,
+        pid_file: PathBuf,
+        pgid_file: PathBuf,
+        child_pid_file: PathBuf,
+        child_pgid_file: PathBuf,
+        ready_file: PathBuf,
+    }
+
+    struct FakeClaudeTree {
+        pid: i32,
+        pgid: i32,
+        child_pid: i32,
+        child_pgid: i32,
+    }
+
+    impl FakeClaude {
+        fn new() -> Self {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let script_path = temp_dir.path().join("fake-claude.sh");
+            let pid_file = temp_dir.path().join("claude.pid");
+            let pgid_file = temp_dir.path().join("claude.pgid");
+            let child_pid_file = temp_dir.path().join("child.pid");
+            let child_pgid_file = temp_dir.path().join("child.pgid");
+            let ready_file = temp_dir.path().join("ready");
+
+            std::fs::write(
+                &script_path,
+                r#"#!/bin/sh
+set -eu
+
+trim_pgid() {
+    ps -o pgid= -p "$1" | tr -d ' '
+}
+
+printf '%s\n' "$$" > "$FAKE_CLAUDE_PID_FILE"
+printf '%s\n' "$(trim_pgid "$$")" > "$FAKE_CLAUDE_PGID_FILE"
+
+sh -c 'trap "" TERM INT; sleep 300' &
+child="$!"
+printf '%s\n' "$child" > "$FAKE_CLAUDE_CHILD_PID_FILE"
+printf '%s\n' "$(trim_pgid "$child")" > "$FAKE_CLAUDE_CHILD_PGID_FILE"
+printf 'ready\n' > "$FAKE_CLAUDE_READY_FILE"
+
+sleep 300
+"#,
+            )
+            .unwrap();
+
+            let mut permissions = std::fs::metadata(&script_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script_path, permissions).unwrap();
+
+            Self {
+                _temp_dir: temp_dir,
+                script_path,
+                pid_file,
+                pgid_file,
+                child_pid_file,
+                child_pgid_file,
+                ready_file,
+            }
+        }
+
+        fn config(&self) -> SessionConfig {
+            SessionConfig::builder("test query".to_string())
+                .output_format(OutputFormat::Text)
+                .env_var(FAKE_CLAUDE_PID_FILE, self.pid_file.to_string_lossy())
+                .env_var(FAKE_CLAUDE_PGID_FILE, self.pgid_file.to_string_lossy())
+                .env_var(
+                    FAKE_CLAUDE_CHILD_PID_FILE,
+                    self.child_pid_file.to_string_lossy(),
+                )
+                .env_var(
+                    FAKE_CLAUDE_CHILD_PGID_FILE,
+                    self.child_pgid_file.to_string_lossy(),
+                )
+                .env_var(FAKE_CLAUDE_READY_FILE, self.ready_file.to_string_lossy())
+                .build()
+                .unwrap()
+        }
+
+        async fn wait_for_tree(&self) -> FakeClaudeTree {
+            wait_for_file(&self.ready_file).await;
+            FakeClaudeTree {
+                pid: read_i32_file(&self.pid_file).await,
+                pgid: read_i32_file(&self.pgid_file).await,
+                child_pid: read_i32_file(&self.child_pid_file).await,
+                child_pgid: read_i32_file(&self.child_pgid_file).await,
+            }
+        }
+    }
+
+    async fn wait_for_file(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if tokio::fs::try_exists(path).await.unwrap_or(false) {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for {}", path.display());
+    }
+
+    async fn read_i32_file(path: &Path) -> i32 {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if let Ok(content) = tokio::fs::read_to_string(path).await
+                && let Ok(value) = content.trim().parse()
+            {
+                return value;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out reading integer from {}", path.display());
+    }
+
+    async fn wait_for_process_exit(pid: i32) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !process_exists(pid) {
+                return true;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        false
+    }
+
+    async fn wait_for_process_handle_taken(session: &Session) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if session.process.lock().await.is_none() {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for output worker to take process handle");
+    }
+
+    fn process_exists(pid: i32) -> bool {
+        let result = unsafe { libc::kill(pid, 0) };
+        if result == 0 {
+            return true;
+        }
+
+        std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    fn current_process_group_id() -> i32 {
+        unsafe { libc::getpgrp() }
+    }
+
+    fn cleanup_process_group(pgid: i32) {
+        if pgid > 1 {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn aborting_launch_and_wait_terminates_fake_claude_tree() {
+        let fake = FakeClaude::new();
+        let client = Client::with_path(&fake.script_path).await.unwrap();
+        let config = fake.config();
+
+        let handle = tokio::spawn(async move { client.launch_and_wait(config).await });
+        let tree = fake.wait_for_tree().await;
+
+        assert_ne!(tree.pgid, current_process_group_id());
+        assert_eq!(tree.child_pgid, tree.pgid);
+
+        handle.abort();
+        let _ = handle.await;
+
+        let parent_exited = wait_for_process_exit(tree.pid).await;
+        let child_exited = wait_for_process_exit(tree.child_pid).await;
+        cleanup_process_group(tree.pgid);
+
+        assert!(parent_exited, "fake Claude process was not terminated");
+        assert!(child_exited, "fake Claude child process was not terminated");
+    }
+
+    #[tokio::test]
+    async fn kill_terminates_fake_claude_tree_after_worker_takes_process() {
+        let fake = FakeClaude::new();
+        let client = Client::with_path(&fake.script_path).await.unwrap();
+        let config = fake.config();
+
+        let mut session = client.launch(config).await.unwrap();
+        let tree = fake.wait_for_tree().await;
+        wait_for_process_handle_taken(&session).await;
+
+        assert_ne!(tree.pgid, current_process_group_id());
+        assert_eq!(tree.child_pgid, tree.pgid);
+
+        let kill_result = session.kill().await;
+        let parent_exited = wait_for_process_exit(tree.pid).await;
+        let child_exited = wait_for_process_exit(tree.child_pid).await;
+        cleanup_process_group(tree.pgid);
+
+        kill_result.unwrap();
+        assert!(!session.is_running().await);
+        assert!(parent_exited, "fake Claude process was not terminated");
+        assert!(child_exited, "fake Claude child process was not terminated");
+    }
 
     #[tokio::test]
     async fn wait_returns_processfailed_preserving_stderr() {
@@ -435,6 +663,7 @@ mod tests {
             config: cfg,
             start_time: Utc::now(),
             process: Arc::new(Mutex::new(None)),
+            process_control: ProcessControl::empty(),
             events_tx: None,
             events: None,
             tasks: vec![],
@@ -468,6 +697,7 @@ mod tests {
             config: cfg,
             start_time: Utc::now(),
             process: Arc::new(Mutex::new(None)),
+            process_control: ProcessControl::empty(),
             events_tx: None,
             events: None,
             tasks: vec![],
@@ -499,6 +729,7 @@ mod tests {
             config: cfg,
             start_time: Utc::now(),
             process: Arc::new(Mutex::new(None)),
+            process_control: ProcessControl::empty(),
             events_tx: None,
             events: None,
             tasks: vec![],
@@ -529,6 +760,7 @@ mod tests {
             config: cfg,
             start_time: Utc::now(),
             process: Arc::new(Mutex::new(None)),
+            process_control: ProcessControl::empty(),
             events_tx: None,
             events: None,
             tasks: vec![],


### PR DESCRIPTION
## Summary
- Spawn Claude sessions in their own Unix process group and add shared process control for group-aware cleanup.
- Keep session task handles cancellation-safe and make `Session::kill()` work after workers take the process handle.
- Add fake-Claude tests covering abort/drop cleanup, explicit kill, and process-group child cleanup.

## Testing
- `cargo test -p claudecode`
- `just crate-test claudecode`
- `just crate-check claudecode`
- `git diff --check`

## Notes
- Reproduced the cancellation/drop leak against baseline code with the new fake-Claude test before verifying it passes with this fix.