### PR TITLE
Add MCP tool cancellation plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/agentic-tools/core/Cargo.toml
+++ b/crates/agentic-tools/core/Cargo.toml
@@ -15,6 +15,7 @@ schemars = { workspace = true }
 thiserror = { workspace = true }
 json-patch = "4"
 rmcp = { workspace = true, features = ["server", "transport-io"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [features]
 default = []

--- a/crates/agentic-tools/core/src/context.rs
+++ b/crates/agentic-tools/core/src/context.rs
@@ -1,21 +1,77 @@
 //! Tool execution context.
 
+pub use tokio_util::sync::CancellationToken;
+
 /// Context passed to tool executions.
 ///
-/// This struct is extensible for future needs like:
-/// - Cancellation tokens
+/// This struct carries cooperative cancellation and is extensible for future needs like:
 /// - Workspace/environment info
 /// - Tracing/spans
 /// - Request metadata
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct ToolContext {
-    // Extensible: add cancellation, workspace, env, tracing, etc.
-    _private: (),
+    cancellation_token: CancellationToken,
+}
+
+impl Default for ToolContext {
+    fn default() -> Self {
+        Self {
+            cancellation_token: CancellationToken::new(),
+        }
+    }
 }
 
 impl ToolContext {
     /// Create a new default context.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a context with an existing cancellation token.
+    pub fn with_cancellation_token(cancellation_token: CancellationToken) -> Self {
+        Self { cancellation_token }
+    }
+
+    /// Return the cancellation token for this tool execution.
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
+    }
+
+    /// Return true when this tool execution has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation_token.is_cancelled()
+    }
+
+    /// Wait until this tool execution is cancelled.
+    pub async fn cancelled(&self) {
+        self.cancellation_token.cancelled().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn cancellation_token_is_shared_with_context() {
+        let token = CancellationToken::new();
+        let ctx = ToolContext::with_cancellation_token(token.clone());
+
+        assert!(!ctx.is_cancelled());
+
+        token.cancel();
+
+        assert!(ctx.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_future_observes_cancellation() {
+        let token = CancellationToken::new();
+        let ctx = ToolContext::with_cancellation_token(token.clone());
+
+        token.cancel();
+
+        ctx.cancelled().await;
     }
 }

--- a/crates/agentic-tools/core/src/lib.rs
+++ b/crates/agentic-tools/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod registry;
 pub mod schema;
 pub mod tool;
 
+pub use context::CancellationToken;
 pub use context::ToolContext;
 pub use error::ToolError;
 pub use fmt::ErasedFmt;

--- a/crates/agentic-tools/mcp/src/server.rs
+++ b/crates/agentic-tools/mcp/src/server.rs
@@ -202,7 +202,7 @@ impl ServerHandler for RegistryServer {
     fn call_tool(
         &self,
         req: m::CallToolRequestParams,
-        _ctx: RequestContext<RoleServer>,
+        request_ctx: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<m::CallToolResult, m::ErrorData>> + Send + '_
     {
         async move {
@@ -214,7 +214,7 @@ impl ServerHandler for RegistryServer {
             }
 
             let args = serde_json::Value::Object(req.arguments.unwrap_or_default());
-            let ctx = ToolContext::default();
+            let ctx = ToolContext::with_cancellation_token(request_ctx.ct.clone());
             let text_opts = self.text_options.clone();
 
             match self

--- a/crates/agentic-tools/mcp/tests/integration.rs
+++ b/crates/agentic-tools/mcp/tests/integration.rs
@@ -12,10 +12,18 @@ use agentic_tools_core::fmt::TextOptions;
 use agentic_tools_mcp::OutputMode;
 use agentic_tools_mcp::RegistryServer;
 use futures::future::BoxFuture;
+use rmcp::model as m;
+use rmcp::service::RoleServer;
+use rmcp::service::RxJsonRpcMessage;
+use rmcp::service::TxJsonRpcMessage;
+use rmcp::transport::Transport;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::sync::mpsc;
+use tokio::time::Duration;
 
 // =============================================================================
 // Test Tool Definitions
@@ -99,6 +107,68 @@ impl Tool for CalculateTool {
             };
             Ok(CalculateOutput { result })
         })
+    }
+}
+
+#[derive(Clone)]
+struct WaitForCancelTool {
+    started: Arc<Notify>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct WaitForCancelInput {}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct WaitForCancelOutput {
+    cancelled: bool,
+}
+
+impl TextFormat for WaitForCancelOutput {}
+
+impl Tool for WaitForCancelTool {
+    type Input = WaitForCancelInput;
+    type Output = WaitForCancelOutput;
+    const NAME: &'static str = "wait_for_cancel";
+    const DESCRIPTION: &'static str = "Wait until the request is cancelled";
+
+    fn call(
+        &self,
+        _input: Self::Input,
+        ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let ctx = ctx.clone();
+        let started = Arc::clone(&self.started);
+
+        Box::pin(async move {
+            started.notify_waiters();
+            ctx.cancelled().await;
+            Ok(WaitForCancelOutput { cancelled: true })
+        })
+    }
+}
+
+struct TestTransport {
+    rx: mpsc::Receiver<RxJsonRpcMessage<RoleServer>>,
+    tx: mpsc::Sender<TxJsonRpcMessage<RoleServer>>,
+}
+
+impl Transport<RoleServer> for TestTransport {
+    type Error = mpsc::error::SendError<TxJsonRpcMessage<RoleServer>>;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleServer>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let tx = self.tx.clone();
+        async move { tx.send(item).await }
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        self.rx.recv().await
+    }
+
+    fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        std::future::ready(Ok(()))
     }
 }
 
@@ -368,4 +438,72 @@ async fn test_dispatch_json_formatted_fallback_for_unknown_tool() {
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Unknown tool"));
+}
+
+#[tokio::test]
+async fn cancelled_notification_reaches_tool_context() {
+    let started = Arc::new(Notify::new());
+    let registry = Arc::new(
+        ToolRegistry::builder()
+            .register::<WaitForCancelTool, ()>(WaitForCancelTool {
+                started: Arc::clone(&started),
+            })
+            .finish(),
+    );
+    let server = RegistryServer::new(registry);
+    let (client_tx, server_rx) = mpsc::channel(8);
+    let (server_tx, mut client_rx) = mpsc::channel(8);
+    let transport = TestTransport {
+        rx: server_rx,
+        tx: server_tx,
+    };
+    let mut running =
+        rmcp::service::serve_directly::<RoleServer, _, _, _, _>(server, transport, None);
+
+    let call_id = m::RequestId::String("wait-call".into());
+    let call =
+        m::CallToolRequestParams::new("wait_for_cancel").with_arguments(serde_json::Map::new());
+    let started_wait = started.notified();
+
+    client_tx
+        .send(m::ClientJsonRpcMessage::request(
+            m::ClientRequest::CallToolRequest(m::CallToolRequest::new(call)),
+            call_id.clone(),
+        ))
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), started_wait)
+        .await
+        .unwrap();
+
+    let cancel = m::CancelledNotification::new(m::CancelledNotificationParam {
+        request_id: call_id.clone(),
+        reason: Some("test cancellation".to_string()),
+    });
+    client_tx
+        .send(m::ClientJsonRpcMessage::notification(
+            m::ClientNotification::CancelledNotification(cancel),
+        ))
+        .await
+        .unwrap();
+
+    let response = tokio::time::timeout(Duration::from_secs(1), client_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let (result, response_id) = response.into_response().unwrap();
+    assert_eq!(response_id, call_id);
+
+    let m::ServerResult::CallToolResult(result) = result else {
+        panic!("expected call tool result");
+    };
+    assert_eq!(result.is_error, Some(false));
+    assert!(
+        serde_json::to_string(&result)
+            .unwrap()
+            .contains("cancelled")
+    );
+
+    running.close().await.unwrap();
 }

--- a/crates/tools/coding-agent-tools/src/lib.rs
+++ b/crates/tools/coding-agent-tools/src/lib.rs
@@ -18,6 +18,7 @@ pub use tools::build_registry;
 
 use agentic_config::types::CliToolsConfig;
 use agentic_config::types::SubagentsConfig;
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use std::sync::Arc;
 use types::AgentOutput;
@@ -263,6 +264,19 @@ impl CodingAgentTools {
         location: Option<types::AgentLocation>,
         query: String,
     ) -> Result<AgentOutput, ToolError> {
+        let ctx = ToolContext::default();
+        self.ask_agent_with_context(agent_type, location, query, &ctx)
+            .await
+    }
+
+    /// Spawn an opinionated Claude subagent with a tool execution context.
+    pub async fn ask_agent_with_context(
+        &self,
+        agent_type: Option<types::AgentType>,
+        location: Option<types::AgentLocation>,
+        query: String,
+        ctx: &ToolContext,
+    ) -> Result<AgentOutput, ToolError> {
         use claudecode::client::Client;
         use claudecode::config::SessionConfig;
         use claudecode::mcp::validate::ValidateOptions;
@@ -296,6 +310,20 @@ impl CodingAgentTools {
 
         // Compose configuration
         let model = agent::model_for(agent_type, &self.subagents);
+        if ctx.is_cancelled() {
+            let error_msg = "ask_agent cancelled".to_string();
+            log_ctx.finish(
+                req_json,
+                None,
+                false,
+                Some(error_msg.clone()),
+                None,
+                Some(model.to_string()),
+                None,
+            );
+            return Err(ToolError::Internal(error_msg));
+        }
+
         let system_prompt = agent::compose_prompt(agent_type, location);
         let enabled_tools = agent::enabled_tools_for(agent_type, location);
 
@@ -310,7 +338,23 @@ impl CodingAgentTools {
 
         // Validate MCP servers before launching (spawn, handshake, tools/list)
         let opts = ValidateOptions::default();
-        if let Err(e) = ensure_valid_mcp_config(&mcp_config, &opts).await {
+        let validation_result = tokio::select! {
+            () = ctx.cancelled() => {
+                let error_msg = "ask_agent cancelled".to_string();
+                log_ctx.finish(
+                    req_json,
+                    None,
+                    false,
+                    Some(error_msg.clone()),
+                    None,
+                    Some(model.to_string()),
+                    None,
+                );
+                return Err(ToolError::Internal(error_msg));
+            }
+            result = ensure_valid_mcp_config(&mcp_config, &opts) => result,
+        };
+        if let Err(e) = validation_result {
             use std::fmt::Write;
             let mut details = String::new();
             for (name, err) in &e.errors {
@@ -318,6 +362,20 @@ impl CodingAgentTools {
             }
             let error_msg =
                 format!("ask_agent unavailable: MCP config validation failed.\n{details}");
+            log_ctx.finish(
+                req_json,
+                None,
+                false,
+                Some(error_msg.clone()),
+                None,
+                Some(model.to_string()),
+                None,
+            );
+            return Err(ToolError::Internal(error_msg));
+        }
+
+        if ctx.is_cancelled() {
+            let error_msg = "ask_agent cancelled".to_string();
             log_ctx.finish(
                 req_json,
                 None,
@@ -378,7 +436,24 @@ impl CodingAgentTools {
             }
         };
 
-        let result = match client.launch_and_wait(config).await {
+        let launch_result = tokio::select! {
+            () = ctx.cancelled() => {
+                let error_msg = "ask_agent cancelled".to_string();
+                log_ctx.finish(
+                    req_json,
+                    None,
+                    false,
+                    Some(error_msg.clone()),
+                    None,
+                    Some(model.to_string()),
+                    None,
+                );
+                return Err(ToolError::Internal(error_msg));
+            }
+            result = client.launch_and_wait(config) => result,
+        };
+
+        let result = match launch_result {
             Ok(r) => r,
             Err(e) => {
                 let error_msg = format!("Failed to run Claude session: {e}");

--- a/crates/tools/coding-agent-tools/src/tools.rs
+++ b/crates/tools/coding-agent-tools/src/tools.rs
@@ -153,12 +153,13 @@ Usage notes:
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let tools = Arc::clone(&self.tools);
+        let ctx = ctx.clone();
         Box::pin(async move {
             tools
-                .ask_agent(input.agent_type, input.location, input.query)
+                .ask_agent_with_context(input.agent_type, input.location, input.query, &ctx)
                 .await
         })
     }

--- a/crates/tools/coding-agent-tools/tests/ask_agent_integration.rs
+++ b/crates/tools/coding-agent-tools/tests/ask_agent_integration.rs
@@ -3,9 +3,37 @@
 //! Run with: cargo test -p `coding_agent_tools` -- --ignored
 #![expect(clippy::unwrap_used)]
 
+use agentic_tools_core::CancellationToken;
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
 use coding_agent_tools::CodingAgentTools;
+use coding_agent_tools::tools::AskAgentInput;
+use coding_agent_tools::tools::AskAgentTool;
 use coding_agent_tools::types::AgentLocation;
 use coding_agent_tools::types::AgentType;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn ask_agent_tool_returns_promptly_when_context_is_cancelled() {
+    let token = CancellationToken::new();
+    token.cancel();
+    let ctx = ToolContext::with_cancellation_token(token);
+    let tool = AskAgentTool::new(Arc::new(CodingAgentTools::new()));
+
+    let err = tool
+        .call(
+            AskAgentInput {
+                agent_type: Some(AgentType::Locator),
+                location: Some(AgentLocation::Codebase),
+                query: "This should not launch Claude".to_string(),
+            },
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("cancelled"));
+}
 
 #[tokio::test]
 #[ignore = "requires live API key and network access"]


### PR DESCRIPTION
## Summary
- Add cooperative cancellation support to `ToolContext` and thread rmcp request cancellation into MCP tool dispatch.
- Make `ask_agent` observe tool cancellation around MCP validation and Claude session launch.
- Add focused core, MCP, and `ask_agent` cancellation coverage.

## Testing
- `cargo test -p agentic-tools-core cancellation`
- `cargo test -p agentic-tools-mcp cancelled_notification_reaches_tool_context`
- `cargo test -p coding_agent_tools ask_agent_tool_returns_promptly_when_context_is_cancelled`
- `just crate-test agentic-tools-core`
- `just crate-test agentic-tools-mcp`
- `just crate-test coding_agent_tools`
- `just crate-check agentic-tools-core`
- `just crate-check agentic-tools-mcp`
- `just crate-check coding_agent_tools`
- `git diff --check`

## Notes
- Linear: ENG-760
- Reviewed open related PRs: #188, #189, #190, #191, #193. #191 remains complementary for robust Claude subprocess cleanup after cancellation.