### PR TITLE
Fix claudecode lifecycle leaks on cancelled sessions + add MCP cancellation across tools (ENG-762)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,8 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -113,6 +115,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1031,6 +1034,7 @@ dependencies = [
  "dirs",
  "futures",
  "libc",
+ "nix 0.29.0",
  "num_cpus",
  "rmcp 1.5.0",
  "serde",
@@ -4119,6 +4123,18 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
@@ -4878,7 +4894,7 @@ checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
- "nix",
+ "nix 0.31.2",
  "tokio",
  "tracing",
  "windows 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ exclude = ["crates/legacy/universal-tool-examples", "vendor"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+nix = { version = "0.29", features = ["signal", "process"] }
 thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"

--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,14 @@ These items have dependencies and should be done in order.
 
 ## To classify/investigate:
 
+- TODO(2): ENG-762 follow-up — add Node/NAPI abort-signal propagation so JS callers can drive `ToolContext` cancellation instead of always using `ToolContext::default()`.
+- TODO(2): ENG-762 follow-up — define mutation-tool cancellation semantics beyond local post-commit monitoring, including whether/when remote rollback is possible.
+- TODO(2): ENG-762 follow-up — have orchestrator monitoring call OpenCode `sessions().abort()` once the API contract and side effects are clearly defined.
+- TODO(2): ENG-762 follow-up — adopt cancellation for `cli_just_search` if the subprocess helper shape remains stable.
+- TODO(2): ENG-762 follow-up — adopt cancellation for remaining blocking-style tools such as `thoughts_get_repo_refs` and `review_diff_snapshot`.
+- TODO(2): ENG-762 follow-up — add Windows-specific process-group/process-tree handling for `claudecode-rs`.
+- TODO(2): ENG-762 follow-up — revisit `[lints] workspace = true` rollout for `agentic-tools-core`, `agentic-tools-mcp`, `claudecode`, and `gpt5_reasoner` after unrelated clippy cleanup is separated from cancellation work.
+
 ### CLAUDE.md cargo commands → just commands
 The xtask autogen system generates raw cargo commands in per-crate CLAUDE.md files (`crates/meta/xtask/src/claude.rs:183-196`), but our primary agents don't use bash and the root CLAUDE.md already documents the preferred `just crate-*` commands. This creates inconsistency where per-crate docs show cargo commands while root docs show just commands. Update xtask to generate:
 - `just crate-check <crate>` instead of `cargo fmt -p ... && cargo clippy -p ...`

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -89,6 +89,13 @@ impl RunOutcome {
     }
 }
 
+async fn abort_command_task(task: &mut Option<JoinHandle<Result<(), String>>>) {
+    if let Some(handle) = task.take() {
+        handle.abort();
+        let _ = handle.await;
+    }
+}
+
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
     serde_json::to_value(request)
         .unwrap_or_else(|error| serde_json::json!({"serialization_error": error.to_string()}))
@@ -306,7 +313,11 @@ impl OrchestratorRunTool {
         }
     }
 
-    async fn run_impl_outcome(&self, input: OrchestratorRunInput) -> Result<RunOutcome, ToolError> {
+    async fn run_impl_outcome(
+        &self,
+        input: OrchestratorRunInput,
+        ctx: &ToolContext,
+    ) -> Result<RunOutcome, ToolError> {
         // Input validation
         if input.session_id.is_none() && input.message.is_none() && input.command.is_none() {
             return Err(ToolError::InvalidInput(
@@ -582,6 +593,11 @@ impl OrchestratorRunTool {
             let command_task_active = command_task.is_some();
 
             tokio::select! {
+                () = ctx.cancelled() => {
+                    abort_command_task(&mut command_task).await;
+                    return Err(ToolError::cancelled(None));
+                }
+
                 maybe_event = subscription.recv(), if sse_active => {
                     let Some(event) = maybe_event else {
                         // SSE stream closed - this can happen due to network issues,
@@ -924,12 +940,13 @@ Examples:
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let this = self.clone();
+        let ctx = ctx.clone();
         Box::pin(async move {
             let timer = CallTimer::start();
-            match this.run_impl_outcome(input.clone()).await {
+            match this.run_impl_outcome(input.clone(), &ctx).await {
                 Ok(outcome) => {
                     log_tool_success(
                         &timer,
@@ -1361,9 +1378,10 @@ Parameters:
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let server_cell = Arc::clone(&self.server);
+        let ctx = ctx.clone();
         Box::pin(async move {
             let timer = CallTimer::start();
             let request = input.clone();
@@ -1478,12 +1496,15 @@ Parameters:
                 let run_tool = OrchestratorRunTool::new(Arc::clone(&server_cell));
                 let wait_for_activity = (!is_reject).then_some(true);
                 let outcome = run_tool
-                    .run_impl_outcome(OrchestratorRunInput {
-                        session_id: Some(input.session_id),
-                        command: None,
-                        message: None,
-                        wait_for_activity,
-                    })
+                    .run_impl_outcome(
+                        OrchestratorRunInput {
+                            session_id: Some(input.session_id),
+                            command: None,
+                            message: None,
+                            wait_for_activity,
+                        },
+                        &ctx,
+                    )
                     .await?;
                 let mut out = outcome.output;
 
@@ -1563,9 +1584,10 @@ Parameters:
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let server_cell = Arc::clone(&self.server);
+        let ctx = ctx.clone();
         Box::pin(async move {
             let timer = CallTimer::start();
             let request = input.clone();
@@ -1657,7 +1679,7 @@ Parameters:
                             command: None,
                             message: None,
                             wait_for_activity: Some(true),
-                        })
+                        }, &ctx)
                         .await?;
                     Ok((outcome.output, outcome.log_meta))
                 }
@@ -1672,7 +1694,7 @@ Parameters:
                             command: None,
                             message: None,
                             wait_for_activity: None,
-                        })
+                        }, &ctx)
                         .await?;
                     Ok((outcome.output, outcome.log_meta))
                 }

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -1,0 +1,176 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod support;
+
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
+use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
+use opencode_orchestrator_mcp::tools::RespondPermissionTool;
+use opencode_orchestrator_mcp::types::OrchestratorRunInput;
+use opencode_orchestrator_mcp::types::PermissionReply;
+use opencode_orchestrator_mcp::types::RespondPermissionInput;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::matchers::path_regex;
+
+use support::SequenceResponder;
+use support::permission_fixture;
+use support::session_fixture;
+use support::status_v2_busy;
+use support::test_orchestrator_server;
+
+#[tokio::test]
+async fn run_returns_cancelled_when_request_context_is_cancelled() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = "cancel-run";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{session_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(session_id)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{session_id}/command")))
+        .respond_with(ResponseTemplate::new(204).set_delay(Duration::from_secs(30)))
+        .mount(&mock)
+        .await;
+
+    let ctx = ToolContext::default();
+    let cancel = ctx.cancellation_token();
+    let handle = tokio::spawn(async move {
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(session_id.into()),
+                command: Some("research".into()),
+                message: Some("test".into()),
+                wait_for_activity: None,
+            },
+            &ctx,
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+
+    let result = timeout(Duration::from_secs(2), handle)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        result,
+        Err(agentic_tools_core::ToolError::Cancelled { .. })
+    ));
+}
+
+#[tokio::test]
+async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock);
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let session_id = "cancel-perm";
+    let permission_id = "perm-1";
+
+    let permission_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            permission_id,
+            session_id,
+            "write",
+            &["src/**"]
+        ),])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(permission_seq)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{session_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(session_id)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let ctx = ToolContext::default();
+    let cancel = ctx.cancellation_token();
+    let handle = tokio::spawn(async move {
+        tool.call(
+            RespondPermissionInput {
+                session_id: session_id.into(),
+                permission_request_id: Some(permission_id.into()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ctx,
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+
+    let result = timeout(Duration::from_secs(2), handle)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        result,
+        Err(agentic_tools_core::ToolError::Cancelled { .. })
+    ));
+}

--- a/crates/agentic-tools/core/Cargo.toml
+++ b/crates/agentic-tools/core/Cargo.toml
@@ -15,6 +15,9 @@ schemars = { workspace = true }
 thiserror = { workspace = true }
 json-patch = "4"
 rmcp = { workspace = true, features = ["server", "transport-io"] }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
 
 [features]
 default = []
@@ -25,7 +28,6 @@ version = "0.3"
 optional = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
 
 [package.metadata.repo]
 role = "lib"

--- a/crates/agentic-tools/core/src/context.rs
+++ b/crates/agentic-tools/core/src/context.rs
@@ -1,21 +1,146 @@
 //! Tool execution context.
 
+use crate::ToolError;
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+use tokio_util::sync::WaitForCancellationFutureOwned;
+
 /// Context passed to tool executions.
 ///
-/// This struct is extensible for future needs like:
-/// - Cancellation tokens
-/// - Workspace/environment info
-/// - Tracing/spans
-/// - Request metadata
-#[derive(Clone, Default, Debug)]
+/// MCP-backed tool calls receive a request-scoped cancellation token through this
+/// context. Non-MCP callers that construct [`ToolContext::default`] or
+/// [`ToolContext::new`] receive a never-cancelled context so existing direct,
+/// native, and NAPI entrypoints remain source-compatible.
+///
+/// Tool authors should prefer these helpers instead of wiring cancellation by hand:
+/// - [`ToolContext::run_cancellable`] for a single async operation that should abort
+///   promptly when the request is cancelled.
+/// - [`ToolContext::cancelled`] when cancellation must participate in a larger
+///   `tokio::select!`.
+/// - [`ToolContext::is_cancelled`] for quick boundary checks before starting more work.
+/// - [`ToolContext::cancellation_token`] when an owned token clone must cross `.await`
+///   boundaries inside a `BoxFuture<'static>` implementation.
+///
+/// Cancellation maps to [`ToolError::Cancelled`]. Returning that error means the tool
+/// stopped because the caller cancelled the request, not because the tool failed.
+///
+/// For subprocess-managing tools, request cancellation should trigger explicit cleanup
+/// before returning. Dropping a future remains a backstop, not the primary cooperative
+/// cleanup path.
+#[derive(Clone, Debug)]
 pub struct ToolContext {
-    // Extensible: add cancellation, workspace, env, tracing, etc.
-    _private: (),
+    cancel: CancellationToken,
+}
+
+impl Default for ToolContext {
+    fn default() -> Self {
+        Self::with_cancel(CancellationToken::new())
+    }
 }
 
 impl ToolContext {
     /// Create a new default context.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a context backed by the supplied cancellation token.
+    pub fn with_cancel(cancel: CancellationToken) -> Self {
+        Self { cancel }
+    }
+
+    /// Clone the request cancellation token for use across `.await` boundaries.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Return an owned future that resolves when the request is cancelled.
+    pub fn cancelled(&self) -> WaitForCancellationFutureOwned {
+        self.cancel.clone().cancelled_owned()
+    }
+
+    /// Check whether the request has already been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Run an async operation that should stop promptly on request cancellation.
+    pub async fn run_cancellable<F, T, E>(&self, fut: F) -> Result<T, ToolError>
+    where
+        F: Future<Output = Result<T, E>>,
+        E: Into<ToolError>,
+    {
+        tokio::select! {
+            _ = self.cancelled() => {
+                tracing::info!("tool request cancelled during run_cancellable");
+                Err(ToolError::cancelled(None))
+            }
+            result = fut => result.map_err(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::Duration;
+    use tokio::time::sleep;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn default_context_is_never_cancelled() {
+        let ctx = ToolContext::default();
+
+        assert!(!ctx.is_cancelled());
+        assert!(
+            timeout(Duration::from_millis(25), ctx.cancelled())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn with_cancel_propagates_cancellation() {
+        let cancel = CancellationToken::new();
+        let ctx = ToolContext::with_cancel(cancel.clone());
+
+        cancel.cancel();
+        ctx.cancelled().await;
+
+        assert!(ctx.is_cancelled());
+        assert!(ctx.cancellation_token().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn run_cancellable_returns_inner_success() {
+        let ctx = ToolContext::default();
+
+        let result = ctx
+            .run_cancellable(async { Ok::<_, ToolError>("done") })
+            .await;
+
+        assert!(matches!(result, Ok("done")));
+    }
+
+    #[tokio::test]
+    async fn run_cancellable_returns_cancelled_when_request_is_cancelled() {
+        let cancel = CancellationToken::new();
+        let ctx = ToolContext::with_cancel(cancel.clone());
+
+        let canceller = tokio::spawn(async move {
+            sleep(Duration::from_millis(25)).await;
+            cancel.cancel();
+        });
+
+        let result = ctx
+            .run_cancellable(async {
+                sleep(Duration::from_secs(5)).await;
+                Ok::<(), ToolError>(())
+            })
+            .await;
+
+        let join_result = canceller.await;
+        assert!(join_result.is_ok());
+        assert!(matches!(result, Err(ToolError::Cancelled { reason: None })));
     }
 }

--- a/crates/agentic-tools/core/src/error.rs
+++ b/crates/agentic-tools/core/src/error.rs
@@ -24,6 +24,18 @@ pub enum ToolError {
     /// Requested resource not found.
     #[error("not found: {0}")]
     NotFound(String),
+
+    /// Tool execution stopped because the caller cancelled the request.
+    #[error(
+        "cancelled{}",
+        .reason
+            .as_deref()
+            .map_or_else(String::new, |reason| format!(": {reason}"))
+    )]
+    Cancelled {
+        /// Optional detail about the cancellation reason.
+        reason: Option<String>,
+    },
 }
 
 impl ToolError {
@@ -50,5 +62,10 @@ impl ToolError {
     /// Create a permission denied error.
     pub fn permission<S: ToString>(s: S) -> Self {
         ToolError::Permission(s.to_string())
+    }
+
+    /// Create a cancelled error.
+    pub fn cancelled(reason: Option<String>) -> Self {
+        ToolError::Cancelled { reason }
     }
 }

--- a/crates/agentic-tools/mcp/Cargo.toml
+++ b/crates/agentic-tools/mcp/Cargo.toml
@@ -14,7 +14,11 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 futures = "0.3"
+
+[dev-dependencies]
+rmcp = { workspace = true, features = ["client", "server", "transport-io"] }
 
 [package.metadata.repo]
 role = "lib"

--- a/crates/agentic-tools/mcp/src/server.rs
+++ b/crates/agentic-tools/mcp/src/server.rs
@@ -1,6 +1,7 @@
 //! MCP server handler backed by ToolRegistry.
 
 use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
 use agentic_tools_core::ToolRegistry;
 use agentic_tools_core::fmt::TextOptions;
 use agentic_tools_core::fmt::fallback_text_from_json;
@@ -202,7 +203,7 @@ impl ServerHandler for RegistryServer {
     fn call_tool(
         &self,
         req: m::CallToolRequestParams,
-        _ctx: RequestContext<RoleServer>,
+        request_context: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<m::CallToolResult, m::ErrorData>> + Send + '_
     {
         async move {
@@ -214,14 +215,21 @@ impl ServerHandler for RegistryServer {
             }
 
             let args = serde_json::Value::Object(req.arguments.unwrap_or_default());
-            let ctx = ToolContext::default();
+            let ctx = ToolContext::with_cancel(request_context.ct.child_token());
             let text_opts = self.text_options.clone();
 
-            match self
+            tracing::info!(tool = %req.name, "tool dispatch started");
+
+            let dispatch_result = self
                 .registry
                 .dispatch_json_formatted(&req.name, args, &ctx, &text_opts)
-                .await
-            {
+                .await;
+
+            if matches!(&dispatch_result, Err(ToolError::Cancelled { .. })) || ctx.is_cancelled() {
+                tracing::info!(tool = %req.name, "tool dispatch exiting after cancellation");
+            }
+
+            match dispatch_result {
                 Ok(res) => {
                     let text = res
                         .text

--- a/crates/agentic-tools/mcp/tests/integration.rs
+++ b/crates/agentic-tools/mcp/tests/integration.rs
@@ -11,11 +11,17 @@ use agentic_tools_core::ToolRegistry;
 use agentic_tools_core::fmt::TextOptions;
 use agentic_tools_mcp::OutputMode;
 use agentic_tools_mcp::RegistryServer;
+use agentic_tools_mcp::ServerHandler;
 use futures::future::BoxFuture;
+use rmcp::ServiceExt;
+use rmcp::model as m;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::time::Duration;
+use tokio::time::timeout;
 
 // =============================================================================
 // Test Tool Definitions
@@ -70,6 +76,47 @@ struct CalculateInput {
     a: i32,
     b: i32,
     operation: String,
+}
+
+#[derive(Clone)]
+struct CancellationProbeTool {
+    started: Arc<Notify>,
+    observed_cancel: Arc<Notify>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct CancellationProbeInput {}
+
+struct TestClient;
+
+impl rmcp::ClientHandler for TestClient {}
+
+impl Tool for CancellationProbeTool {
+    type Input = CancellationProbeInput;
+    type Output = String;
+    const NAME: &'static str = "cancellation_probe";
+    const DESCRIPTION: &'static str = "Waits for rmcp request cancellation";
+
+    fn call(
+        &self,
+        _input: Self::Input,
+        ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let started = Arc::clone(&self.started);
+        let observed_cancel = Arc::clone(&self.observed_cancel);
+        let ctx = ctx.clone();
+
+        Box::pin(async move {
+            started.notify_one();
+            ctx.cancelled().await;
+
+            if ctx.is_cancelled() {
+                observed_cancel.notify_one();
+            }
+
+            Err(ToolError::cancelled(None))
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -368,4 +415,71 @@ async fn test_dispatch_json_formatted_fallback_for_unknown_tool() {
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Unknown tool"));
+}
+
+#[tokio::test]
+async fn test_rmcp_cancellation_flips_tool_context_mid_call() -> Result<(), String> {
+    let started = Arc::new(Notify::new());
+    let observed_cancel = Arc::new(Notify::new());
+    let server = Arc::new(RegistryServer::new(Arc::new(
+        ToolRegistry::builder()
+            .register::<CancellationProbeTool, ()>(CancellationProbeTool {
+                started: Arc::clone(&started),
+                observed_cancel: Arc::clone(&observed_cancel),
+            })
+            .finish(),
+    )));
+
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let (running, client) = tokio::try_join!(
+        async {
+            server
+                .clone()
+                .serve(server_transport)
+                .await
+                .map_err(|err| err.to_string())
+        },
+        async {
+            TestClient
+                .serve(client_transport)
+                .await
+                .map_err(|err| err.to_string())
+        },
+    )?;
+
+    let request_context =
+        rmcp::service::RequestContext::new(m::NumberOrString::Number(1), running.peer().clone());
+    let cancel = request_context.ct.clone();
+    let server_for_call = Arc::clone(&server);
+    let call_task = tokio::spawn(async move {
+        server_for_call
+            .call_tool(
+                m::CallToolRequestParams::new("cancellation_probe"),
+                request_context,
+            )
+            .await
+            .map_err(|err| err.to_string())
+    });
+
+    timeout(Duration::from_secs(5), started.notified())
+        .await
+        .map_err(|_| "cancellation probe never started".to_string())?;
+
+    cancel.cancel();
+
+    timeout(Duration::from_secs(5), observed_cancel.notified())
+        .await
+        .map_err(|_| "tool context never observed cancellation".to_string())?;
+
+    let tool_result = call_task.await.map_err(|err| err.to_string())??;
+
+    assert_eq!(tool_result.is_error, Some(true));
+    let content_json =
+        serde_json::to_string(&tool_result.content).map_err(|err| err.to_string())?;
+    assert!(content_json.contains("cancelled"));
+
+    drop(client);
+    drop(running);
+
+    Ok(())
 }

--- a/crates/services/claudecode-rs/Cargo.toml
+++ b/crates/services/claudecode-rs/Cargo.toml
@@ -16,8 +16,9 @@ dist = false
 
 [dependencies]
 # Core async runtime
-tokio = { version = "1.40", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+nix = { workspace = true }
 
 # Async traits and utilities
 futures = "0.3"

--- a/crates/services/claudecode-rs/src/bin/fake_claude.rs
+++ b/crates/services/claudecode-rs/src/bin/fake_claude.rs
@@ -1,0 +1,132 @@
+use claudecode::types::Event;
+use claudecode::types::Result as ClaudeResult;
+use claudecode::types::ResultEvent;
+use claudecode::types::SystemEvent;
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+use tokio::signal::unix::SignalKind;
+
+#[derive(serde::Serialize)]
+struct PidInfo {
+    parent_pid: u32,
+    child_pid: u32,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let output_format = arg_value(&args, "--output-format").unwrap_or_else(|| "text".into());
+    let query = args
+        .iter()
+        .position(|arg| arg == "--")
+        .and_then(|idx| args.get(idx + 1))
+        .cloned()
+        .unwrap_or_default();
+    let should_hang_on_term = query.contains("[hang]");
+
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg("trap '' TERM INT; while :; do sleep 1; done")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    if let Some(pid_file) = env::var_os("FAKE_CLAUDE_PID_FILE") {
+        let info = PidInfo {
+            parent_pid: std::process::id(),
+            child_pid: child.id(),
+        };
+        std::fs::write(PathBuf::from(pid_file), serde_json::to_vec(&info)?)?;
+    }
+
+    emit_output(&output_format).await?;
+
+    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())?;
+    let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
+    loop {
+        tokio::select! {
+            _ = sigterm.recv() => {
+                if !should_hang_on_term {
+                    break;
+                }
+            }
+            _ = sigint.recv() => {
+                if !should_hang_on_term {
+                    break;
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn arg_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|window| window[0] == flag)
+        .map(|window| window[1].clone())
+}
+
+async fn emit_output(output_format: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stdout = tokio::io::stdout();
+
+    match output_format {
+        "json" => {
+            let result = ClaudeResult {
+                result_type: Some("result".into()),
+                content: Some("fake json output".into()),
+                result: Some("fake json output".into()),
+                is_error: false,
+                session_id: Some("fake-session".into()),
+                ..ClaudeResult::default()
+            };
+            stdout
+                .write_all(serde_json::to_string(&result)?.as_bytes())
+                .await?;
+        }
+        "stream-json" => {
+            let system = Event::System(SystemEvent {
+                session_id: "fake-session".into(),
+                subtype: Some("init".into()),
+                cwd: None,
+                model: Some("fake-model".into()),
+                permission_mode: None,
+                api_key_source: None,
+                tools: None,
+                mcp_servers: None,
+            });
+            let result = Event::Result(ResultEvent {
+                session_id: "fake-session".into(),
+                result: Some("fake stream output".into()),
+                is_error: false,
+                error: None,
+                total_cost_usd: None,
+                duration_ms: Some(1),
+                duration_api_ms: Some(1),
+                num_turns: Some(1),
+                usage: None,
+            });
+            stdout
+                .write_all(
+                    format!(
+                        "{}\n{}\n",
+                        serde_json::to_string(&system)?,
+                        serde_json::to_string(&result)?
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+        }
+        _ => {
+            stdout.write_all(b"fake text output").await?;
+        }
+    }
+
+    stdout.flush().await?;
+    Ok(())
+}

--- a/crates/services/claudecode-rs/src/bin/fake_claude.rs
+++ b/crates/services/claudecode-rs/src/bin/fake_claude.rs
@@ -4,6 +4,7 @@ use claudecode::types::ResultEvent;
 use claudecode::types::SystemEvent;
 use std::env;
 use std::path::PathBuf;
+use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
@@ -13,6 +14,36 @@ use tokio::signal::unix::SignalKind;
 struct PidInfo {
     parent_pid: u32,
     child_pid: u32,
+}
+
+struct HelperChild {
+    child: Option<Child>,
+}
+
+impl HelperChild {
+    fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("helper child must exist while pid is queried")
+            .id()
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for HelperChild {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
 }
 
 #[tokio::main]
@@ -34,6 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+    let child = HelperChild::new(child);
 
     if let Some(pid_file) = env::var_os("FAKE_CLAUDE_PID_FILE") {
         let info = PidInfo {
@@ -42,6 +74,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         std::fs::write(PathBuf::from(pid_file), serde_json::to_vec(&info)?)?;
     }
+
+    maybe_force_error_after_spawn()?;
 
     emit_output(&output_format).await?;
 
@@ -61,6 +95,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {}
         }
+    }
+
+    Ok(())
+}
+
+fn maybe_force_error_after_spawn() -> Result<(), Box<dyn std::error::Error>> {
+    if env::var_os("FAKE_CLAUDE_FORCE_ERROR_AFTER_SPAWN").is_some() {
+        return Err(std::io::Error::other("forced fake_claude error after helper spawn").into());
     }
 
     Ok(())

--- a/crates/services/claudecode-rs/src/process.rs
+++ b/crates/services/claudecode-rs/src/process.rs
@@ -1,18 +1,40 @@
 use crate::error::ClaudeError;
 use crate::error::Result;
+use nix::errno::Errno;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::BufReader;
 use tokio::process::Child;
 use tokio::process::Command;
+use tokio::sync::Mutex;
 use which::which;
 
+pub(crate) const KILL_GRACE: Duration = Duration::from_millis(250);
+
 pub struct ProcessHandle {
-    child: Child,
+    child: Arc<Mutex<Child>>,
     stdout_reader: Option<BufReader<tokio::process::ChildStdout>>,
     stderr_reader: Option<BufReader<tokio::process::ChildStderr>>,
+}
+
+#[derive(Clone)]
+pub struct KillHandle {
+    pid: i32,
+}
+
+impl std::fmt::Debug for KillHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KillHandle")
+            .field("pid", &self.pid)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ProcessHandle {
@@ -35,6 +57,12 @@ impl ProcessHandle {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+
+        #[cfg(unix)]
+        {
+            // TODO(2): add Windows-equivalent process-tree handling.
+            cmd.process_group(0);
+        }
 
         // Set working directory if specified
         if let Some(dir) = working_dir {
@@ -71,27 +99,43 @@ impl ProcessHandle {
             })?;
 
         Ok(ProcessHandle {
-            child,
+            child: Arc::new(Mutex::new(child)),
             stdout_reader: Some(BufReader::new(stdout)),
             stderr_reader: Some(BufReader::new(stderr)),
         })
     }
 
-    pub async fn wait(mut self) -> Result<std::process::ExitStatus> {
-        Ok(self.child.wait().await?)
+    pub async fn wait(self) -> Result<std::process::ExitStatus> {
+        let mut child = self.child.lock().await;
+        Ok(child.wait().await?)
     }
 
     pub async fn kill(&mut self) -> Result<()> {
-        self.child.kill().await?;
+        let mut child = self.child.lock().await;
+        child.kill().await?;
         Ok(())
     }
 
     pub fn id(&self) -> Option<u32> {
-        self.child.id()
+        self.child.try_lock().ok().and_then(|child| child.id())
     }
 
     pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
-        Ok(self.child.try_wait()?)
+        let mut child = self
+            .child
+            .try_lock()
+            .map_err(|_| ClaudeError::SessionError {
+                message: "Process wait already in progress".to_string(),
+            })?;
+        Ok(child.try_wait()?)
+    }
+
+    pub fn kill_handle(&self) -> Result<KillHandle> {
+        let pid = self.id().ok_or_else(|| ClaudeError::SessionError {
+            message: "Process not found or already terminated".to_string(),
+        })?;
+
+        Ok(KillHandle { pid: pid as i32 })
     }
 
     pub(crate) fn take_stdout(&mut self) -> Option<BufReader<tokio::process::ChildStdout>> {
@@ -100,6 +144,41 @@ impl ProcessHandle {
 
     pub(crate) fn take_stderr(&mut self) -> Option<BufReader<tokio::process::ChildStderr>> {
         self.stderr_reader.take()
+    }
+}
+
+impl KillHandle {
+    pub fn signal(&self, sig: Signal) -> nix::Result<()> {
+        signal_process_group(self.pid, sig)
+    }
+
+    pub async fn graceful_terminate(&self) -> Result<()> {
+        tracing::info!(pid = self.pid, "terminating Claude process group");
+        self.signal(Signal::SIGTERM).map_err(nix_to_claude_error)?;
+
+        tokio::time::sleep(KILL_GRACE).await;
+
+        self.kill_now().map_err(nix_to_claude_error)?;
+
+        Ok(())
+    }
+
+    pub fn kill_now(&self) -> nix::Result<()> {
+        tracing::info!(pid = self.pid, "force killing Claude process group");
+        self.signal(Signal::SIGKILL)
+    }
+}
+
+fn nix_to_claude_error(err: Errno) -> ClaudeError {
+    ClaudeError::SessionError {
+        message: format!("Process-group signal failed: {err}"),
+    }
+}
+
+fn signal_process_group(pid: i32, sig: Signal) -> nix::Result<()> {
+    match signal::killpg(Pid::from_raw(pid), sig) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(err) => Err(err),
     }
 }
 

--- a/crates/services/claudecode-rs/src/session.rs
+++ b/crates/services/claudecode-rs/src/session.rs
@@ -13,6 +13,8 @@ use chrono::Utc;
 use futures::StreamExt;
 use nix::sys::signal::Signal;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::io::AsyncBufReadExt;
@@ -39,6 +41,7 @@ pub struct Session {
     // Background tasks
     worker_task: std::sync::Mutex<Option<JoinHandle<()>>>,
     stderr_task: std::sync::Mutex<Option<JoinHandle<()>>>,
+    process_group_owned: Arc<AtomicBool>,
 
     // Result storage
     result: Arc<RwLock<Option<ClaudeResult>>>,
@@ -70,6 +73,7 @@ impl Session {
         let kill = process.kill_handle()?;
         let result = Arc::new(RwLock::new(None));
         let error = Arc::new(RwLock::new(None));
+        let process_group_owned = Arc::new(AtomicBool::new(true));
 
         let mut session = Self {
             id,
@@ -80,6 +84,7 @@ impl Session {
             events,
             worker_task: std::sync::Mutex::new(None),
             stderr_task: std::sync::Mutex::new(None),
+            process_group_owned,
             result: result.clone(),
             error: error.clone(),
             _mcp_temp_file: None,
@@ -94,6 +99,7 @@ impl Session {
     async fn start_tasks(&mut self, mut process: ProcessHandle) -> Result<()> {
         let result = self.result.clone();
         let error = self.error.clone();
+        let process_group_owned = self.process_group_owned.clone();
 
         match self.config.output_format {
             OutputFormat::StreamingJson => {
@@ -113,10 +119,16 @@ impl Session {
                 });
                 Self::store_task(&self.stderr_task, stderr_task)?;
 
+                let process_group_owned = process_group_owned.clone();
                 let worker_task = tokio::spawn(async move {
-                    if let Err(e) =
-                        Self::handle_streaming_json(process, events_tx, result_clone, error.clone())
-                            .await
+                    if let Err(e) = Self::handle_streaming_json(
+                        process,
+                        events_tx,
+                        result_clone,
+                        error.clone(),
+                        process_group_owned,
+                    )
+                    .await
                     {
                         error.write().await.replace(e);
                     }
@@ -124,8 +136,9 @@ impl Session {
                 Self::store_task(&self.worker_task, worker_task)?;
             }
             OutputFormat::Json => {
+                let process_group_owned = process_group_owned.clone();
                 let worker_task = tokio::spawn(async move {
-                    match Self::handle_json(process, error.clone()).await {
+                    match Self::handle_json(process, error.clone(), process_group_owned).await {
                         Ok(r) => {
                             result.write().await.replace(r);
                         }
@@ -137,8 +150,9 @@ impl Session {
                 Self::store_task(&self.worker_task, worker_task)?;
             }
             OutputFormat::Text => {
+                let process_group_owned = process_group_owned.clone();
                 let worker_task = tokio::spawn(async move {
-                    match Self::handle_text(process, error.clone()).await {
+                    match Self::handle_text(process, error.clone(), process_group_owned).await {
                         Ok(r) => {
                             result.write().await.replace(r);
                         }
@@ -219,6 +233,7 @@ impl Session {
         events_tx: mpsc::UnboundedSender<Event>,
         result_arc: Arc<RwLock<Option<ClaudeResult>>>,
         error: Arc<RwLock<Option<ClaudeError>>>,
+        process_group_owned: Arc<AtomicBool>,
     ) -> Result<()> {
         let stdout = process
             .take_stdout()
@@ -272,6 +287,7 @@ impl Session {
 
         // Wait for process to complete
         let status = process.wait().await?;
+        process_group_owned.store(false, Ordering::Release);
         if !status.success() {
             let code = status.code().unwrap_or(-1);
             if error.read().await.is_none() {
@@ -288,6 +304,7 @@ impl Session {
     async fn handle_json(
         mut process: ProcessHandle,
         _error: Arc<RwLock<Option<ClaudeError>>>,
+        process_group_owned: Arc<AtomicBool>,
     ) -> Result<ClaudeResult> {
         let stdout = process
             .take_stdout()
@@ -306,6 +323,7 @@ impl Session {
 
         // Wait for process
         let status = process.wait().await?;
+        process_group_owned.store(false, Ordering::Release);
         if !status.success() && !result.is_error {
             return Err(ClaudeError::ProcessFailed {
                 code: status.code().unwrap_or(-1),
@@ -319,6 +337,7 @@ impl Session {
     async fn handle_text(
         mut process: ProcessHandle,
         _error: Arc<RwLock<Option<ClaudeError>>>,
+        process_group_owned: Arc<AtomicBool>,
     ) -> Result<ClaudeResult> {
         let stdout = process
             .take_stdout()
@@ -337,6 +356,7 @@ impl Session {
 
         // Wait for process
         let status = process.wait().await?;
+        process_group_owned.store(false, Ordering::Release);
         if !status.success() && !result.is_error {
             return Err(ClaudeError::ProcessFailed {
                 code: status.code().unwrap_or(-1),
@@ -373,6 +393,7 @@ impl Session {
     pub async fn cancel(&self) -> Result<()> {
         info!(session_id = %self.id, "cancelling Claude session");
         self.kill.graceful_terminate().await?;
+        self.process_group_owned.store(false, Ordering::Release);
 
         let worker_task = Self::take_task(&self.worker_task)?;
         let stderr_task = Self::take_task(&self.stderr_task)?;
@@ -431,7 +452,9 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        let _ = self.kill.kill_now();
+        if self.process_group_owned.load(Ordering::Acquire) {
+            let _ = self.kill.kill_now();
+        }
 
         if let Ok(mut worker_task) = self.worker_task.lock()
             && let Some(task) = worker_task.take()
@@ -486,6 +509,7 @@ mod tests {
             events: None,
             worker_task: std::sync::Mutex::new(None),
             stderr_task: std::sync::Mutex::new(None),
+            process_group_owned: Arc::new(AtomicBool::new(false)),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(ClaudeError::ProcessFailed {
                 code: 1,
@@ -522,6 +546,7 @@ mod tests {
             events: None,
             worker_task: std::sync::Mutex::new(None),
             stderr_task: std::sync::Mutex::new(None),
+            process_group_owned: Arc::new(AtomicBool::new(false)),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(ClaudeError::SessionError {
                 message: "custom session error".into(),
@@ -555,6 +580,7 @@ mod tests {
             events: None,
             worker_task: std::sync::Mutex::new(None),
             stderr_task: std::sync::Mutex::new(None),
+            process_group_owned: Arc::new(AtomicBool::new(false)),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(io.into()))),
             _mcp_temp_file: None,
@@ -588,6 +614,7 @@ mod tests {
             events: None,
             worker_task: std::sync::Mutex::new(None),
             stderr_task: std::sync::Mutex::new(None),
+            process_group_owned: Arc::new(AtomicBool::new(false)),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(None)),
             _mcp_temp_file: None,
@@ -598,5 +625,45 @@ mod tests {
             ClaudeError::SessionError { message } => assert_eq!(message, "No result available"),
             other => panic!("expected SessionError, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn drop_skips_kill_when_process_group_is_released() {
+        let cfg = SessionConfig::builder("test".to_string())
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let mut process = ProcessHandle::spawn(
+            Path::new("/bin/sh"),
+            vec!["-c".to_string(), "sleep 5".to_string()],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let kill = process.kill_handle().unwrap();
+
+        let session = Session {
+            id: "test".into(),
+            config: cfg,
+            start_time: Utc::now(),
+            kill,
+            events_tx: None,
+            events: None,
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
+            process_group_owned: Arc::new(AtomicBool::new(false)),
+            result: Arc::new(RwLock::new(None)),
+            error: Arc::new(RwLock::new(None)),
+            _mcp_temp_file: None,
+        };
+
+        drop(session);
+
+        assert!(process.try_wait().unwrap().is_none());
+
+        process.kill().await.unwrap();
+        process.wait().await.unwrap();
     }
 }

--- a/crates/services/claudecode-rs/src/session.rs
+++ b/crates/services/claudecode-rs/src/session.rs
@@ -1,6 +1,7 @@
 use crate::config::SessionConfig;
 use crate::error::ClaudeError;
 use crate::error::Result;
+use crate::process::KillHandle;
 use crate::process::ProcessHandle;
 use crate::stream::JsonStreamParser;
 use crate::stream::SingleJsonParser;
@@ -10,31 +11,34 @@ use crate::types::OutputFormat;
 use crate::types::Result as ClaudeResult;
 use chrono::Utc;
 use futures::StreamExt;
+use nix::sys::signal::Signal;
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::debug;
+use tracing::info;
 use tracing::warn;
 use uuid::Uuid;
+
+const TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub struct Session {
     id: String,
     config: SessionConfig,
     start_time: chrono::DateTime<Utc>,
-
-    // Process handle
-    process: Arc<Mutex<Option<ProcessHandle>>>,
+    kill: KillHandle,
 
     // Event channel for streaming
     events_tx: Option<mpsc::UnboundedSender<Event>>,
     events: Option<mpsc::UnboundedReceiver<Event>>,
 
     // Background tasks
-    tasks: Vec<JoinHandle<()>>,
+    worker_task: std::sync::Mutex<Option<JoinHandle<()>>>,
+    stderr_task: std::sync::Mutex<Option<JoinHandle<()>>>,
 
     // Result storage
     result: Arc<RwLock<Option<ClaudeResult>>>,
@@ -63,7 +67,7 @@ impl Session {
             _ => (None, None),
         };
 
-        let process = Arc::new(Mutex::new(Some(process)));
+        let kill = process.kill_handle()?;
         let result = Arc::new(RwLock::new(None));
         let error = Arc::new(RwLock::new(None));
 
@@ -71,34 +75,45 @@ impl Session {
             id,
             config: config.clone(),
             start_time: Utc::now(),
-            process: process.clone(),
+            kill,
             events_tx,
             events,
-            tasks: Vec::new(),
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
             result: result.clone(),
             error: error.clone(),
             _mcp_temp_file: None,
         };
 
         // Start background tasks based on output format
-        session.start_tasks().await?;
+        session.start_tasks(process).await?;
 
         Ok(session)
     }
 
-    async fn start_tasks(&mut self) -> Result<()> {
-        let process = self.process.clone();
+    async fn start_tasks(&mut self, mut process: ProcessHandle) -> Result<()> {
         let result = self.result.clone();
         let error = self.error.clone();
 
         match self.config.output_format {
             OutputFormat::StreamingJson => {
+                let stderr = process
+                    .take_stderr()
+                    .ok_or_else(|| ClaudeError::SessionError {
+                        message: "No stderr reader".to_string(),
+                    })?;
                 let events_tx = self
                     .events_tx
                     .take()
                     .expect("events_tx must exist for StreamingJson output format");
                 let result_clone = result.clone();
-                let task = tokio::spawn(async move {
+                let error_clone = error.clone();
+                let stderr_task = tokio::spawn(async move {
+                    Self::capture_stderr(stderr, error_clone).await;
+                });
+                Self::store_task(&self.stderr_task, stderr_task)?;
+
+                let worker_task = tokio::spawn(async move {
                     if let Err(e) =
                         Self::handle_streaming_json(process, events_tx, result_clone, error.clone())
                             .await
@@ -106,10 +121,10 @@ impl Session {
                         error.write().await.replace(e);
                     }
                 });
-                self.tasks.push(task);
+                Self::store_task(&self.worker_task, worker_task)?;
             }
             OutputFormat::Json => {
-                let task = tokio::spawn(async move {
+                let worker_task = tokio::spawn(async move {
                     match Self::handle_json(process, error.clone()).await {
                         Ok(r) => {
                             result.write().await.replace(r);
@@ -119,10 +134,10 @@ impl Session {
                         }
                     }
                 });
-                self.tasks.push(task);
+                Self::store_task(&self.worker_task, worker_task)?;
             }
             OutputFormat::Text => {
-                let task = tokio::spawn(async move {
+                let worker_task = tokio::spawn(async move {
                     match Self::handle_text(process, error.clone()).await {
                         Ok(r) => {
                             result.write().await.replace(r);
@@ -132,57 +147,84 @@ impl Session {
                         }
                     }
                 });
-                self.tasks.push(task);
+                Self::store_task(&self.worker_task, worker_task)?;
             }
         }
 
         Ok(())
     }
 
+    fn store_task(
+        slot: &std::sync::Mutex<Option<JoinHandle<()>>>,
+        task: JoinHandle<()>,
+    ) -> Result<()> {
+        let mut guard = slot.lock().map_err(|_| ClaudeError::SessionError {
+            message: "Session task mutex poisoned".to_string(),
+        })?;
+        guard.replace(task);
+        Ok(())
+    }
+
+    fn take_task(
+        slot: &std::sync::Mutex<Option<JoinHandle<()>>>,
+    ) -> Result<Option<JoinHandle<()>>> {
+        let mut guard = slot.lock().map_err(|_| ClaudeError::SessionError {
+            message: "Session task mutex poisoned".to_string(),
+        })?;
+        Ok(guard.take())
+    }
+
+    async fn await_task(task: Option<JoinHandle<()>>, label: &str) -> Result<()> {
+        if let Some(task) = task {
+            task.await.map_err(|err| ClaudeError::SessionError {
+                message: format!("{label} task failed: {err}"),
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn shutdown_task(mut task: Option<JoinHandle<()>>, label: &str) -> Result<()> {
+        if let Some(mut handle) = task.take()
+            && tokio::time::timeout(TASK_SHUTDOWN_TIMEOUT, &mut handle)
+                .await
+                .is_err()
+        {
+            warn!(task = label, "aborting stalled session task");
+            handle.abort();
+            let _ = tokio::time::timeout(TASK_SHUTDOWN_TIMEOUT, handle).await;
+        }
+        Ok(())
+    }
+
+    async fn capture_stderr(
+        stderr: tokio::io::BufReader<tokio::process::ChildStderr>,
+        error: Arc<RwLock<Option<ClaudeError>>>,
+    ) {
+        let mut stderr_content = String::new();
+        let mut lines = stderr.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            stderr_content.push_str(&line);
+            stderr_content.push('\n');
+        }
+        if !stderr_content.trim().is_empty() {
+            error.write().await.replace(ClaudeError::ProcessFailed {
+                code: -1,
+                stderr: stderr_content,
+            });
+        }
+    }
+
     async fn handle_streaming_json(
-        process: Arc<Mutex<Option<ProcessHandle>>>,
+        mut process: ProcessHandle,
         events_tx: mpsc::UnboundedSender<Event>,
         result_arc: Arc<RwLock<Option<ClaudeResult>>>,
         error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<()> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
-
         let stdout = process
             .take_stdout()
             .ok_or_else(|| ClaudeError::SessionError {
                 message: "No stdout reader".to_string(),
             })?;
-
-        let stderr = process
-            .take_stderr()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "No stderr reader".to_string(),
-            })?;
-
-        // Handle stderr in background
-        let error_clone = error.clone();
-        tokio::spawn(async move {
-            let mut stderr_content = String::new();
-            let mut lines = stderr.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                stderr_content.push_str(&line);
-                stderr_content.push('\n');
-            }
-            if !stderr_content.trim().is_empty() {
-                error_clone
-                    .write()
-                    .await
-                    .replace(ClaudeError::ProcessFailed {
-                        code: -1,
-                        stderr: stderr_content,
-                    });
-            }
-        });
 
         // Parse streaming JSON from stdout
         let parser = JsonStreamParser::new(stdout);
@@ -244,16 +286,9 @@ impl Session {
     }
 
     async fn handle_json(
-        process: Arc<Mutex<Option<ProcessHandle>>>,
+        mut process: ProcessHandle,
         _error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<ClaudeResult> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
-
         let stdout = process
             .take_stdout()
             .ok_or_else(|| ClaudeError::SessionError {
@@ -282,16 +317,9 @@ impl Session {
     }
 
     async fn handle_text(
-        process: Arc<Mutex<Option<ProcessHandle>>>,
+        mut process: ProcessHandle,
         _error: Arc<RwLock<Option<ClaudeError>>>,
     ) -> Result<ClaudeResult> {
-        let mut process_guard = process.lock().await;
-        let mut process = process_guard
-            .take()
-            .ok_or_else(|| ClaudeError::SessionError {
-                message: "Process already taken".to_string(),
-            })?;
-
         let stdout = process
             .take_stdout()
             .ok_or_else(|| ClaudeError::SessionError {
@@ -320,11 +348,12 @@ impl Session {
     }
 
     /// Wait for the session to complete and return the result
-    pub async fn wait(mut self) -> Result<ClaudeResult> {
-        // Wait for all tasks to complete
-        for task in self.tasks.drain(..) {
-            let _ = task.await;
-        }
+    pub async fn wait(&self) -> Result<ClaudeResult> {
+        let worker_task = Self::take_task(&self.worker_task)?;
+        let stderr_task = Self::take_task(&self.stderr_task)?;
+
+        Self::await_task(worker_task, "worker").await?;
+        Self::await_task(stderr_task, "stderr").await?;
 
         // Check for errors first - preserve original error variant (e.g., ProcessFailed{stderr})
         if let Some(error) = self.error.write().await.take() {
@@ -341,39 +370,33 @@ impl Session {
             })
     }
 
+    pub async fn cancel(&self) -> Result<()> {
+        info!(session_id = %self.id, "cancelling Claude session");
+        self.kill.graceful_terminate().await?;
+
+        let worker_task = Self::take_task(&self.worker_task)?;
+        let stderr_task = Self::take_task(&self.stderr_task)?;
+        Self::shutdown_task(worker_task, "worker").await?;
+        Self::shutdown_task(stderr_task, "stderr").await?;
+
+        Ok(())
+    }
+
     /// Kill the Claude process
     pub async fn kill(&mut self) -> Result<()> {
-        if let Some(mut process) = self.process.lock().await.take() {
-            process.kill().await?;
-        }
-        Ok(())
+        info!(session_id = %self.id, "force-killing Claude session");
+        self.cancel().await
     }
 
     /// Send interrupt signal to the Claude process
     ///
     /// On Unix systems, this sends SIGINT which allows graceful shutdown.
     pub async fn interrupt(&mut self) -> Result<()> {
-        if let Some(process) = self.process.lock().await.as_mut()
-            && let Some(pid) = process.id()
-        {
-            // Send SIGINT for graceful shutdown
-            unsafe {
-                let result = libc::kill(pid as i32, libc::SIGINT);
-                if result == 0 {
-                    return Ok(());
-                } else {
-                    return Err(ClaudeError::SessionError {
-                        message: format!(
-                            "Failed to send interrupt signal: {}",
-                            std::io::Error::last_os_error()
-                        ),
-                    });
-                }
-            }
-        }
-        Err(ClaudeError::SessionError {
-            message: "Process not found or already terminated".to_string(),
-        })
+        self.kill
+            .signal(Signal::SIGINT)
+            .map_err(|err| ClaudeError::SessionError {
+                message: format!("Failed to send interrupt signal: {err}"),
+            })
     }
 
     /// Get the session ID
@@ -388,12 +411,11 @@ impl Session {
 
     /// Check if session is still running
     pub async fn is_running(&self) -> bool {
-        if let Some(ref _process) = *self.process.lock().await {
-            // Process is still held, might be running
-            true
-        } else {
-            false
-        }
+        self.worker_task
+            .lock()
+            .ok()
+            .and_then(|task| task.as_ref().map(|task| !task.is_finished()))
+            .unwrap_or(false)
     }
 
     /// Take the event stream receiver
@@ -409,8 +431,17 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        // Ensure all tasks are aborted on drop
-        for task in &self.tasks {
+        let _ = self.kill.kill_now();
+
+        if let Ok(mut worker_task) = self.worker_task.lock()
+            && let Some(task) = worker_task.take()
+        {
+            task.abort();
+        }
+
+        if let Ok(mut stderr_task) = self.stderr_task.lock()
+            && let Some(task) = stderr_task.take()
+        {
             task.abort();
         }
     }
@@ -422,6 +453,20 @@ mod tests {
     use crate::config::SessionConfig;
     use crate::error::ClaudeError;
     use crate::types::OutputFormat;
+    use std::path::Path;
+
+    async fn test_kill_handle() -> KillHandle {
+        let process = ProcessHandle::spawn(
+            Path::new("/bin/sh"),
+            vec!["-c".to_string(), "exit 0".to_string()],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        process.kill_handle().unwrap()
+    }
 
     #[tokio::test]
     async fn wait_returns_processfailed_preserving_stderr() {
@@ -430,14 +475,17 @@ mod tests {
             .build()
             .unwrap();
 
+        let kill = test_kill_handle().await;
+
         let session = Session {
             id: "test".into(),
             config: cfg,
             start_time: Utc::now(),
-            process: Arc::new(Mutex::new(None)),
+            kill,
             events_tx: None,
             events: None,
-            tasks: vec![],
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(ClaudeError::ProcessFailed {
                 code: 1,
@@ -463,14 +511,17 @@ mod tests {
             .build()
             .unwrap();
 
+        let kill = test_kill_handle().await;
+
         let session = Session {
             id: "test".into(),
             config: cfg,
             start_time: Utc::now(),
-            process: Arc::new(Mutex::new(None)),
+            kill,
             events_tx: None,
             events: None,
-            tasks: vec![],
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(ClaudeError::SessionError {
                 message: "custom session error".into(),
@@ -493,15 +544,17 @@ mod tests {
             .unwrap();
 
         let io = std::io::Error::other("disk full");
+        let kill = test_kill_handle().await;
 
         let session = Session {
             id: "test".into(),
             config: cfg,
             start_time: Utc::now(),
-            process: Arc::new(Mutex::new(None)),
+            kill,
             events_tx: None,
             events: None,
-            tasks: vec![],
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(Some(io.into()))),
             _mcp_temp_file: None,
@@ -524,14 +577,17 @@ mod tests {
             .build()
             .unwrap();
 
+        let kill = test_kill_handle().await;
+
         let session = Session {
             id: "test".into(),
             config: cfg,
             start_time: Utc::now(),
-            process: Arc::new(Mutex::new(None)),
+            kill,
             events_tx: None,
             events: None,
-            tasks: vec![],
+            worker_task: std::sync::Mutex::new(None),
+            stderr_task: std::sync::Mutex::new(None),
             result: Arc::new(RwLock::new(None)),
             error: Arc::new(RwLock::new(None)),
             _mcp_temp_file: None,

--- a/crates/services/claudecode-rs/tests/lifecycle.rs
+++ b/crates/services/claudecode-rs/tests/lifecycle.rs
@@ -5,9 +5,12 @@ use nix::unistd::Pid;
 use serial_test::serial;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::time::Duration;
 use std::time::Instant;
 use tempfile::TempDir;
+use tokio::process::Child;
+use tokio::process::Command;
 
 #[derive(Debug, serde::Deserialize)]
 struct PidInfo {
@@ -31,6 +34,23 @@ fn config(output_format: OutputFormat, query: &str, pid_file: &Path) -> SessionC
         .unwrap()
 }
 
+fn spawn_fake_claude(query: &str, pid_file: &Path, force_error_after_spawn: bool) -> Child {
+    let mut cmd = Command::new(fake_claude_path());
+    cmd.arg("--output-format")
+        .arg("text")
+        .arg("--")
+        .arg(query)
+        .env("FAKE_CLAUDE_PID_FILE", pid_file.display().to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if force_error_after_spawn {
+        cmd.env("FAKE_CLAUDE_FORCE_ERROR_AFTER_SPAWN", "1");
+    }
+
+    cmd.spawn().unwrap()
+}
+
 async fn wait_for_pid_info(pid_file: &PathBuf) -> PidInfo {
     for _ in 0..100 {
         if let Ok(bytes) = tokio::fs::read(pid_file).await {
@@ -43,7 +63,12 @@ async fn wait_for_pid_info(pid_file: &PathBuf) -> PidInfo {
 
 async fn wait_for_process_exit(pid: u32) {
     for _ in 0..200 {
-        if !PathBuf::from(format!("/proc/{pid}")).exists() {
+        let exists = match nix::sys::signal::kill(Pid::from_raw(pid as i32), None) {
+            Ok(()) | Err(nix::errno::Errno::EPERM) => true,
+            Err(nix::errno::Errno::ESRCH) => false,
+            Err(_) => true,
+        };
+        if !exists {
             return;
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
@@ -81,6 +106,51 @@ async fn session_kill_works_after_worker_startup() {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     session.kill().await.unwrap();
+
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn fake_claude_reaps_helper_child_after_normal_exit() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let child = spawn_fake_claude("normal exit test", &pid_path, false);
+    let pids = wait_for_pid_info(&pid_path).await;
+
+    nix::sys::signal::kill(
+        Pid::from_raw(pids.parent_pid as i32),
+        Some(nix::sys::signal::Signal::SIGTERM),
+    )
+    .unwrap();
+
+    let output = child.wait_with_output().await.unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "fake text output"
+    );
+
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn fake_claude_reaps_helper_child_after_forced_error_exit() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let child = spawn_fake_claude("forced error test", &pid_path, true);
+    let pids = wait_for_pid_info(&pid_path).await;
+
+    let output = child.wait_with_output().await.unwrap();
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("forced fake_claude error after helper spawn")
+    );
 
     wait_for_process_exit(pids.parent_pid).await;
     wait_for_process_exit(pids.child_pid).await;

--- a/crates/services/claudecode-rs/tests/lifecycle.rs
+++ b/crates/services/claudecode-rs/tests/lifecycle.rs
@@ -1,0 +1,146 @@
+use claudecode::Client;
+use claudecode::OutputFormat;
+use claudecode::SessionConfig;
+use nix::unistd::Pid;
+use serial_test::serial;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+use tempfile::TempDir;
+
+#[derive(Debug, serde::Deserialize)]
+struct PidInfo {
+    parent_pid: u32,
+    child_pid: u32,
+}
+
+fn fake_claude_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_fake_claude"))
+}
+
+fn pid_file(temp_dir: &TempDir) -> PathBuf {
+    temp_dir.path().join("fake-clause-pids.json")
+}
+
+fn config(output_format: OutputFormat, query: &str, pid_file: &Path) -> SessionConfig {
+    SessionConfig::builder(query)
+        .output_format(output_format)
+        .env_var("FAKE_CLAUDE_PID_FILE", pid_file.display().to_string())
+        .build()
+        .unwrap()
+}
+
+async fn wait_for_pid_info(pid_file: &PathBuf) -> PidInfo {
+    for _ in 0..100 {
+        if let Ok(bytes) = tokio::fs::read(pid_file).await {
+            return serde_json::from_slice(&bytes).unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("timed out waiting for fake claude pid file");
+}
+
+async fn wait_for_process_exit(pid: u32) {
+    for _ in 0..200 {
+        if !PathBuf::from(format!("/proc/{pid}")).exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("process {pid} did not exit in time");
+}
+
+#[tokio::test]
+#[serial]
+async fn dropping_launch_and_wait_kills_fake_claude_and_child() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let client = Client::with_path(fake_claude_path()).await.unwrap();
+    let cfg = config(OutputFormat::Text, "drop test", &pid_path);
+
+    let task = tokio::spawn(async move { client.launch_and_wait(cfg).await });
+    let pids = wait_for_pid_info(&pid_path).await;
+    task.abort();
+    let _ = task.await;
+
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn session_kill_works_after_worker_startup() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let client = Client::with_path(fake_claude_path()).await.unwrap();
+    let cfg = config(OutputFormat::Text, "kill test", &pid_path);
+
+    let mut session = client.launch(cfg).await.unwrap();
+    let pids = wait_for_pid_info(&pid_path).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    session.kill().await.unwrap();
+
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn fake_claude_runs_in_separate_process_group() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let client = Client::with_path(fake_claude_path()).await.unwrap();
+    let cfg = config(OutputFormat::Text, "pgid test", &pid_path);
+
+    let session = client.launch(cfg).await.unwrap();
+    let pids = wait_for_pid_info(&pid_path).await;
+
+    let test_pgid = nix::unistd::getpgid(None).unwrap();
+    let fake_pgid = nix::unistd::getpgid(Some(Pid::from_raw(pids.parent_pid as i32))).unwrap();
+    assert_ne!(fake_pgid, test_pgid);
+
+    session.cancel().await.unwrap();
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn fake_claude_child_shares_parent_process_group() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let client = Client::with_path(fake_claude_path()).await.unwrap();
+    let cfg = config(OutputFormat::Text, "child pgid test", &pid_path);
+
+    let session = client.launch(cfg).await.unwrap();
+    let pids = wait_for_pid_info(&pid_path).await;
+
+    let parent_pgid = nix::unistd::getpgid(Some(Pid::from_raw(pids.parent_pid as i32))).unwrap();
+    let child_pgid = nix::unistd::getpgid(Some(Pid::from_raw(pids.child_pid as i32))).unwrap();
+    assert_eq!(parent_pgid, child_pgid);
+
+    session.cancel().await.unwrap();
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn session_cancel_completes_within_bound_for_hung_process() {
+    let temp_dir = TempDir::new().unwrap();
+    let pid_path = pid_file(&temp_dir);
+    let client = Client::with_path(fake_claude_path()).await.unwrap();
+    let cfg = config(OutputFormat::Text, "[hang] cancel test", &pid_path);
+
+    let session = client.launch(cfg).await.unwrap();
+    let pids = wait_for_pid_info(&pid_path).await;
+
+    let started = Instant::now();
+    session.cancel().await.unwrap();
+    assert!(started.elapsed() < Duration::from_secs(2));
+
+    wait_for_process_exit(pids.parent_pid).await;
+    wait_for_process_exit(pids.child_pid).await;
+}

--- a/crates/tools/coding-agent-tools/src/just/exec.rs
+++ b/crates/tools/coding-agent-tools/src/just/exec.rs
@@ -7,8 +7,10 @@ use super::parser::ParamKind;
 use super::security::SecurityValidator;
 use super::types::ExecuteOutput;
 use crate::paths;
+use agentic_tools_core::ToolContext;
 use serde_json::Value;
 use std::collections::HashMap;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 /// Execute a recipe by name, with optional directory disambiguation and arguments.
@@ -29,6 +31,7 @@ pub async fn execute_recipe(
     dir_opt: Option<String>,
     args_opt: Option<HashMap<String, Value>>,
     repo_root: &str,
+    ctx: &ToolContext,
 ) -> Result<ExecuteOutput, String> {
     // Canonicalize to resolve symlinks (e.g., /var -> /private/var on macOS)
     let repo_root = paths::to_abs_string(repo_root)?;
@@ -126,20 +129,62 @@ pub async fn execute_recipe(
         }
     }
 
-    let output = Command::new("just")
+    let mut child = Command::new("just")
         .args(&argv)
         .current_dir(&chosen_dir)
-        .output()
-        .await
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
         .map_err(|e| format!("Failed to execute just: {e}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture just stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture just stderr".to_string())?;
+
+    let stdout_task = tokio::spawn(async move {
+        let mut stdout = stdout;
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).await.map(|_| bytes)
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut stderr = stderr;
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).await.map(|_| bytes)
+    });
+
+    let status = tokio::select! {
+        () = ctx.cancelled() => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            stdout_task.abort();
+            stderr_task.abort();
+            return Err("Just execution cancelled".to_string());
+        }
+        status = child.wait() => status.map_err(|e| format!("Failed to execute just: {e}"))?,
+    };
+
+    let stdout = stdout_task
+        .await
+        .map_err(|e| format!("Failed to join stdout reader: {e}"))?
+        .map_err(|e| format!("Failed to read just stdout: {e}"))?;
+    let stderr = stderr_task
+        .await
+        .map_err(|e| format!("Failed to join stderr reader: {e}"))?
+        .map_err(|e| format!("Failed to read just stderr: {e}"))?;
 
     Ok(ExecuteOutput {
         dir: chosen_dir,
         recipe: recipe_name.to_string(),
-        success: output.status.success(),
-        exit_code: output.status.code(),
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        success: status.success(),
+        exit_code: status.code(),
+        stdout: String::from_utf8_lossy(&stdout).to_string(),
+        stderr: String::from_utf8_lossy(&stderr).to_string(),
     })
 }
 
@@ -158,6 +203,7 @@ fn value_to_arg(v: &Value) -> Result<String, String> {
 #[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use agentic_tools_core::ToolContext;
     use serde_json::json;
     use std::fs;
     use tempfile::TempDir;
@@ -215,8 +261,15 @@ mod tests {
         fs::write(root.join("justfile"), "build:\n    echo building").unwrap();
 
         let registry = JustRegistry::new();
-        let result =
-            execute_recipe(&registry, "nonexistent", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "nonexistent",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -238,7 +291,15 @@ mod tests {
 
         let registry = JustRegistry::new();
         // No dir specified - should default to root
-        let result = execute_recipe(&registry, "check", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "check",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let output = result.unwrap();
@@ -262,7 +323,15 @@ mod tests {
 
         let registry = JustRegistry::new();
         // No dir specified, recipe not in root - should error
-        let result = execute_recipe(&registry, "check", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "check",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -285,7 +354,15 @@ mod tests {
 
         let registry = JustRegistry::new();
         // Call without providing the required arg
-        let result = execute_recipe(&registry, "greet", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "greet",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -302,7 +379,15 @@ mod tests {
         fs::write(root.join("justfile"), "hello:\n    echo hello world").unwrap();
 
         let registry = JustRegistry::new();
-        let result = execute_recipe(&registry, "hello", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "hello",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let output = result.unwrap();
@@ -320,7 +405,15 @@ mod tests {
         fs::write(root.join("justfile"), "fail:\n    exit 42").unwrap();
 
         let registry = JustRegistry::new();
-        let result = execute_recipe(&registry, "fail", None, None, root.to_str().unwrap()).await;
+        let result = execute_recipe(
+            &registry,
+            "fail",
+            None,
+            None,
+            root.to_str().unwrap(),
+            &ToolContext::default(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let output = result.unwrap();
@@ -351,6 +444,7 @@ mod tests {
             Some(sub_dir),
             None,
             root.to_str().unwrap(),
+            &ToolContext::default(),
         )
         .await;
 
@@ -384,6 +478,7 @@ mod tests {
             None,
             Some(wrong_args),
             root.to_str().unwrap(),
+            &ToolContext::default(),
         )
         .await;
 
@@ -396,5 +491,29 @@ mod tests {
         assert!(err.contains("tgt"));
         // Should list expected parameters
         assert!(err.contains("Expected parameter"));
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_recipe_execution() {
+        skip_if_just_unavailable!();
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(root.join("justfile"), "hang:\n    sleep 30").unwrap();
+
+        let registry = JustRegistry::new();
+        let ctx = ToolContext::default();
+        let cancel = ctx.cancellation_token();
+
+        let handle = tokio::spawn({
+            let repo_root = root.to_str().unwrap().to_string();
+            async move { execute_recipe(&registry, "hang", None, None, &repo_root, &ctx).await }
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancel.cancel();
+
+        let result = handle.await.unwrap();
+        assert_eq!(result.unwrap_err(), "Just execution cancelled");
     }
 }

--- a/crates/tools/coding-agent-tools/src/lib.rs
+++ b/crates/tools/coding-agent-tools/src/lib.rs
@@ -19,6 +19,8 @@ pub use tools::build_registry;
 use agentic_config::types::CliToolsConfig;
 use agentic_config::types::SubagentsConfig;
 use agentic_tools_core::ToolError;
+use claudecode::types::Result as ClaudeResult;
+use std::future::Future;
 use std::sync::Arc;
 use types::AgentOutput;
 use types::Depth;
@@ -44,6 +46,29 @@ fn pick_non_empty_text(result: &claudecode::types::Result) -> Option<String> {
                 .filter(|s| !s.trim().is_empty())
                 .cloned()
         })
+}
+
+async fn wait_for_claude_result<F, C, CFn>(
+    ctx: &agentic_tools_core::ToolContext,
+    wait_fut: F,
+    cancel_fn: CFn,
+) -> Result<ClaudeResult, ToolError>
+where
+    F: Future<Output = claudecode::Result<ClaudeResult>>,
+    C: Future<Output = claudecode::Result<()>>,
+    CFn: FnOnce() -> C,
+{
+    tokio::select! {
+        () = ctx.cancelled() => {
+            cancel_fn()
+                .await
+                .map_err(|e| ToolError::Internal(format!("Failed to cancel Claude session cleanly: {e}")))?;
+            Err(ToolError::cancelled(None))
+        }
+        result = wait_fut => {
+            result.map_err(|e| ToolError::Internal(format!("Failed to run Claude session: {e}")))
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -262,6 +287,7 @@ impl CodingAgentTools {
         agent_type: Option<types::AgentType>,
         location: Option<types::AgentLocation>,
         query: String,
+        ctx: &agentic_tools_core::ToolContext,
     ) -> Result<AgentOutput, ToolError> {
         use claudecode::client::Client;
         use claudecode::config::SessionConfig;
@@ -378,10 +404,10 @@ impl CodingAgentTools {
             }
         };
 
-        let result = match client.launch_and_wait(config).await {
-            Ok(r) => r,
+        let session = match client.launch(config).await {
+            Ok(session) => session,
             Err(e) => {
-                let error_msg = format!("Failed to run Claude session: {e}");
+                let error_msg = format!("Failed to start Claude session: {e}");
                 log_ctx.finish(
                     req_json,
                     None,
@@ -392,6 +418,34 @@ impl CodingAgentTools {
                     None,
                 );
                 return Err(ToolError::Internal(error_msg));
+            }
+        };
+
+        let result = match wait_for_claude_result(ctx, session.wait(), || session.cancel()).await {
+            Ok(result) => result,
+            Err(ToolError::Cancelled { .. }) => {
+                log_ctx.finish(
+                    req_json,
+                    None,
+                    false,
+                    Some("Request cancelled".into()),
+                    None,
+                    Some(model.to_string()),
+                    None,
+                );
+                return Err(ToolError::cancelled(None));
+            }
+            Err(e) => {
+                log_ctx.finish(
+                    req_json,
+                    None,
+                    false,
+                    Some(e.to_string()),
+                    None,
+                    Some(model.to_string()),
+                    None,
+                );
+                return Err(e);
             }
         };
 
@@ -746,6 +800,7 @@ impl CodingAgentTools {
         recipe: String,
         dir: Option<String>,
         args: Option<std::collections::HashMap<String, serde_json::Value>>,
+        ctx: &agentic_tools_core::ToolContext,
     ) -> Result<just::ExecuteOutput, ToolError> {
         // Start logging context
         let log_ctx = logging::ToolLogCtx::start("cli_just_execute");
@@ -777,7 +832,8 @@ impl CodingAgentTools {
             }
         };
 
-        match just::exec::execute_recipe(&self.just_registry, &recipe, dir, args, &repo_root).await
+        match just::exec::execute_recipe(&self.just_registry, &recipe, dir, args, &repo_root, ctx)
+            .await
         {
             Ok(output) => {
                 let summary = serde_json::json!({
@@ -789,6 +845,11 @@ impl CodingAgentTools {
                 Ok(output)
             }
             Err(e) => {
+                if e == "Just execution cancelled" {
+                    log_ctx.finish(req_json, None, false, Some(e), None, None, None);
+                    return Err(ToolError::cancelled(None));
+                }
+
                 let error_msg = e;
                 log_ctx.finish(
                     req_json,
@@ -863,5 +924,35 @@ mod ask_agent_filter_tests {
         };
         // Helper uses trim().is_empty() for emptiness check, but returns original string
         assert_eq!(pick_non_empty_text(&r).as_deref(), Some("  result text  "));
+    }
+
+    #[tokio::test]
+    async fn wait_for_claude_result_runs_cancel_branch() {
+        let ctx = agentic_tools_core::ToolContext::default();
+        let cancel = ctx.cancellation_token();
+        let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let cancelled_flag = Arc::clone(&cancelled);
+
+        let task = tokio::spawn(async move {
+            wait_for_claude_result(
+                &ctx,
+                std::future::pending::<claudecode::Result<ClaudeResult>>(),
+                move || async move {
+                    cancelled_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        let result = match task.await {
+            Ok(result) => result,
+            Err(err) => panic!("task join failed: {err}"),
+        };
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
+        assert!(cancelled.load(std::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/crates/tools/coding-agent-tools/src/lib.rs
+++ b/crates/tools/coding-agent-tools/src/lib.rs
@@ -60,9 +60,9 @@ where
 {
     tokio::select! {
         () = ctx.cancelled() => {
-            cancel_fn()
-                .await
-                .map_err(|e| ToolError::Internal(format!("Failed to cancel Claude session cleanly: {e}")))?;
+            if let Err(e) = cancel_fn().await {
+                tracing::warn!(error = %e, "Failed to cancel Claude session cleanly");
+            }
             Err(ToolError::cancelled(None))
         }
         result = wait_fut => {
@@ -845,7 +845,7 @@ impl CodingAgentTools {
                 Ok(output)
             }
             Err(e) => {
-                if e == "Just execution cancelled" {
+                if ctx.is_cancelled() {
                     log_ctx.finish(req_json, None, false, Some(e), None, None, None);
                     return Err(ToolError::cancelled(None));
                 }
@@ -870,6 +870,32 @@ impl CodingAgentTools {
 mod ask_agent_filter_tests {
     use super::*;
     use claudecode::types::Result as ClaudeResult;
+    use serial_test::serial;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    struct DirGuard {
+        prev: PathBuf,
+    }
+
+    impl DirGuard {
+        fn set(to: &Path) -> Self {
+            let prev =
+                std::env::current_dir().unwrap_or_else(|e| panic!("current_dir failed: {e}"));
+            std::env::set_current_dir(to)
+                .unwrap_or_else(|e| panic!("set_current_dir({}) failed: {e}", to.display()));
+            Self { prev }
+        }
+    }
+
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.prev)
+                .unwrap_or_else(|e| panic!("restore cwd failed: {e}"));
+        }
+    }
 
     #[test]
     fn prefers_content_when_result_is_empty_string() {
@@ -954,5 +980,68 @@ mod ask_agent_filter_tests {
         };
         assert!(matches!(result, Err(ToolError::Cancelled { .. })));
         assert!(cancelled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn wait_for_claude_result_preserves_cancelled_when_cleanup_fails() {
+        let ctx = agentic_tools_core::ToolContext::default();
+        let cancel = ctx.cancellation_token();
+
+        let task = tokio::spawn(async move {
+            wait_for_claude_result(
+                &ctx,
+                std::future::pending::<claudecode::Result<ClaudeResult>>(),
+                || async move {
+                    Err(claudecode::ClaudeError::IoError {
+                        source: std::io::Error::other("cleanup failed during cancellation"),
+                    })
+                },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        let result = match task.await {
+            Ok(result) => result,
+            Err(err) => panic!("task join failed: {err}"),
+        };
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
+    }
+
+    #[tokio::test]
+    #[serial(env)]
+    async fn just_execute_returns_structured_cancelled_without_string_match() {
+        if tokio::process::Command::new("just")
+            .arg("--version")
+            .output()
+            .await
+            .is_err()
+        {
+            eprintln!("Skipping test: just not installed");
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("TempDir::new failed: {e}"));
+        fs::write(tmp.path().join("justfile"), "hang:\n    sleep 30")
+            .unwrap_or_else(|e| panic!("writing justfile failed: {e}"));
+        let _dir = DirGuard::set(tmp.path());
+
+        let tools = CodingAgentTools::new();
+        let ctx = agentic_tools_core::ToolContext::default();
+        let cancel = ctx.cancellation_token();
+
+        let handle =
+            tokio::spawn(async move { tools.just_execute("hang".into(), None, None, &ctx).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancel.cancel();
+
+        let result = match handle.await {
+            Ok(result) => result,
+            Err(err) => panic!("task join failed: {err}"),
+        };
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
     }
 }

--- a/crates/tools/coding-agent-tools/src/tools.rs
+++ b/crates/tools/coding-agent-tools/src/tools.rs
@@ -153,12 +153,13 @@ Usage notes:
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let tools = Arc::clone(&self.tools);
+        let ctx = ctx.clone();
         Box::pin(async move {
             tools
-                .ask_agent(input.agent_type, input.location, input.query)
+                .ask_agent(input.agent_type, input.location, input.query, &ctx)
                 .await
         })
     }
@@ -415,12 +416,13 @@ impl Tool for JustExecuteTool {
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let tools = Arc::clone(&self.tools);
+        let ctx = ctx.clone();
         Box::pin(async move {
             tools
-                .just_execute(input.recipe, input.dir, input.args)
+                .just_execute(input.recipe, input.dir, input.args, &ctx)
                 .await
         })
     }

--- a/crates/tools/coding-agent-tools/tests/ask_agent_integration.rs
+++ b/crates/tools/coding-agent-tools/tests/ask_agent_integration.rs
@@ -3,6 +3,7 @@
 //! Run with: cargo test -p `coding_agent_tools` -- --ignored
 #![expect(clippy::unwrap_used)]
 
+use agentic_tools_core::ToolContext;
 use coding_agent_tools::CodingAgentTools;
 use coding_agent_tools::types::AgentLocation;
 use coding_agent_tools::types::AgentType;
@@ -11,11 +12,13 @@ use coding_agent_tools::types::AgentType;
 #[ignore = "requires live API key and network access"]
 async fn locator_codebase_basic() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     let out = tools
         .ask_agent(
             Some(AgentType::Locator),
             Some(AgentLocation::Codebase),
             "Find Cargo.toml files and related config".into(),
+            &ctx,
         )
         .await;
 
@@ -33,11 +36,13 @@ async fn locator_codebase_basic() {
 #[ignore = "requires live API key and network access"]
 async fn analyzer_web_basic() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     let out = tools
         .ask_agent(
             Some(AgentType::Analyzer),
             Some(AgentLocation::Web),
             "Summarize the core concepts of Rust error handling with sources".into(),
+            &ctx,
         )
         .await;
 
@@ -55,11 +60,13 @@ async fn analyzer_web_basic() {
 #[ignore = "requires live API key and network access"]
 async fn locator_web_basic() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     let out = tools
         .ask_agent(
             Some(AgentType::Locator),
             Some(AgentLocation::Web),
             "Find the official Rust documentation for the Result type".into(),
+            &ctx,
         )
         .await;
 
@@ -77,11 +84,13 @@ async fn locator_web_basic() {
 #[ignore = "requires live API key and network access"]
 async fn analyzer_codebase_basic() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     let out = tools
         .ask_agent(
             Some(AgentType::Analyzer),
             Some(AgentLocation::Codebase),
             "Analyze how the ls tool handles pagination in this codebase".into(),
+            &ctx,
         )
         .await;
 
@@ -99,11 +108,13 @@ async fn analyzer_codebase_basic() {
 #[ignore = "requires live API key and network access"]
 async fn ask_agent_empty_query_fails() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     let out = tools
         .ask_agent(
             Some(AgentType::Locator),
             Some(AgentLocation::Codebase),
             "   ".into(), // empty/whitespace only
+            &ctx,
         )
         .await;
 
@@ -116,9 +127,10 @@ async fn ask_agent_empty_query_fails() {
 #[ignore = "requires live API key and network access"]
 async fn ask_agent_defaults_to_locator_codebase() {
     let tools = CodingAgentTools::new();
+    let ctx = ToolContext::default();
     // Test that defaults work (locator + codebase)
     let out = tools
-        .ask_agent(None, None, "Find test files in this project".into())
+        .ask_agent(None, None, "Find test files in this project".into(), &ctx)
         .await;
 
     match out {

--- a/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
+++ b/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
@@ -49,6 +49,10 @@ pub async fn gpt5_reasoner_impl(
     output_filename: Option<String>,
     ctx: &ToolContext,
 ) -> std::result::Result<String, ToolError> {
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
+
     // Start logging timer
     let timer = CallTimer::start();
     let server = "gpt5_reasoner".to_string();
@@ -566,8 +570,18 @@ mod retry_tests {
 
         let result = gpt5_reasoner_impl(
             "test".to_string(),
-            vec![],
-            None,
+            vec![FileMeta {
+                filename: "/definitely/not/present.txt".into(),
+                description: "missing file that should never be prechecked".into(),
+            }],
+            Some(vec![DirectoryMeta {
+                directory_path: "/definitely/not/a/real/directory".into(),
+                description: "directory expansion should be skipped".into(),
+                extensions: None,
+                recursive: true,
+                include_hidden: false,
+                max_files: 1000,
+            }]),
             &ReasoningConfig::default(),
             PromptType::Reasoning,
             None,

--- a/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
+++ b/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
@@ -20,6 +20,7 @@ use agentic_config::types::ReasoningConfig;
 use agentic_logging::CallTimer;
 use agentic_logging::LogWriter;
 use agentic_logging::ToolCallRecord;
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use async_openai::types::chat::ChatCompletionRequestMessage;
 use async_openai::types::chat::ChatCompletionRequestUserMessageArgs;
@@ -46,6 +47,7 @@ pub async fn gpt5_reasoner_impl(
     cfg: &ReasoningConfig,
     prompt_type: PromptType,
     output_filename: Option<String>,
+    ctx: &ToolContext,
 ) -> std::result::Result<String, ToolError> {
     // Start logging timer
     let timer = CallTimer::start();
@@ -167,6 +169,10 @@ pub async fn gpt5_reasoner_impl(
     // Auto-inject plan_structure.md for Plan prompts (before optimizer)
     maybe_inject_plan_structure_meta(&prompt_type, &mut files);
 
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
+
     // Load env OpenRouter key (CLI already optionally did dotenv)
     let client = OrClient::from_env().map_err(ToolError::from)?;
 
@@ -186,16 +192,28 @@ pub async fn gpt5_reasoner_impl(
                 attempt + 1,
                 TEMPLATE_RETRIES + 1
             );
-            tokio::time::sleep(TEMPLATE_RETRY_DELAY).await;
+            tokio::select! {
+                () = ctx.cancelled() => return Err(ToolError::cancelled(None)),
+                () = tokio::time::sleep(TEMPLATE_RETRY_DELAY) => {}
+            }
         }
 
         // Call optimizer (this has its own Layer 2 network retry)
-        let raw = match call_optimizer(&client, &opt_model, &prompt_type, &prompt, &files).await {
+        let raw = match ctx
+            .run_cancellable(call_optimizer(
+                &client,
+                &opt_model,
+                &prompt_type,
+                &prompt,
+                &files,
+            ))
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 let msg = format!("stage=optimizer_call: {}", e);
                 log_record(false, Some(msg), None, None, None, files.len());
-                return Err(ToolError::from(e));
+                return Err(e);
             }
         };
 
@@ -304,7 +322,10 @@ pub async fn gpt5_reasoner_impl(
                 attempt + 1,
                 EXECUTOR_RETRIES + 1
             );
-            tokio::time::sleep(EXECUTOR_DELAY).await;
+            tokio::select! {
+                () = ctx.cancelled() => return Err(ToolError::cancelled(None)),
+                () = tokio::time::sleep(EXECUTOR_DELAY) => {}
+            }
         }
 
         // Build request inside the loop; clone final_prompt to keep ownership
@@ -336,7 +357,13 @@ pub async fn gpt5_reasoner_impl(
         };
 
         let start = std::time::Instant::now();
-        match client.client.chat().create(req).await {
+        let chat = client.client.chat();
+        let executor_response = tokio::select! {
+            () = ctx.cancelled() => return Err(ToolError::cancelled(None)),
+            response = chat.create(req) => response,
+        };
+
+        match executor_response {
             Ok(resp) => {
                 let duration = start.elapsed();
                 tracing::debug!("Executor API succeeded in {:?}", duration);
@@ -511,7 +538,9 @@ pub async fn gpt5_reasoner_impl(
 
 #[cfg(test)]
 mod retry_tests {
+    use super::*;
     use crate::errors::ReasonerError;
+    use agentic_config::types::ReasoningConfig;
 
     #[test]
     fn test_template_error_is_retryable() {
@@ -522,11 +551,30 @@ mod retry_tests {
     #[test]
     fn test_yaml_error_is_not_template_error() {
         // Create a YAML error by parsing invalid YAML
-        let yaml_result: Result<serde_yaml::Value, _> =
+        let yaml_result: std::result::Result<serde_yaml::Value, _> =
             serde_yaml::from_str("invalid: yaml: syntax");
         assert!(yaml_result.is_err());
 
         let yaml_err = ReasonerError::Yaml(yaml_result.unwrap_err());
         assert!(!matches!(yaml_err, ReasonerError::Template(_)));
+    }
+
+    #[tokio::test]
+    async fn pre_cancelled_context_returns_cancelled_before_api_setup() {
+        let ctx = agentic_tools_core::ToolContext::default();
+        ctx.cancellation_token().cancel();
+
+        let result = gpt5_reasoner_impl(
+            "test".to_string(),
+            vec![],
+            None,
+            &ReasoningConfig::default(),
+            PromptType::Reasoning,
+            None,
+            &ctx,
+        )
+        .await;
+
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
     }
 }

--- a/crates/tools/gpt5-reasoner/src/tools.rs
+++ b/crates/tools/gpt5-reasoner/src/tools.rs
@@ -73,9 +73,10 @@ impl Tool for RequestTool {
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let cfg = self.cfg.clone();
+        let ctx = ctx.clone();
         Box::pin(async move {
             gpt5_reasoner_impl(
                 input.prompt,
@@ -84,6 +85,7 @@ impl Tool for RequestTool {
                 &cfg,
                 input.prompt_type,
                 input.output_filename,
+                &ctx,
             )
             .await
         })

--- a/crates/tools/review-tools/src/lib.rs
+++ b/crates/tools/review-tools/src/lib.rs
@@ -16,6 +16,7 @@ pub mod validation;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use agentic_tools_utils::prompt::wrap_untrusted;
 use cache::SnapshotCache;
@@ -166,7 +167,11 @@ impl ReviewTools {
     }
 
     /// Run a lens-based code review over a cached snapshot.
-    pub async fn review_run(&self, input: ReviewRunInput) -> Result<ReviewRunOutput, ToolError> {
+    pub async fn review_run(
+        &self,
+        input: ReviewRunInput,
+        ctx: &ToolContext,
+    ) -> Result<ReviewRunOutput, ToolError> {
         let snap = self.cache.get(&input.diff_handle).ok_or_else(|| {
             ToolError::InvalidInput(format!(
                 "Invalid or expired diff_handle '{}'. Run review_diff_snapshot to generate a new snapshot.",
@@ -222,7 +227,9 @@ impl ReviewTools {
         let user_prompt = compose_user_prompt(input.lens, &combined_diff, input.focus.as_deref());
 
         // Run reviewer with retry
-        let raw1 = self.run_with_retry(&system_prompt, &user_prompt).await?;
+        let raw1 = self
+            .run_with_retry(&system_prompt, &user_prompt, ctx)
+            .await?;
 
         // Parse attempt #1
         let report1 = match parse_and_validate_report(&raw1, input.lens) {
@@ -253,7 +260,9 @@ impl ReviewTools {
                     wrap_untrusted("untrusted_previous_response", &raw1_trunc),
                 );
 
-                let raw2 = self.run_with_retry(&system_prompt, &repair_prompt).await?;
+                let raw2 = self
+                    .run_with_retry(&system_prompt, &repair_prompt, ctx)
+                    .await?;
                 parse_and_validate_report(&raw2, input.lens)?
             }
         };
@@ -320,7 +329,7 @@ impl ReviewTools {
         );
 
         let raw2 = self
-            .run_with_retry(&system_prompt, &grounding_repair_prompt)
+            .run_with_retry(&system_prompt, &grounding_repair_prompt, ctx)
             .await?;
         let mut report2 = parse_and_validate_report(&raw2, input.lens)?;
 
@@ -375,6 +384,7 @@ impl ReviewTools {
         &self,
         system_prompt: &str,
         user_prompt: &str,
+        ctx: &ToolContext,
     ) -> Result<String, ToolError> {
         let mut last_err = None;
 
@@ -383,7 +393,11 @@ impl ReviewTools {
 
             match self
                 .runner
-                .run_text(system_prompt.to_string(), user_prompt.to_string())
+                .run_text(
+                    system_prompt.to_string(),
+                    user_prompt.to_string(),
+                    ctx.clone(),
+                )
                 .await
             {
                 Ok(v) => return Ok(v),

--- a/crates/tools/review-tools/src/reviewer.rs
+++ b/crates/tools/review-tools/src/reviewer.rs
@@ -1,5 +1,6 @@
 //! Reviewer runner infrastructure for spawning Claude sessions.
 
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use claudecode::client::Client;
 use claudecode::config::MCPConfig;
@@ -11,6 +12,7 @@ use claudecode::types::PermissionMode;
 use claudecode::types::Result as ClaudeResult;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Semaphore;
@@ -44,7 +46,31 @@ pub trait ReviewerRunner: Send + Sync {
         &self,
         system_prompt: String,
         user_prompt: String,
+        ctx: ToolContext,
     ) -> BoxFuture<'static, Result<String, ToolError>>;
+}
+
+async fn wait_for_review_result<F, C, CFn>(
+    ctx: &ToolContext,
+    wait_fut: F,
+    cancel_fn: CFn,
+) -> Result<ClaudeResult, ToolError>
+where
+    F: Future<Output = claudecode::Result<ClaudeResult>>,
+    C: Future<Output = claudecode::Result<()>>,
+    CFn: FnOnce() -> C,
+{
+    tokio::select! {
+        () = ctx.cancelled() => {
+            cancel_fn()
+                .await
+                .map_err(|e| ToolError::Internal(format!("Failed to cancel Claude session: {e}")))?;
+            Err(ToolError::cancelled(None))
+        }
+        result = wait_fut => {
+            result.map_err(|e| ToolError::Internal(format!("Failed to run Claude session: {e}")))
+        }
+    }
 }
 
 /// Production implementation using Claude CLI.
@@ -103,6 +129,7 @@ impl ReviewerRunner for ClaudeCliRunner {
         &self,
         system_prompt: String,
         user_prompt: String,
+        ctx: ToolContext,
     ) -> BoxFuture<'static, Result<String, ToolError>> {
         let semaphore = Arc::clone(&self.semaphore);
         let builtin_tools = Self::builtin_tools();
@@ -135,10 +162,11 @@ impl ReviewerRunner for ClaudeCliRunner {
                     .await
                     .map_err(|e| ToolError::Internal(format!("Claude CLI not runnable: {e}")))?;
 
-                client
-                    .launch_and_wait(cfg)
-                    .await
-                    .map_err(|e| ToolError::Internal(format!("Failed to run Claude session: {e}")))
+                let session = client.launch(cfg).await.map_err(|e| {
+                    ToolError::Internal(format!("Failed to start Claude session: {e}"))
+                })?;
+
+                wait_for_review_result(&ctx, session.wait(), || session.cancel()).await
             })
             .await
             .map_err(|_| {
@@ -188,6 +216,7 @@ impl ReviewerRunner for MockRunner {
         &self,
         _system_prompt: String,
         _user_prompt: String,
+        _ctx: ToolContext,
     ) -> BoxFuture<'static, Result<String, ToolError>> {
         let response = {
             let mut responses = self.responses.lock().expect("lock poisoned");
@@ -204,6 +233,8 @@ impl ReviewerRunner for MockRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn reviewer_tool_constants() {
@@ -237,14 +268,48 @@ mod tests {
     #[tokio::test]
     async fn mock_runner_returns_responses() {
         let runner = MockRunner::new(vec![Ok("test response".into())]);
-        let result = runner.run_text("system".into(), "user".into()).await;
+        let result = runner
+            .run_text("system".into(), "user".into(), ToolContext::default())
+            .await;
         assert_eq!(result.unwrap(), "test response");
     }
 
     #[tokio::test]
     async fn mock_runner_exhaustion() {
         let runner = MockRunner::new(vec![]);
-        let result = runner.run_text("system".into(), "user".into()).await;
+        let result = runner
+            .run_text("system".into(), "user".into(), ToolContext::default())
+            .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_review_result_runs_cancel_branch() {
+        let ctx = ToolContext::default();
+        let cancel = ctx.cancellation_token();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_flag = Arc::clone(&cancelled);
+
+        let task = tokio::spawn(async move {
+            wait_for_review_result(
+                &ctx,
+                std::future::pending::<claudecode::Result<ClaudeResult>>(),
+                move || async move {
+                    cancelled_flag.store(true, Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        let result = match task.await {
+            Ok(result) => result,
+            Err(err) => panic!("task join failed: {err}"),
+        };
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
+        assert!(cancelled.load(Ordering::SeqCst));
     }
 }

--- a/crates/tools/review-tools/src/tools.rs
+++ b/crates/tools/review-tools/src/tools.rs
@@ -81,10 +81,11 @@ impl Tool for RunTool {
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let svc = Arc::clone(&self.svc);
-        Box::pin(async move { svc.review_run(input).await })
+        let ctx = ctx.clone();
+        Box::pin(async move { svc.review_run(input, &ctx).await })
     }
 }
 

--- a/crates/tools/web-retrieval/src/fetch.rs
+++ b/crates/tools/web-retrieval/src/fetch.rs
@@ -1,5 +1,6 @@
 // TODO(1): Add optional JS-rendering sidecar for dynamic pages (Playwright/etc.)
 
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::error::ToolError;
 use chrono::Utc;
 
@@ -17,6 +18,7 @@ pub const HARD_MAX_BYTES: usize = 20 * 1024 * 1024;
 pub async fn web_fetch(
     tools: &WebTools,
     input: WebFetchInput,
+    ctx: &ToolContext,
 ) -> Result<WebFetchOutput, ToolError> {
     #[expect(clippy::cast_possible_truncation)]
     let default_max_bytes = tools.cfg.default_max_bytes as usize;
@@ -28,13 +30,21 @@ pub async fn web_fetch(
         )));
     }
 
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
+
     // Send GET request
-    let mut response = tools
-        .http
-        .get(&input.url)
-        .send()
-        .await
-        .map_err(|e| ToolError::external(format!("HTTP request failed: {e}")))?;
+    let mut response = ctx
+        .run_cancellable(async {
+            tools
+                .http
+                .get(&input.url)
+                .send()
+                .await
+                .map_err(|e| ToolError::external(format!("HTTP request failed: {e}")))
+        })
+        .await?;
 
     let status = response.status();
     if !status.is_success() {
@@ -70,10 +80,18 @@ pub async fn web_fetch(
             break;
         }
 
-        let Some(chunk) = response
-            .chunk()
-            .await
-            .map_err(|e| ToolError::external(format!("Failed to read response body: {e}")))?
+        if ctx.is_cancelled() {
+            return Err(ToolError::cancelled(None));
+        }
+
+        let Some(chunk) = ctx
+            .run_cancellable(async {
+                response
+                    .chunk()
+                    .await
+                    .map_err(|e| ToolError::external(format!("Failed to read response body: {e}")))
+            })
+            .await?
         else {
             break;
         };
@@ -96,13 +114,17 @@ pub async fn web_fetch(
     // Optional summarization
     let summary = if input.summarize {
         Some(
-            crate::haiku::summarize_markdown(tools, &content)
+            crate::haiku::summarize_markdown(tools, &content, ctx)
                 .await
                 .map_err(|e| ToolError::external(format!("Summarization failed: {e}")))?,
         )
     } else {
         None
     };
+
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
 
     Ok(WebFetchOutput {
         final_url,
@@ -257,6 +279,7 @@ mod tests {
         use super::*;
         use crate::WebTools;
         use crate::types::WebFetchInput;
+        use agentic_tools_core::ToolContext;
         use wiremock::Mock;
         use wiremock::MockServer;
         use wiremock::ResponseTemplate;
@@ -280,7 +303,7 @@ mod tests {
                 max_bytes: None,
             };
 
-            let result = web_fetch(&tools, input).await;
+            let result = web_fetch(&tools, input, &ToolContext::default()).await;
             assert!(result.is_err(), "Expected error for 404 response");
             let err = result.unwrap_err();
             assert!(
@@ -307,7 +330,7 @@ mod tests {
                 max_bytes: None,
             };
 
-            let result = web_fetch(&tools, input).await;
+            let result = web_fetch(&tools, input, &ToolContext::default()).await;
             assert!(result.is_err(), "Expected error for 500 response");
             let err = result.unwrap_err();
             assert!(
@@ -338,7 +361,7 @@ mod tests {
                 max_bytes: None,
             };
 
-            let result = web_fetch(&tools, input).await;
+            let result = web_fetch(&tools, input, &ToolContext::default()).await;
             assert!(result.is_ok(), "Expected success for 200 response");
             let output = result.unwrap();
             assert_eq!(output.content, "Hello, world!");
@@ -366,7 +389,7 @@ mod tests {
                 max_bytes: None,
             };
 
-            let result = web_fetch(&tools, input).await;
+            let result = web_fetch(&tools, input, &ToolContext::default()).await;
             assert!(
                 result.is_ok(),
                 "Expected success for HTML without Content-Type"
@@ -394,6 +417,25 @@ mod tests {
                 !output.content.contains("<p>"),
                 "HTML tags should be removed by markdown conversion"
             );
+        }
+
+        #[tokio::test]
+        async fn web_fetch_returns_cancelled_before_sending_request() {
+            let mock_server = MockServer::start().await;
+            let http = reqwest::Client::new();
+            let tools = WebTools::with_http_client(http);
+            let ctx = ToolContext::default();
+            ctx.cancellation_token().cancel();
+
+            let input = WebFetchInput {
+                url: mock_server.uri(),
+                summarize: false,
+                max_bytes: None,
+            };
+
+            let result = web_fetch(&tools, input, &ctx).await;
+            assert!(matches!(result, Err(ToolError::Cancelled { .. })));
+            assert!(mock_server.received_requests().await.unwrap().is_empty());
         }
     }
 }

--- a/crates/tools/web-retrieval/src/fetch.rs
+++ b/crates/tools/web-retrieval/src/fetch.rs
@@ -112,15 +112,7 @@ pub async fn web_fetch(
     let word_count = content.split_whitespace().count();
 
     // Optional summarization
-    let summary = if input.summarize {
-        Some(
-            crate::haiku::summarize_markdown(tools, &content, ctx)
-                .await
-                .map_err(|e| ToolError::external(format!("Summarization failed: {e}")))?,
-        )
-    } else {
-        None
-    };
+    let summary = summarize_content_if_requested(tools, &content, input.summarize, ctx).await?;
 
     if ctx.is_cancelled() {
         return Err(ToolError::cancelled(None));
@@ -136,6 +128,23 @@ pub async fn web_fetch(
         content,
         summary,
     })
+}
+
+async fn summarize_content_if_requested(
+    tools: &WebTools,
+    content: &str,
+    summarize: bool,
+    ctx: &ToolContext,
+) -> Result<Option<String>, ToolError> {
+    if !summarize {
+        return Ok(None);
+    }
+
+    match crate::haiku::summarize_markdown(tools, content, ctx).await {
+        Ok(summary) => Ok(Some(summary)),
+        Err(ToolError::Cancelled { reason }) => Err(ToolError::Cancelled { reason }),
+        Err(e) => Err(ToolError::external(format!("Summarization failed: {e}"))),
+    }
 }
 
 /// Decode bytes and convert to a useful text format based on content-type.
@@ -436,6 +445,17 @@ mod tests {
             let result = web_fetch(&tools, input, &ctx).await;
             assert!(matches!(result, Err(ToolError::Cancelled { .. })));
             assert!(mock_server.received_requests().await.unwrap().is_empty());
+        }
+
+        #[tokio::test]
+        async fn summarization_preserves_cancelled_error() {
+            let tools = WebTools::with_http_client(reqwest::Client::new());
+            let ctx = ToolContext::default();
+            ctx.cancellation_token().cancel();
+
+            let result = summarize_content_if_requested(&tools, "content", true, &ctx).await;
+
+            assert!(matches!(result, Err(ToolError::Cancelled { .. })));
         }
     }
 }

--- a/crates/tools/web-retrieval/src/haiku.rs
+++ b/crates/tools/web-retrieval/src/haiku.rs
@@ -3,6 +3,7 @@
 
 //! Haiku summarization via Anthropic API.
 
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::error::ToolError;
 use anthropic_async::types::ContentBlock;
 use anthropic_async::types::MessageParam;
@@ -12,6 +13,8 @@ use tracing::debug;
 
 use crate::WebTools;
 
+const MAX_MARKDOWN_CHARS: usize = 100_000;
+
 /// Summarize markdown content using Claude Haiku.
 ///
 /// Lazy-initializes the Anthropic client on first call.
@@ -19,9 +22,16 @@ use crate::WebTools;
 ///
 /// # Errors
 /// Returns `ToolError` if the Anthropic client cannot be initialized or the API call fails.
-pub async fn summarize_markdown(tools: &WebTools, markdown: &str) -> Result<String, ToolError> {
+pub async fn summarize_markdown(
+    tools: &WebTools,
+    markdown: &str,
+    ctx: &ToolContext,
+) -> Result<String, ToolError> {
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
+
     // Truncate to avoid context window overflow (~25K tokens, well under 200K limit)
-    const MAX_MARKDOWN_CHARS: usize = 100_000;
     let markdown: String = markdown.chars().take(MAX_MARKDOWN_CHARS).collect();
 
     let base_url = tools.anthropic_cfg.base_url.clone();
@@ -47,11 +57,15 @@ pub async fn summarize_markdown(tools: &WebTools, markdown: &str) -> Result<Stri
         ..Default::default()
     };
 
-    let resp = client
-        .messages()
-        .create(req)
-        .await
-        .map_err(|e| ToolError::external(format!("Haiku API call failed: {e}")))?;
+    let resp = ctx
+        .run_cancellable(async {
+            client
+                .messages()
+                .create(req)
+                .await
+                .map_err(|e| ToolError::external(format!("Haiku API call failed: {e}")))
+        })
+        .await?;
 
     // Extract text from content blocks
     let text = resp

--- a/crates/tools/web-retrieval/src/search.rs
+++ b/crates/tools/web-retrieval/src/search.rs
@@ -1,5 +1,6 @@
 //! Web search implementation using Exa API.
 
+use agentic_tools_core::ToolContext;
 use agentic_tools_core::error::ToolError;
 use chrono::Utc;
 use url::Url;
@@ -21,7 +22,12 @@ const MAX_SNIPPET_CHARS: usize = 300;
 pub async fn web_search(
     tools: &WebTools,
     input: WebSearchInput,
+    ctx: &ToolContext,
 ) -> Result<WebSearchOutput, ToolError> {
+    if ctx.is_cancelled() {
+        return Err(ToolError::cancelled(None));
+    }
+
     let default_results = tools.cfg.default_search_results;
     let max_results = tools.cfg.max_search_results;
     let num_results = input
@@ -45,12 +51,16 @@ pub async fn web_search(
             summary: Some(exa_async::types::common::SummaryContentsOptions::default()),
         });
 
-    let resp = tools
-        .exa
-        .search()
-        .create(req)
-        .await
-        .map_err(|e| ToolError::external(format!("Exa search failed: {e}")))?;
+    let resp = ctx
+        .run_cancellable(async {
+            tools
+                .exa
+                .search()
+                .create(req)
+                .await
+                .map_err(|e| ToolError::external(format!("Exa search failed: {e}")))
+        })
+        .await?;
 
     // Trim context
     let context = resp
@@ -130,6 +140,8 @@ fn trim_chars(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WebTools;
+    use agentic_tools_core::ToolContext;
 
     #[test]
     fn test_extract_domain() {
@@ -175,6 +187,25 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(pick_snippet(&result), Some("highlight text".into()));
+    }
+
+    #[tokio::test]
+    async fn web_search_returns_cancelled_when_context_cancelled() {
+        let tools = WebTools::new();
+        let ctx = ToolContext::default();
+        ctx.cancellation_token().cancel();
+
+        let result = web_search(
+            &tools,
+            WebSearchInput {
+                query: "rust error handling".into(),
+                num_results: None,
+            },
+            &ctx,
+        )
+        .await;
+
+        assert!(matches!(result, Err(ToolError::Cancelled { .. })));
     }
 
     #[test]

--- a/crates/tools/web-retrieval/src/tools.rs
+++ b/crates/tools/web-retrieval/src/tools.rs
@@ -42,10 +42,11 @@ impl Tool for WebFetchTool {
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let tools = Arc::clone(&self.tools);
-        Box::pin(async move { crate::fetch::web_fetch(&tools, input).await })
+        let ctx = ctx.clone();
+        Box::pin(async move { crate::fetch::web_fetch(&tools, input, &ctx).await })
     }
 }
 
@@ -77,10 +78,11 @@ impl Tool for WebSearchTool {
     fn call(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let tools = Arc::clone(&self.tools);
-        Box::pin(async move { crate::search::web_search(&tools, input).await })
+        let ctx = ctx.clone();
+        Box::pin(async move { crate::search::web_search(&tools, input, &ctx).await })
     }
 }
 

--- a/crates/tools/web-retrieval/tests/fetch_streaming.rs
+++ b/crates/tools/web-retrieval/tests/fetch_streaming.rs
@@ -1,5 +1,6 @@
 //! Integration tests for streaming download behavior in `web_fetch`.
 
+use agentic_tools_core::ToolContext;
 use web_retrieval::WebTools;
 use web_retrieval::fetch::HARD_MAX_BYTES;
 use web_retrieval::fetch::web_fetch;
@@ -33,7 +34,9 @@ async fn fetch_under_cap_is_not_truncated() {
         max_bytes: Some(1024),
     };
 
-    let out = web_fetch(&tools, input).await.unwrap();
+    let out = web_fetch(&tools, input, &ToolContext::default())
+        .await
+        .unwrap();
     assert!(!out.truncated);
     assert_eq!(out.content.len(), body.len());
 }
@@ -62,7 +65,9 @@ async fn fetch_over_cap_is_truncated_and_returns_exactly_max_bytes() {
         max_bytes: Some(cap),
     };
 
-    let out = web_fetch(&tools, input).await.unwrap();
+    let out = web_fetch(&tools, input, &ToolContext::default())
+        .await
+        .unwrap();
     assert!(out.truncated);
     assert_eq!(out.content.len(), cap);
 }
@@ -78,7 +83,9 @@ async fn max_bytes_over_hard_cap_is_rejected_before_request() {
         max_bytes: Some(HARD_MAX_BYTES + 1),
     };
 
-    let err = web_fetch(&tools, input).await.unwrap_err();
+    let err = web_fetch(&tools, input, &ToolContext::default())
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("max_bytes"));
 
     let received = server.received_requests().await.unwrap();

--- a/workflow.md
+++ b/workflow.md
@@ -99,6 +99,8 @@ REVIEW:     review
 
 If I ever need additional tools that aren't in the list of ones above, I'll tab over to a different agent that has access to them. Also, sometimes commands will automatically bring those tools into context just for the duration of the command being ran, e.g. `/commit`
 
+Request-scoped MCP cancellation now flows through `ToolContext`, so long-running tools can stop promptly and clean up subprocesses before returning.
+
 ---
 
 ## Agent-Specific Additional Tools


### PR DESCRIPTION
PR description will be populated by /describe_pr.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

### Summary

This PR fixes the original ENG-762 claudecode session lifecycle leak, where cancelling a Claude-backed tool call could leave the Claude process and its nested MCP child alive. It also expands the work to propagate MCP request cancellation through the shared tool stack so long-running tools can stop promptly and clean up subprocesses before returning.

### Linear ticket

- `ENG-762` ticket mirror: [`thoughts/allison-eng-762-fix-claudecode-process-lifecycle-leaks-on-cancelled/artifacts/eng-762.md`](./thoughts/allison-eng-762-fix-claudecode-process-lifecycle-leaks-on-cancelled/artifacts/eng-762.md)

### Scope expansion

ENG-762 started as a narrow `claudecode-rs` lifecycle fix, but this branch intentionally expands scope beyond the original ticket. In addition to hardening Claude session cancellation, it wires MCP-level cancellation through both MCP apps and the explicitly approved high-risk long-running tools so request aborts become observable and actionable across the stack.

### OpenCode / Claude Code interop note

Claude Code already emits request cancellation on `Esc`, but OpenCode currently drops that abort signal in its MCP wrapper before it reaches the server. This PR still implements cancellation correctly at the MCP/tool boundary for Claude Code immediately, and it future-proofs the stack for OpenCode once its wrapper forwards aborts per the MCP contract.

## What user-facing changes did I ship?

### What changed by area

- Cancellation infrastructure (`agentic-tools-core`, `agentic-tools-mcp`)
  - Added first-class cancellation to `ToolContext` via `CancellationToken`, plus `cancelled()`, `is_cancelled()`, `cancellation_token()`, and `run_cancellable(...)` helpers (`crates/agentic-tools/core/src/context.rs:8-81`).
  - Added a dedicated `ToolError::Cancelled` variant so request aborts are represented distinctly from tool failures (`crates/agentic-tools/core/src/error.rs:7-70`).
  - Threaded rmcp request cancellation into tool dispatch with a child token in `RegistryServer::call_tool(...)` and added cancellation-aware dispatch logging (`crates/agentic-tools/mcp/src/server.rs:203-263`).

- `claudecode-rs` lifecycle (original ticket fix)
  - Spawn Claude in its own Unix process group with `Command::process_group(0)` and introduced a cloneable `KillHandle` plus process-group signalling and a bounded grace period (`crates/services/claudecode-rs/src/process.rs:19-169`).
  - Refactored `Session` to retain kill capability after worker startup, track worker/stderr tasks explicitly, make `wait()` cancellation-safe, and make explicit `cancel()` cleanup the primary path while keeping `Drop` as a best-effort backstop (`crates/services/claudecode-rs/src/session.rs:29-448`).
  - Added a fake Claude binary and lifecycle coverage for drop cleanup, post-startup kill, process-group isolation, child pgid inheritance, and bounded cancel latency (`crates/services/claudecode-rs/src/bin/fake_claude.rs:1-132`, `crates/services/claudecode-rs/tests/lifecycle.rs:1-146`).

- High-risk tool adoption
  - `run`, `respond_permission`, `respond_question`: added request-cancellation handling to the orchestrator monitoring path and regression tests around cancelled waits (`apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs:28-176`).
  - `ask_agent`: switched Claude-backed execution from bare `launch_and_wait(...)` to explicit session lifecycle handling so cancellation calls `session.cancel().await` before returning (`crates/tools/coding-agent-tools/src/lib.rs`).
  - `review_run`: applied the same explicit Claude-session cancellation path inside the existing reviewer timeout policy (`crates/tools/review-tools/src/reviewer.rs`).
  - `cli_just_execute`: replaced `Command::output()` with an explicit cancellable child process path that kills `just` on request cancellation (`crates/tools/coding-agent-tools/src/just/exec.rs`).
  - `ask_reasoning_model`: races optimizer/executor network work and retry backoff against request cancellation (`crates/tools/gpt5-reasoner/src/engine/orchestration.rs`).
  - `web_fetch`, `web_search`: guard request startup, chunk reads, and optional summarization with `ToolContext` cancellation (`crates/tools/web-retrieval/src/fetch.rs`, `crates/tools/web-retrieval/src/search.rs`, `crates/tools/web-retrieval/src/haiku.rs`).

- Docs / TODO follow-ups
  - Added the ENG-762 follow-up queue to `TODO.md:64-70`.
  - Added a workflow note documenting that MCP request cancellation now flows through `ToolContext` (`workflow.md:101`).

## How I implemented it

### Key design decisions

- Kept `Tool::call(input, &ToolContext)` unchanged and extended `ToolContext` instead, so cancellation became available everywhere without forcing a tool trait signature change (`crates/agentic-tools/core/src/context.rs:30-81`).
- Put a cloneable `KillHandle` on `Session` so kill/cancel survives handing `ProcessHandle` ownership to worker tasks (`crates/services/claudecode-rs/src/process.rs:27-169`, `crates/services/claudecode-rs/src/session.rs:29-91`).
- Used `Command::process_group(0)` on Unix instead of a custom spawn hook, since the workspace Tokio version already supports it (`crates/services/claudecode-rs/src/process.rs:61-65`).
- Chose a fixed 250ms grace period before SIGKILL to keep cancellation responsive while still allowing cooperative shutdown first (`crates/services/claudecode-rs/src/process.rs:19,155-163`).
- Added `ToolError::Cancelled` so callers, logs, and MCP responses can distinguish request aborts from real failures (`crates/agentic-tools/core/src/error.rs:28-70`).
- Treat `Drop` as a synchronous backstop only; explicit `cancel()` / `kill()` remains the primary cleanup path for subprocess-owning code (`crates/services/claudecode-rs/src/session.rs:373-448`).

### Testing

Added or expanded focused cancellation coverage in:

- `crates/services/claudecode-rs/tests/lifecycle.rs`
- `crates/services/claudecode-rs/src/bin/fake_claude.rs`
- `crates/agentic-tools/mcp/tests/integration.rs`
- `apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs`
- `crates/tools/coding-agent-tools/src/just/exec.rs`
- `crates/tools/coding-agent-tools/src/lib.rs`
- `crates/tools/review-tools/src/reviewer.rs`
- `crates/tools/gpt5-reasoner/src/engine/orchestration.rs`
- `crates/tools/web-retrieval/src/fetch.rs`
- `crates/tools/web-retrieval/src/search.rs`

### Verification

- [x] `just check`
- [x] `just test`
- [x] `just xtask-verify-check`
- [x] `just crate-test claudecode`
- [x] I ran the "check" and "test" recipes via the Just MCP tools and they passed

### Deferred follow-ups (TODOs added)

- Node/NAPI abort-signal propagation for JS callers
- Mutation-tool cancellation semantics after a remote side effect has started
- OpenCode `sessions().abort()` from orchestrator monitoring
- `cli_just_search` cancellation adoption
- Remaining blocking tools such as `thoughts_get_repo_refs` and `review_diff_snapshot`
- Windows process-group / process-tree handling for `claudecode-rs`
- `[lints] workspace = true` rollout for `agentic-tools-core`, `agentic-tools-mcp`, `claudecode`, and `gpt5_reasoner`

### Acceptance criteria checklist

- [x] Dropping or aborting a running `launch_and_wait` future terminates the fake Claude process.
- [x] The fake Claude child process is also terminated.
- [x] `Session::kill` works after the output worker has taken ownership of the process.
- [x] Claude's process group differs from the test process group.
- [x] Fake Claude's child shares Claude's process group.
- [x] `cargo test -p claudecode` passes.

## How to verify it

- [x] Run `just check`
- [x] Run `just test`
- [x] Run `just xtask-verify-check`
- [x] Run `just crate-test claudecode`

## Description for the changelog

Fix Claude session cancellation leaks and propagate MCP cancellation through the shared tool stack so cancelled long-running calls stop promptly and clean up their subprocesses.
<!-- END:describe_pr:autogen -->
