### PR TITLE
Opencode orchestrator 400 error on command usage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,7 +52,12 @@ These items have dependencies and should be done in order.
 - Could bundle with Linear tools in same agent.
 
 ### Wire live opencode command-path integration tests into CI
-- `crates/services/opencode-rs/tests/integration.rs:6-18,53-55,153-156` and `apps/opencode-orchestrator-mcp/tests/integration.rs:24-26,125-128` show the live tests are both `#[ignore]`-gated and require `OPENCODE_INTEGRATION` / `OPENCODE_ORCHESTRATOR_INTEGRATION`, while `.github/workflows/ci.yml:71-87` and `.github/workflows/ci.yml:223-238` never set those env vars or pass `--ignored`. Result: CI never exercises the real `POST /session/{id}/command` path, which is how the recent `messageID` validator regression in `opencode-rs` slipped through. Decide where these should run (probably nightly), wire the env vars in, and run the ignored tests there.
+
+- TODO(1): `crates/services/opencode-rs/tests/integration.rs:6-18,53-55,153-156` and `apps/opencode-orchestrator-mcp/tests/integration.rs:24-26,125-128` show the live tests are both `#[ignore]`-gated and require `OPENCODE_INTEGRATION` / `OPENCODE_ORCHESTRATOR_INTEGRATION`, while `.github/workflows/ci.yml:71-87` and `.github/workflows/ci.yml:223-238` never set those env vars or pass `--ignored`. Result: CI never exercises the real `POST /session/{id}/command` path, which is how the recent `messageID` validator regression in `opencode-rs` slipped through. Decide where these should run (probably nightly), wire the env vars in, and run the ignored tests there.
+
+### Decide on idempotency semantics for opencode-rs command dispatch retries
+
+- TODO(1): `crates/services/opencode-rs/src/http/messages.rs:94-99` (`command()`) currently uses `post_json_with_retry`, but upstream opencode 1.14.19 does not dedupe by `messageID` (`references/anomalyco/opencode@r-refs~2ftags~2fv1.14.19/packages/opencode/src/session/prompt.ts:940-942,1276-1293`, `packages/opencode/src/session/projectors.ts:83-96`). A retry fired after server-side execution has begun (e.g., connection dropped mid-response) can cause duplicate command execution. Decide between (a) disabling transport retries on `/session/{id}/command` to fail fast, (b) implementing a real server-side idempotency contract upstream, or (c) accepting at-least-once semantics and documenting it. Currently the code path is documented but unchanged.
 
 ## To classify/investigate:
 

--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,9 @@ These items have dependencies and should be done in order.
 - Probably only needs one tool for searching, maybe a second for reading context around results.
 - Could bundle with Linear tools in same agent.
 
+### Wire live opencode command-path integration tests into CI
+- `crates/services/opencode-rs/tests/integration.rs:6-18,53-55,153-156` and `apps/opencode-orchestrator-mcp/tests/integration.rs:24-26,125-128` show the live tests are both `#[ignore]`-gated and require `OPENCODE_INTEGRATION` / `OPENCODE_ORCHESTRATOR_INTEGRATION`, while `.github/workflows/ci.yml:71-87` and `.github/workflows/ci.yml:223-238` never set those env vars or pass `--ignored`. Result: CI never exercises the real `POST /session/{id}/command` path, which is how the recent `messageID` validator regression in `opencode-rs` slipped through. Decide where these should run (probably nightly), wire the env vars in, and run the ignored tests there.
+
 ## To classify/investigate:
 
 ### CLAUDE.md cargo commands → just commands

--- a/apps/opencode-orchestrator-mcp/tests/integration.rs
+++ b/apps/opencode-orchestrator-mcp/tests/integration.rs
@@ -152,9 +152,12 @@ async fn unknown_command_errors_fast() {
     cleanup_session(&server, &session_id).await;
 
     let result = result.expect("REGRESSION: timed out waiting for error (should fail fast)");
+    let err = result.expect_err("expected error for unknown command");
+    let err_text = err.to_string();
     assert!(
-        result.is_err(),
-        "expected error for unknown command, got: {result:?}"
+        err_text.contains("Command not found")
+            || err_text.contains("___definitely_not_a_real_command___"),
+        "expected surfaced command lookup error, got: {err_text}"
     );
     assert!(
         elapsed < Duration::from_secs(5),

--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -8,7 +8,7 @@ use std::fs;
 
 pub(crate) const MISE_PATH: &str = "mise.toml";
 
-const TOOL_PINS_BLOCK: &str = "claude = \"2.1.116\"\n\"npm:opencode-ai\" = \"1.3.17\"";
+const TOOL_PINS_BLOCK: &str = "claude = \"2.1.116\"\n\"npm:opencode-ai\" = \"1.14.19\"";
 
 const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("linux-x64", "x86_64-unknown-linux-gnu"),

--- a/crates/services/opencode-rs/src/error.rs
+++ b/crates/services/opencode-rs/src/error.rs
@@ -96,6 +96,71 @@ pub struct HttpErrorBody {
     pub data: Option<serde_json::Value>,
 }
 
+fn format_error_path(path: &[serde_json::Value]) -> Option<String> {
+    let formatted: Vec<String> = path
+        .iter()
+        .map(|segment| match segment {
+            serde_json::Value::String(value) => value.clone(),
+            other => other.to_string(),
+        })
+        .collect();
+
+    if formatted.is_empty() {
+        None
+    } else {
+        Some(formatted.join("."))
+    }
+}
+
+fn format_validator_entry(entry: &serde_json::Value) -> String {
+    let path = entry
+        .get("path")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|segments| format_error_path(segments));
+    let message = entry
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .map(std::string::ToString::to_string);
+
+    match (path, message) {
+        (Some(path), Some(message)) => format!("{path}: {message}"),
+        (Some(path), None) => format!("{path}: {entry}"),
+        (None, Some(message)) => message,
+        (None, None) => entry.to_string(),
+    }
+}
+
+fn extract_http_error_message(v: &serde_json::Value) -> Option<String> {
+    if matches!(v.get("success"), Some(serde_json::Value::Bool(false)))
+        && let Some(errors) = v.get("error").and_then(serde_json::Value::as_array)
+    {
+        let messages: Vec<String> = errors.iter().map(format_validator_entry).collect();
+        if !messages.is_empty() {
+            return Some(messages.join("; "));
+        }
+    }
+
+    if let (Some(name), Some(message)) = (
+        v.get("name").and_then(serde_json::Value::as_str),
+        v.get("data")
+            .and_then(|data| data.get("message"))
+            .and_then(serde_json::Value::as_str),
+    ) {
+        return Some(format!("{name}: {message}"));
+    }
+
+    v.get("message")
+        .and_then(serde_json::Value::as_str)
+        .map(std::string::ToString::to_string)
+}
+
+fn truncate_body_text(body_text: &str, max_chars: usize) -> String {
+    match body_text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}…", &body_text[..idx]),
+        None => body_text.to_string(),
+    }
+}
+
 impl HttpErrorBody {
     /// Parse from a JSON value.
     pub fn from_json(v: &serde_json::Value) -> Self {
@@ -104,10 +169,7 @@ impl HttpErrorBody {
                 .get("name")
                 .and_then(|x| x.as_str())
                 .map(std::string::ToString::to_string),
-            message: v
-                .get("message")
-                .and_then(|x| x.as_str())
-                .map(std::string::ToString::to_string),
+            message: extract_http_error_message(v),
             data: v.get("data").cloned(),
         }
     }
@@ -116,17 +178,17 @@ impl HttpErrorBody {
 impl OpencodeError {
     /// Create an HTTP error from status and optional JSON body.
     pub fn http(status: u16, body_text: &str) -> Self {
-        // Try to parse as JSON to extract NamedError fields
         let parsed: Option<serde_json::Value> = serde_json::from_str(body_text).ok();
         let info = parsed.as_ref().map(HttpErrorBody::from_json);
+        let message = info
+            .as_ref()
+            .and_then(|i| i.message.clone())
+            .unwrap_or_else(|| truncate_body_text(body_text, 1024));
 
         Self::Http {
             status,
             name: info.as_ref().and_then(|i| i.name.clone()),
-            message: info
-                .as_ref()
-                .and_then(|i| i.message.clone())
-                .unwrap_or_else(|| format!("HTTP {status}")),
+            message,
             data: info.and_then(|i| i.data),
         }
     }
@@ -161,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_http_error_from_named_error() {
-        let body = r#"{"name":"NotFound","message":"Session not found","data":{"id":"123"}}"#;
+        let body = r#"{"name":"NotFound","data":{"message":"Session not found","id":"123"}}"#;
         let err = OpencodeError::http(404, body);
 
         match err {
@@ -173,7 +235,7 @@ mod tests {
             } => {
                 assert_eq!(status, 404);
                 assert_eq!(name, Some("NotFound".to_string()));
-                assert_eq!(message, "Session not found");
+                assert_eq!(message, "NotFound: Session not found");
                 assert!(data.is_some());
             }
             _ => panic!("Expected Http error"),
@@ -193,7 +255,89 @@ mod tests {
             } => {
                 assert_eq!(status, 500);
                 assert!(name.is_none());
-                assert_eq!(message, "HTTP 500");
+                assert_eq!(message, "Internal Server Error");
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_legacy_top_level_message() {
+        let body = r#"{"name":"ValidationError","message":"Legacy message"}"#;
+        let err = OpencodeError::http(400, body);
+
+        match err {
+            OpencodeError::Http { name, message, .. } => {
+                assert_eq!(name, Some("ValidationError".to_string()));
+                assert_eq!(message, "Legacy message");
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_validator_messageid_invalid() {
+        let body = r#"{
+  "data": {"command":"linear","arguments":"hello","messageID":"550e8400-e29b-41d4-a716-446655440000"},
+  "error": [
+    {
+      "origin": "string",
+      "code": "invalid_format",
+      "format": "starts_with",
+      "prefix": "msg",
+      "path": ["messageID"],
+      "message": "Invalid string: must start with \"msg\""
+    }
+  ],
+  "success": false
+}"#;
+        let err = OpencodeError::http(400, body);
+
+        match err {
+            OpencodeError::Http { message, .. } => {
+                assert!(message.contains("messageID"), "message was: {message}");
+                assert!(
+                    message.contains("must start with"),
+                    "message was: {message}"
+                );
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_named_error_unknown_command() {
+        let body = r#"{
+  "name": "UnknownError",
+  "data": {
+    "message": "Command not found: \"___definitely_not_a_real_command___\". Available commands: init, review, ..."
+  }
+}"#;
+        let err = OpencodeError::http(400, body);
+
+        match err {
+            OpencodeError::Http { message, .. } => {
+                assert!(
+                    message.contains("Command not found"),
+                    "message was: {message}"
+                );
+                assert!(
+                    message.contains("___definitely_not_a_real_command___"),
+                    "message was: {message}"
+                );
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_unknown_shape_preserves_body() {
+        let body = r#"{ "weird": "shape" }"#;
+        let err = OpencodeError::http(418, body);
+
+        match err {
+            OpencodeError::Http { message, .. } => {
+                assert!(message.contains(body), "message was: {message}");
             }
             _ => panic!("Expected Http error"),
         }

--- a/crates/services/opencode-rs/src/error.rs
+++ b/crates/services/opencode-rs/src/error.rs
@@ -183,7 +183,14 @@ impl OpencodeError {
         let message = info
             .as_ref()
             .and_then(|i| i.message.clone())
-            .unwrap_or_else(|| truncate_body_text(body_text, 1024));
+            .unwrap_or_else(|| {
+                let truncated = truncate_body_text(body_text, 1024);
+                if truncated.trim().is_empty() {
+                    format!("HTTP {status}")
+                } else {
+                    truncated
+                }
+            });
 
         Self::Http {
             status,
@@ -256,6 +263,44 @@ mod tests {
                 assert_eq!(status, 500);
                 assert!(name.is_none());
                 assert_eq!(message, "Internal Server Error");
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_empty_body_uses_status_fallback() {
+        let err = OpencodeError::http(502, "");
+
+        match err {
+            OpencodeError::Http {
+                status,
+                name,
+                message,
+                ..
+            } => {
+                assert_eq!(status, 502);
+                assert!(name.is_none());
+                assert_eq!(message, "HTTP 502");
+            }
+            _ => panic!("Expected Http error"),
+        }
+    }
+
+    #[test]
+    fn test_http_error_from_whitespace_body_uses_status_fallback() {
+        let err = OpencodeError::http(503, "   \n");
+
+        match err {
+            OpencodeError::Http {
+                status,
+                name,
+                message,
+                ..
+            } => {
+                assert_eq!(status, 503);
+                assert!(name.is_none());
+                assert_eq!(message, "HTTP 503");
             }
             _ => panic!("Expected Http error"),
         }

--- a/crates/services/opencode-rs/src/http/messages.rs
+++ b/crates/services/opencode-rs/src/http/messages.rs
@@ -88,6 +88,13 @@ impl MessagesApi {
     ///
     /// Uses transport-level retry for transient network failures (connect/timeout).
     ///
+    /// Upstream opencode 1.14.19 does not dedupe command dispatch by `messageID`,
+    /// so supplying `CommandRequest::message_id` does not provide an idempotency
+    /// guarantee. If the server has already started executing the command before a
+    /// retryable network failure occurs (for example, a connection drop
+    /// mid-response), a retry can trigger duplicate command execution. Callers
+    /// should therefore treat this endpoint as at-least-once, not exactly-once.
+    ///
     /// # Errors
     ///
     /// Returns an error if the request fails after retries.

--- a/crates/services/opencode-rs/src/http/messages.rs
+++ b/crates/services/opencode-rs/src/http/messages.rs
@@ -13,7 +13,6 @@ use crate::types::message::Message;
 use crate::types::message::PromptRequest;
 use crate::types::message::ShellRequest;
 use reqwest::Method;
-use uuid::Uuid;
 
 /// Messages API client.
 #[derive(Clone)]
@@ -88,21 +87,13 @@ impl MessagesApi {
     /// Execute a command in a session.
     ///
     /// Uses transport-level retry for transient network failures (connect/timeout).
-    /// To make retries safe, the SDK ensures each dispatch includes a stable `message_id`
-    /// (generated UUID if not provided) so the server can deduplicate repeated requests.
     ///
     /// # Errors
     ///
     /// Returns an error if the request fails after retries.
     pub async fn command(&self, session_id: &str, req: &CommandRequest) -> Result<CommandResponse> {
         let sid = encode_path_segment(session_id);
-
-        let mut req = req.clone();
-        if req.message_id.is_none() {
-            req.message_id = Some(Uuid::new_v4().to_string());
-        }
-
-        let body = serde_json::to_value(&req)?;
+        let body = serde_json::to_value(req)?;
         self.http
             .post_json_with_retry(&format!("/session/{sid}/command"), Some(body))
             .await

--- a/crates/services/opencode-rs/tests/command_retry.rs
+++ b/crates/services/opencode-rs/tests/command_retry.rs
@@ -73,12 +73,15 @@ async fn command_retries_on_timeout() {
         command_requests.len()
     );
 
-    // Verify both retry attempts share identical messageID
-    let b1: serde_json::Value = serde_json::from_slice(&command_requests[0].body).unwrap();
-    let b2: serde_json::Value = serde_json::from_slice(&command_requests[1].body).unwrap();
+    // Verify both retry attempts reused the exact same serialized body bytes.
+    assert_eq!(
+        command_requests[0].body, command_requests[1].body,
+        "expected identical request bodies across retries"
+    );
 
-    let mid1 = b1.get("messageID").and_then(|v| v.as_str()).unwrap();
-    let mid2 = b2.get("messageID").and_then(|v| v.as_str()).unwrap();
-    assert!(!mid1.is_empty());
-    assert_eq!(mid1, mid2, "expected stable messageID across retries");
+    let body: serde_json::Value = serde_json::from_slice(&command_requests[0].body).unwrap();
+    assert!(
+        body.get("messageID").is_none(),
+        "expected messageID to be omitted when request.message_id is None, got {body:?}"
+    );
 }

--- a/crates/services/opencode-rs/tests/command_timeout.rs
+++ b/crates/services/opencode-rs/tests/command_timeout.rs
@@ -40,8 +40,11 @@ async fn default_timeout_allows_301s_command_response() {
         "request should not time out with 1800s default, got: {result:?}"
     );
 
-    // Verify messageID was sent
+    // Verify messageID is omitted when the caller passes None.
     let received = server.received_requests().await.unwrap();
     let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
-    assert!(body.get("messageID").and_then(|v| v.as_str()).is_some());
+    assert!(
+        body.get("messageID").is_none(),
+        "expected messageID to be omitted when request.message_id is None, got {body:?}"
+    );
 }

--- a/crates/services/opencode-rs/tests/integration.rs
+++ b/crates/services/opencode-rs/tests/integration.rs
@@ -43,6 +43,7 @@ use tokio::sync::OnceCell;
 use opencode_rs::Client;
 use opencode_rs::ClientBuilder;
 use opencode_rs::types::event::Event;
+use opencode_rs::types::message::CommandRequest;
 use opencode_rs::types::message::PromptPart;
 use opencode_rs::types::message::PromptRequest;
 use opencode_rs::types::session::CreateSessionRequest;
@@ -533,6 +534,55 @@ async fn test_agents_list() {
 
     // Should have at least one agent
     assert!(!agents.is_empty(), "Should have at least one agent");
+}
+
+/// Test that command dispatch reaches command lookup instead of request validation.
+#[tokio::test]
+#[ignore = "requires: opencode serve"]
+async fn test_command_dispatch_passes_request_validation_v1_14_19() {
+    if !should_run() {
+        return;
+    }
+
+    let client = build_client().await;
+    let session = client
+        .sessions()
+        .create(&CreateSessionRequest::default())
+        .await
+        .expect("Failed to create session");
+
+    let result = client
+        .messages()
+        .command(
+            &session.id,
+            &CommandRequest {
+                command: "___definitely_not_a_real_command___".into(),
+                arguments: "hello".into(),
+                message_id: None,
+            },
+        )
+        .await;
+
+    client
+        .sessions()
+        .delete(&session.id)
+        .await
+        .expect("Failed to delete session");
+
+    let err = result.expect_err("unknown command should fail after request validation passes");
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("Command not found"),
+        "expected command lookup error, got: {err_text}"
+    );
+    assert!(
+        err_text.contains("___definitely_not_a_real_command___"),
+        "expected unknown command name in error, got: {err_text}"
+    );
+    assert!(
+        !err_text.contains("messageID"),
+        "request should not fail validation on messageID anymore: {err_text}"
+    );
 }
 
 /// Test commands list.


### PR DESCRIPTION
## My Notes (preserved)

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog
<!-- END:describe_pr:autogen -->
