### PR TITLE
Route agentic-mcp tracing to stderr

### DIFF
--- a/apps/agentic-mcp/src/main.rs
+++ b/apps/agentic-mcp/src/main.rs
@@ -149,7 +149,9 @@ fn parse_config(args: &Args) -> (AgenticToolsConfig, Option<String>) {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
 
     // Install the rustls CryptoProvider before any HTTP clients are created.
     // Required because Cargo's additive features cause both ring and aws-lc-rs

--- a/apps/agentic-mcp/tests/stderr_logging.rs
+++ b/apps/agentic-mcp/tests/stderr_logging.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn tracing_setup_explicitly_uses_stderr_writer() {
+    let main_rs_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    let main_rs = std::fs::read_to_string(&main_rs_path).expect("read src/main.rs");
+
+    let main_start = main_rs
+        .find("async fn main() -> anyhow::Result<()>")
+        .expect("main function should exist");
+    let startup = &main_rs[main_start..];
+    let rustls_start = startup
+        .find("// Install the rustls CryptoProvider")
+        .expect("rustls setup should follow tracing setup");
+    let tracing_setup = &startup[..rustls_start];
+
+    assert!(
+        tracing_setup.contains("tracing_subscriber::fmt()"),
+        "tracing setup should use the configurable fmt builder; found:\n{tracing_setup}"
+    );
+    assert!(
+        tracing_setup.contains(".with_writer(std::io::stderr)"),
+        "agentic-mcp tracing must explicitly write to stderr; found:\n{tracing_setup}"
+    );
+    assert!(
+        !tracing_setup.contains("tracing_subscriber::fmt::init()"),
+        "fmt::init() uses the default writer instead of explicitly selecting stderr; found:\n{tracing_setup}"
+    );
+}
+
+#[test]
+fn list_tools_keeps_stdout_empty_for_protocol_safety() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentic-mcp"))
+        .arg("--list-tools")
+        .output()
+        .expect("run agentic-mcp --list-tools");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "agentic-mcp --list-tools failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "stdout must stay reserved for MCP protocol messages; got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("Available tools"),
+        "expected --list-tools output on stderr; got:\n{stderr}"
+    );
+}

--- a/apps/agentic-mcp/tests/stderr_logging.rs
+++ b/apps/agentic-mcp/tests/stderr_logging.rs
@@ -11,7 +11,7 @@ fn tracing_setup_explicitly_uses_stderr_writer() {
         .expect("main function should exist");
     let startup = &main_rs[main_start..];
     let rustls_start = startup
-        .find("// Install the rustls CryptoProvider")
+        .find("default_provider().install_default()")
         .expect("rustls setup should follow tracing setup");
     let tracing_setup = &startup[..rustls_start];
 


### PR DESCRIPTION
## Summary
- Route `agentic-mcp` tracing through an explicit stderr writer so stdout stays reserved for stdio MCP protocol messages.
- Add focused regression coverage for stderr tracing setup and `--list-tools` stdout cleanliness.

## Testing
- `cargo test -p agentic-mcp --test stderr_logging` failed before the implementation because `tracing_setup_explicitly_uses_stderr_writer` caught the missing explicit stderr writer.
- `cargo test -p agentic-mcp --test stderr_logging`
- `just crate-check agentic-mcp && just crate-test agentic-mcp`