### PR TITLE
Fix ENG-726 reasoning-tool hangs with executor streaming recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -149,7 +149,6 @@ project. Either than or tooling for interacting with cargo cache
 in a clean/streamlined abstraction. Probably both would be ideal
 long term.
 
-- TODO(2): `gpt5_reasoner`: `reasoning.api_base_url` / `AGENTIC_REASONING_API_BASE_URL` exists in config but the client hardcodes OpenRouter base URL (see `crates/tools/gpt5-reasoner/src/client.rs`).
 - TODO(2): `thoughts`: `status --detailed` flag is accepted but currently has no effect (unused parameter in `apps/thoughts/src/commands/status.rs`).
 - TODO(2): `thoughts`: `sync` code comment claims "repository-aware sync" but behavior does not filter by repo (see `apps/thoughts/src/commands/sync.rs`).
 - TODO(2): `agentic-bin`: missing `[package.metadata.binstall]` unlike other shipped binaries (see `apps/agentic/Cargo.toml`).

--- a/agentic.schema.json
+++ b/agentic.schema.json
@@ -44,8 +44,11 @@
       "description": "Tool-specific config for gpt5-reasoner.",
       "$ref": "#/$defs/ReasoningConfig",
       "default": {
+        "empty_response_no_retry_after_secs": 600,
         "executor_model": "openai/gpt-5.2",
-        "optimizer_model": "anthropic/claude-sonnet-4.6"
+        "executor_timeout_secs": 2700,
+        "optimizer_model": "anthropic/claude-sonnet-4.6",
+        "stream_heartbeat_secs": 30
       }
     },
     "services": {
@@ -209,10 +212,24 @@
             "null"
           ]
         },
+        "empty_response_no_retry_after_secs": {
+          "description": "Suppress empty-response retry when attempt duration exceeds this threshold.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 600,
+          "minimum": 0
+        },
         "executor_model": {
           "description": "`OpenRouter` model ID for executor/reasoner step.",
           "type": "string",
           "default": "openai/gpt-5.2"
+        },
+        "executor_timeout_secs": {
+          "description": "Executor timeout in seconds.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 2700,
+          "minimum": 0
         },
         "optimizer_model": {
           "description": "`OpenRouter` model ID for optimizer step.",
@@ -229,6 +246,13 @@
               "type": "null"
             }
           ]
+        },
+        "stream_heartbeat_secs": {
+          "description": "Heartbeat cadence for executor streaming logs.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 30,
+          "minimum": 0
         },
         "token_limit": {
           "description": "Optional token limit for reasoning requests.",

--- a/crates/agentic-tools/registry/src/lib.rs
+++ b/crates/agentic-tools/registry/src/lib.rs
@@ -445,6 +445,9 @@ mod tests {
                 reasoning_effort: Some("high".into()),
                 api_base_url: None,
                 token_limit: None,
+                executor_timeout_secs: 2700,
+                empty_response_no_retry_after_secs: 600,
+                stream_heartbeat_secs: 30,
             },
             ..Default::default()
         };

--- a/crates/infra/agentic-config/src/loader.rs
+++ b/crates/infra/agentic-config/src/loader.rs
@@ -156,6 +156,21 @@ fn apply_env_overrides(cfg: &mut AgenticConfig) {
     {
         cfg.reasoning.token_limit = Some(n);
     }
+    if let Some(v) = env_trimmed("AGENTIC_REASONING_EXECUTOR_TIMEOUT_SECS")
+        && let Ok(n) = v.parse()
+    {
+        cfg.reasoning.executor_timeout_secs = n;
+    }
+    if let Some(v) = env_trimmed("AGENTIC_REASONING_EMPTY_RESPONSE_NO_RETRY_AFTER_SECS")
+        && let Ok(n) = v.parse()
+    {
+        cfg.reasoning.empty_response_no_retry_after_secs = n;
+    }
+    if let Some(v) = env_trimmed("AGENTIC_REASONING_STREAM_HEARTBEAT_SECS")
+        && let Ok(n) = v.parse()
+    {
+        cfg.reasoning.stream_heartbeat_secs = n;
+    }
 
     // --- Logging overrides ---
     if let Some(v) = env_trimmed("AGENTIC_LOG_LEVEL") {
@@ -301,6 +316,41 @@ optimizer_model = "file-model"
 
         let loaded = load_merged(temp.path()).unwrap();
         assert_eq!(loaded.config.reasoning.optimizer_model, "env-model");
+    }
+
+    #[test]
+    #[serial]
+    fn test_reasoning_defaults_include_streaming_recovery_fields() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvGuard::set(CONFIG_DIR_TEST_VAR, temp.path());
+
+        let loaded = load_merged(temp.path()).unwrap();
+
+        assert_eq!(loaded.config.reasoning.executor_timeout_secs, 2700);
+        assert_eq!(
+            loaded.config.reasoning.empty_response_no_retry_after_secs,
+            600
+        );
+        assert_eq!(loaded.config.reasoning.stream_heartbeat_secs, 30);
+    }
+
+    #[test]
+    #[serial]
+    fn test_reasoning_streaming_env_overrides_apply() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvGuard::set(CONFIG_DIR_TEST_VAR, temp.path());
+        let _g1 = EnvGuard::set("AGENTIC_REASONING_EXECUTOR_TIMEOUT_SECS", "123");
+        let _g2 = EnvGuard::set("AGENTIC_REASONING_EMPTY_RESPONSE_NO_RETRY_AFTER_SECS", "45");
+        let _g3 = EnvGuard::set("AGENTIC_REASONING_STREAM_HEARTBEAT_SECS", "9");
+
+        let loaded = load_merged(temp.path()).unwrap();
+
+        assert_eq!(loaded.config.reasoning.executor_timeout_secs, 123);
+        assert_eq!(
+            loaded.config.reasoning.empty_response_no_retry_after_secs,
+            45
+        );
+        assert_eq!(loaded.config.reasoning.stream_heartbeat_secs, 9);
     }
 
     #[test]

--- a/crates/infra/agentic-config/src/types.rs
+++ b/crates/infra/agentic-config/src/types.rs
@@ -115,6 +115,12 @@ pub struct ReasoningConfig {
     /// Optional token limit for reasoning requests.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_limit: Option<u32>,
+    /// Executor timeout in seconds.
+    pub executor_timeout_secs: u64,
+    /// Suppress empty-response retry when attempt duration exceeds this threshold.
+    pub empty_response_no_retry_after_secs: u64,
+    /// Heartbeat cadence for executor streaming logs.
+    pub stream_heartbeat_secs: u64,
 }
 
 impl Default for ReasoningConfig {
@@ -125,6 +131,9 @@ impl Default for ReasoningConfig {
             reasoning_effort: None,
             api_base_url: None,
             token_limit: None,
+            executor_timeout_secs: 2700,
+            empty_response_no_retry_after_secs: 600,
+            stream_heartbeat_secs: 30,
         }
     }
 }

--- a/crates/tools/gpt5-reasoner/Cargo.toml
+++ b/crates/tools/gpt5-reasoner/Cargo.toml
@@ -41,6 +41,7 @@ path = "src/lib.rs"
 tempfile = "3"
 tokio-test = "0.4"
 serial_test = "3"
+wiremock = "0.6"
 
 [package.metadata.repo]
 role = "tool-lib"

--- a/crates/tools/gpt5-reasoner/src/client.rs
+++ b/crates/tools/gpt5-reasoner/src/client.rs
@@ -8,12 +8,16 @@ pub struct OrClient {
 }
 
 impl OrClient {
-    pub fn from_env() -> Result<Self> {
+    pub fn from_env(api_base_url: Option<&str>) -> Result<Self> {
         let api_key = std::env::var("OPENROUTER_API_KEY")
             .map_err(|_| ReasonerError::MissingEnv("OPENROUTER_API_KEY".into()))?;
 
+        let base = api_base_url
+            .unwrap_or("https://openrouter.ai/api/v1")
+            .trim_end_matches('/');
+
         let config = OpenAIConfig::new()
-            .with_api_base("https://openrouter.ai/api/v1")
+            .with_api_base(base)
             .with_api_key(api_key);
 
         Ok(Self {

--- a/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
+++ b/crates/tools/gpt5-reasoner/src/engine/orchestration.rs
@@ -22,12 +22,70 @@ use agentic_logging::LogWriter;
 use agentic_logging::ToolCallRecord;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
+use async_openai::error::OpenAIError;
 use async_openai::types::chat::ChatCompletionRequestMessage;
 use async_openai::types::chat::ChatCompletionRequestUserMessageArgs;
+use async_openai::types::chat::ChatCompletionStreamOptions;
+use async_openai::types::chat::CompletionUsage;
 use async_openai::types::chat::CreateChatCompletionRequestArgs;
 use async_openai::types::chat::ReasoningEffort;
+use futures::StreamExt;
 use thoughts_tool::DocumentType;
 use thoughts_tool::write_document;
+
+const PARTIAL_REASONING_MARKER: &str = "> **Warning:** Partial response (executor stream interrupted). Content below may be incomplete.\n\n";
+
+const PARTIAL_PLAN_MARKER: &str = "**WARNING: INCOMPLETE PLAN**\nThe plan below may be incomplete because the executor stream ended unexpectedly.\n\n---\n\n";
+
+#[derive(Debug)]
+enum ExecutorStreamError {
+    Cancelled,
+    OpenAI(OpenAIError),
+}
+
+#[derive(Debug, Default)]
+struct ExecutorStreamState {
+    content: String,
+    usage: Option<CompletionUsage>,
+    chunks: usize,
+    first_content_ms: Option<u128>,
+}
+
+impl ExecutorStreamState {
+    fn has_content(&self) -> bool {
+        !self.content.trim().is_empty()
+    }
+}
+
+fn prepend_partial_output(prompt_type: &PromptType, content: &str) -> String {
+    match prompt_type {
+        PromptType::Reasoning => format!("{PARTIAL_REASONING_MARKER}{content}"),
+        PromptType::Plan => format!("{PARTIAL_PLAN_MARKER}{content}"),
+    }
+}
+
+fn executor_stream_summary(
+    attempt: usize,
+    duration: std::time::Duration,
+    state: &ExecutorStreamState,
+    partial: bool,
+    timeout: bool,
+    empty: bool,
+    stream_error: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "attempt": attempt + 1,
+        "duration_ms": duration.as_millis(),
+        "chunks": state.chunks,
+        "chars": state.content.len(),
+        "first_content_ms": state.first_content_ms,
+        "usage_present": state.usage.is_some(),
+        "partial": partial,
+        "timeout": timeout,
+        "empty": empty,
+        "stream_error": stream_error,
+    })
+}
 
 /// Parse reasoning effort string to enum, defaulting to Xhigh.
 fn parse_reasoning_effort(v: Option<&str>) -> ReasoningEffort {
@@ -78,7 +136,8 @@ pub async fn gpt5_reasoner_impl(
                       response_file: Option<String>,
                       model: Option<String>,
                       token_usage: Option<agentic_logging::TokenUsage>,
-                      files_count: usize| {
+                      files_count: usize,
+                      summary: Option<serde_json::Value>| {
         if let Some(ref w) = writer {
             let (completed_at, duration_ms) = timer.finish();
             // TODO(2): Consider truncating large payloads (prompt, directories) to reduce log
@@ -103,7 +162,7 @@ pub async fn gpt5_reasoner_impl(
                 error,
                 model,
                 token_usage,
-                summary: None,
+                summary,
             };
             if let Err(e) = w.append_jsonl(&record) {
                 tracing::warn!("Failed to append JSONL log: {}", e);
@@ -117,7 +176,7 @@ pub async fn gpt5_reasoner_impl(
             Ok(v) => v,
             Err(e) => {
                 let msg = format!("stage=expand_directories: {}", e);
-                log_record(false, Some(msg), None, None, None, files.len());
+                log_record(false, Some(msg), None, None, None, files.len(), None);
                 return Err(ToolError::from(e));
             }
         };
@@ -165,7 +224,7 @@ pub async fn gpt5_reasoner_impl(
     tracing::info!("Pre-validating {} file(s) before optimizer", files.len());
     if let Err(e) = precheck_files(&files) {
         let msg = format!("stage=precheck_files: {}", e);
-        log_record(false, Some(msg), None, None, None, files.len());
+        log_record(false, Some(msg), None, None, None, files.len(), None);
         return Err(e);
     }
     // ===== END NEW =====
@@ -178,7 +237,7 @@ pub async fn gpt5_reasoner_impl(
     }
 
     // Load env OpenRouter key (CLI already optionally did dotenv)
-    let client = OrClient::from_env().map_err(ToolError::from)?;
+    let client = OrClient::from_env(cfg.api_base_url.as_deref()).map_err(ToolError::from)?;
 
     // Step 1: optimize with retry on validation errors
     let opt_model = cfg.optimizer_model.clone();
@@ -216,7 +275,7 @@ pub async fn gpt5_reasoner_impl(
             Ok(v) => v,
             Err(e) => {
                 let msg = format!("stage=optimizer_call: {}", e);
-                log_record(false, Some(msg), None, None, None, files.len());
+                log_record(false, Some(msg), None, None, None, files.len(), None);
                 return Err(e);
             }
         };
@@ -252,7 +311,7 @@ pub async fn gpt5_reasoner_impl(
                 };
 
                 let msg = format!("stage={}: {}", stage, e);
-                log_record(false, Some(msg), None, None, None, files.len());
+                log_record(false, Some(msg), None, None, None, files.len(), None);
                 return Err(ToolError::from(e));
             }
         }
@@ -278,7 +337,7 @@ pub async fn gpt5_reasoner_impl(
         Ok(v) => v,
         Err(e) => {
             let msg = format!("stage=inject_files: {}", e);
-            log_record(false, Some(msg), None, None, None, files.len());
+            log_record(false, Some(msg), None, None, None, files.len(), None);
             return Err(ToolError::from(e));
         }
     };
@@ -290,7 +349,7 @@ pub async fn gpt5_reasoner_impl(
         Ok(v) => v,
         Err(e) => {
             let msg = format!("stage=count_tokens: {}", e);
-            log_record(false, Some(msg), None, None, None, files.len());
+            log_record(false, Some(msg), None, None, None, files.len(), None);
             return Err(ToolError::from(e));
         }
     };
@@ -302,9 +361,75 @@ pub async fn gpt5_reasoner_impl(
 
     if let Err(e) = enforce_limit(&final_prompt) {
         let msg = format!("stage=enforce_limit: {}", e);
-        log_record(false, Some(msg), None, None, None, files.len());
+        log_record(false, Some(msg), None, None, None, files.len(), None);
         return Err(ToolError::from(e));
     }
+
+    let finalize_executor_success = |content: String,
+                                     usage: Option<agentic_logging::TokenUsage>,
+                                     partial: bool,
+                                     summary: Option<serde_json::Value>|
+     -> std::result::Result<String, ToolError> {
+        let rendered = if partial {
+            prepend_partial_output(&prompt_type, &content)
+        } else {
+            content
+        };
+
+        let mut response_file = None;
+        let returned: String;
+
+        match prompt_type {
+            PromptType::Plan => {
+                if let Some(ref name) = output_filename {
+                    match write_document(&DocumentType::Plan, name, &rendered) {
+                        Ok(ok) => {
+                            returned = ok.path;
+                        }
+                        Err(e) => {
+                            let msg = format!("stage=write_plan_document: {}", e);
+                            log_record(
+                                false,
+                                Some(msg),
+                                None,
+                                Some(cfg.executor_model.clone()),
+                                None,
+                                files.len(),
+                                summary,
+                            );
+                            return Err(ToolError::internal(e.to_string()));
+                        }
+                    }
+                } else {
+                    returned = rendered;
+                }
+            }
+            PromptType::Reasoning => {
+                if let Some(ref w) = writer {
+                    let (completed_at, _) = timer.finish();
+                    if let Ok(md_name) =
+                        w.write_markdown_response(completed_at, &timer.call_id, &rendered)
+                        && !md_name.is_empty()
+                    {
+                        response_file = Some(md_name);
+                    }
+                }
+                returned = rendered;
+            }
+        }
+
+        log_record(
+            true,
+            None,
+            response_file,
+            Some(cfg.executor_model.clone()),
+            usage,
+            files.len(),
+            summary,
+        );
+
+        Ok(returned)
+    };
 
     // Execute with application-level retries for network/transport errors
     const EXECUTOR_RETRIES: usize = 1;
@@ -340,7 +465,7 @@ pub async fn gpt5_reasoner_impl(
             Ok(m) => m,
             Err(e) => {
                 let msg = format!("stage=build_chat_request: user message build failed: {}", e);
-                log_record(false, Some(msg), None, None, None, files.len());
+                log_record(false, Some(msg), None, None, None, files.len(), None);
                 return Err(ToolError::from(ReasonerError::from(e)));
             }
         };
@@ -350,178 +475,271 @@ pub async fn gpt5_reasoner_impl(
             .messages([ChatCompletionRequestMessage::User(user_msg)])
             .reasoning_effort(reasoning_effort.clone())
             .temperature(0.2)
+            .stream_options(ChatCompletionStreamOptions {
+                include_usage: Some(true),
+                include_obfuscation: None,
+            })
             .build()
         {
             Ok(r) => r,
             Err(e) => {
                 let msg = format!("stage=build_chat_request: request build failed: {}", e);
-                log_record(false, Some(msg), None, None, None, files.len());
+                log_record(false, Some(msg), None, None, None, files.len(), None);
                 return Err(ToolError::from(ReasonerError::from(e)));
             }
         };
 
-        let start = std::time::Instant::now();
-        let chat = client.client.chat();
-        let executor_response = tokio::select! {
-            () = ctx.cancelled() => return Err(ToolError::cancelled(None)),
-            response = chat.create(req) => response,
-        };
+        let attempt_started = std::time::Instant::now();
+        let executor_timeout = std::time::Duration::from_secs(cfg.executor_timeout_secs);
+        let heartbeat = std::time::Duration::from_secs(cfg.stream_heartbeat_secs);
+        let mut stream_state = ExecutorStreamState::default();
 
-        match executor_response {
-            Ok(resp) => {
-                let duration = start.elapsed();
-                tracing::debug!("Executor API succeeded in {:?}", duration);
+        let stream_result = tokio::time::timeout(executor_timeout, async {
+            let chat = client.client.chat();
+            let mut stream = tokio::select! {
+                () = ctx.cancelled() => return Err(ExecutorStreamError::Cancelled),
+                response = chat.create_stream(req) => response.map_err(ExecutorStreamError::OpenAI)?,
+            };
+            let mut heartbeat_sleep =
+                (heartbeat.as_secs() > 0).then(|| Box::pin(tokio::time::sleep(heartbeat)));
 
-                // NEW: log response metadata + classify emptiness
-                let empty_kind = crate::logging::log_chat_response("executor", &resp, duration);
-
-                // Extract content option
-                let content_opt = resp.choices.first().and_then(|c| c.message.content.clone());
-
-                // Determine if content is effectively empty
-                let is_effectively_empty = match &content_opt {
-                    None => true,
-                    Some(s) if s.is_empty() => true,
-                    Some(s) if s.trim().is_empty() => true,
-                    _ => false,
+            loop {
+                let item = if let Some(ref mut heartbeat_sleep) = heartbeat_sleep {
+                    tokio::select! {
+                        () = ctx.cancelled() => return Err(ExecutorStreamError::Cancelled),
+                        _ = heartbeat_sleep.as_mut() => {
+                            tracing::debug!(
+                                elapsed_ms = attempt_started.elapsed().as_millis(),
+                                chars_so_far = stream_state.content.len(),
+                                chunks = stream_state.chunks,
+                                "executor stream heartbeat"
+                            );
+                            heartbeat_sleep
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + heartbeat);
+                            continue;
+                        }
+                        item = stream.next() => item,
+                    }
+                } else {
+                    tokio::select! {
+                        () = ctx.cancelled() => return Err(ExecutorStreamError::Cancelled),
+                        item = stream.next() => item,
+                    }
                 };
 
-                if is_effectively_empty {
-                    // Warn with specific classification if available
-                    if let Some(kind) = empty_kind {
-                        crate::logging::log_empty_warning("executor", kind, &resp);
-                    } else {
-                        tracing::warn!("Executor received empty content (unclassified)");
-                    }
+                match item {
+                    None => break,
+                    Some(Ok(chunk)) => {
+                        stream_state.chunks += 1;
 
-                    // NEW: Treat as retryable anomaly once, then return helpful error
-                    if attempt < EXECUTOR_RETRIES {
+                        if let Some(usage) = chunk.usage {
+                            stream_state.usage = Some(usage);
+                        }
+
+                        for choice in chunk.choices {
+                            if let Some(delta) = choice.delta.content
+                                && !delta.is_empty()
+                            {
+                                if stream_state.first_content_ms.is_none() {
+                                    stream_state.first_content_ms =
+                                        Some(attempt_started.elapsed().as_millis());
+                                }
+                                stream_state.content.push_str(&delta);
+                            }
+                        }
+
+                        if let Some(ref mut heartbeat_sleep) = heartbeat_sleep {
+                            heartbeat_sleep
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + heartbeat);
+                        }
+                    }
+                    Some(Err(e)) => return Err(ExecutorStreamError::OpenAI(e)),
+                }
+            }
+
+            Ok(())
+        })
+        .await;
+
+        let duration = attempt_started.elapsed();
+        let usage = stream_state
+            .usage
+            .as_ref()
+            .map(crate::logging::token_usage_from_completion_usage);
+
+        match stream_result {
+            Ok(Ok(())) => {
+                tracing::debug!(
+                    duration_ms = duration.as_millis(),
+                    chunks = stream_state.chunks,
+                    chars = stream_state.content.len(),
+                    "Executor stream completed"
+                );
+
+                if !stream_state.has_content() {
+                    let summary = Some(executor_stream_summary(
+                        attempt,
+                        duration,
+                        &stream_state,
+                        false,
+                        false,
+                        true,
+                        None,
+                    ));
+                    let attempt_secs = duration.as_secs();
+
+                    if attempt == 0 && attempt_secs <= cfg.empty_response_no_retry_after_secs {
                         tracing::warn!(
-                            "Empty response from executor model {}; retrying (attempt {} of {})",
-                            executor_model,
-                            attempt + 2,
-                            EXECUTOR_RETRIES + 1
+                            duration_secs = attempt_secs,
+                            threshold_secs = cfg.empty_response_no_retry_after_secs,
+                            "Executor stream completed empty; retrying once"
                         );
                         continue;
                     }
 
-                    // Final failure after retry
-                    let err_msg = format!(
-                        "Reasoning model returned no response after {} attempt(s). \
-                         Possible causes: content filtering, prompt issues, or API anomaly.",
-                        attempt + 1
-                    );
+                    let err_msg = if attempt == 0
+                        && attempt_secs > cfg.empty_response_no_retry_after_secs
+                    {
+                        format!(
+                            "Reasoning model returned no response after a long attempt ({}s); retry suppressed.",
+                            attempt_secs
+                        )
+                    } else {
+                        format!(
+                            "Reasoning model returned no response after {} attempt(s). Possible causes: content filtering, prompt issues, or API anomaly.",
+                            attempt + 1
+                        )
+                    };
+
                     tracing::error!("{}", err_msg);
                     log_record(
                         false,
                         Some(format!("stage=empty_response: {}", err_msg)),
                         None,
                         Some(executor_model.to_string()),
-                        None,
+                        usage,
                         files.len(),
+                        summary,
                     );
-                    return Err(ToolError::Internal(
-                        "Reasoning model returned no response after retry. \
-                         Check logs for response metadata (id, finish_reason, usage). \
-                         Possible causes: content filtering, prompt issues, or API anomaly."
-                            .to_string(),
-                    ));
+                    return Err(ToolError::internal(err_msg));
                 }
 
-                // Non-empty content → success
-                let content = content_opt.expect("guarded by is_effectively_empty=false");
-
-                // Extract token usage (includes reasoning_tokens when present)
-                let usage = crate::logging::extract_token_usage(&resp);
-
-                let mut response_file = None;
-                let returned: String;
-
-                match prompt_type {
-                    PromptType::Plan => {
-                        if let Some(ref name) = output_filename {
-                            // Write plan to plans/ directory
-                            match write_document(&DocumentType::Plan, name, &content) {
-                                Ok(ok) => {
-                                    returned = ok.path;
-                                }
-                                Err(e) => {
-                                    let msg = format!("stage=write_plan_document: {}", e);
-                                    log_record(
-                                        false,
-                                        Some(msg),
-                                        None,
-                                        Some(executor_model.to_string()),
-                                        None,
-                                        files.len(),
-                                    );
-                                    // TODO(3): Use ErrorCode::IoError instead of internal() for better error semantics
-                                    return Err(ToolError::internal(e.to_string()));
-                                }
-                            }
-                        } else {
-                            // Return content directly
-                            returned = content;
-                        }
-                    }
-                    PromptType::Reasoning => {
-                        // Write response markdown to logs/ daily dir (best-effort)
-                        // TODO(2): timer.finish() is non-idempotent (returns fresh Utc::now() each call).
-                        // The log_record closure also calls timer.finish() at line 57, causing timestamp
-                        // drift between the markdown filename and JSONL log. Refactor to call finish()
-                        // once and pass (completed_at, duration_ms) to log_record as params.
-                        if let Some(ref w) = writer {
-                            let (completed_at, _) = timer.finish();
-                            if let Ok(md_name) =
-                                w.write_markdown_response(completed_at, &timer.call_id, &content)
-                                && !md_name.is_empty()
-                            {
-                                response_file = Some(md_name);
-                            }
-                        }
-                        returned = content;
-                    }
-                }
-
-                // Append JSONL via closure (best-effort)
-                log_record(
-                    true,
+                let summary = Some(executor_stream_summary(
+                    attempt,
+                    duration,
+                    &stream_state,
+                    false,
+                    false,
+                    false,
                     None,
-                    response_file,
-                    Some(executor_model.to_string()),
-                    usage,
-                    files.len(),
-                );
-
-                return Ok(returned);
+                ));
+                return finalize_executor_success(stream_state.content, usage, false, summary);
             }
-            Err(e) => {
+            Ok(Err(ExecutorStreamError::Cancelled)) => return Err(ToolError::cancelled(None)),
+            Ok(Err(ExecutorStreamError::OpenAI(e))) => {
+                let error_text = e.to_string();
+                if stream_state.has_content() {
+                    tracing::warn!(
+                        error = %e,
+                        chars = stream_state.content.len(),
+                        chunks = stream_state.chunks,
+                        "Executor stream failed after partial content; salvaging"
+                    );
+                    let summary = Some(executor_stream_summary(
+                        attempt,
+                        duration,
+                        &stream_state,
+                        true,
+                        false,
+                        false,
+                        Some(&error_text),
+                    ));
+                    return finalize_executor_success(stream_state.content, usage, true, summary);
+                }
+
                 let retryable = crate::errors::is_retryable_app_level(&e);
                 if attempt < EXECUTOR_RETRIES && retryable {
-                    tracing::warn!("Executor call failed with retryable error: {e}; retrying...");
+                    tracing::warn!("Executor stream failed with retryable error: {e}; retrying...");
                     continue;
                 }
 
-                // Not retryable or retries exhausted
                 if retryable {
                     tracing::error!(
-                        "Executor call failed after {} attempts with retryable error: {}",
+                        "Executor stream failed after {} attempts with retryable error: {}",
                         attempt + 1,
                         e
                     );
                 } else {
-                    tracing::error!("Executor call failed with non-retryable error: {}", e);
+                    tracing::error!("Executor stream failed with non-retryable error: {}", e);
                 }
+
+                let summary = Some(executor_stream_summary(
+                    attempt,
+                    duration,
+                    &stream_state,
+                    false,
+                    false,
+                    false,
+                    Some(&error_text),
+                ));
                 let msg = format!("stage=chat_execute: {}", e);
                 log_record(
                     false,
                     Some(msg),
                     None,
                     Some(executor_model.to_string()),
-                    None,
+                    usage,
                     files.len(),
+                    summary,
                 );
                 return Err(ToolError::from(ReasonerError::from(e)));
+            }
+            Err(_) => {
+                if stream_state.has_content() {
+                    tracing::warn!(
+                        timeout_secs = cfg.executor_timeout_secs,
+                        chars = stream_state.content.len(),
+                        chunks = stream_state.chunks,
+                        "Executor stream timed out after partial content; salvaging"
+                    );
+                    let summary = Some(executor_stream_summary(
+                        attempt,
+                        duration,
+                        &stream_state,
+                        true,
+                        true,
+                        false,
+                        Some("executor_timeout"),
+                    ));
+                    return finalize_executor_success(stream_state.content, usage, true, summary);
+                }
+
+                let err_msg = format!(
+                    "Executor stream timed out after {} second(s) before any content arrived.",
+                    cfg.executor_timeout_secs
+                );
+                tracing::error!("{}", err_msg);
+                let summary = Some(executor_stream_summary(
+                    attempt,
+                    duration,
+                    &stream_state,
+                    false,
+                    true,
+                    false,
+                    Some("executor_timeout"),
+                ));
+                log_record(
+                    false,
+                    Some(format!("stage=executor_timeout: {}", err_msg)),
+                    None,
+                    Some(executor_model.to_string()),
+                    usage,
+                    files.len(),
+                    summary,
+                );
+                return Err(ToolError::external(err_msg));
             }
         }
     }
@@ -534,6 +752,7 @@ pub async fn gpt5_reasoner_impl(
         Some(executor_model.to_string()),
         None,
         files.len(),
+        None,
     );
     Err(ToolError::Internal(
         "Executor failed after all retries".to_string(),

--- a/crates/tools/gpt5-reasoner/src/logging.rs
+++ b/crates/tools/gpt5-reasoner/src/logging.rs
@@ -1,21 +1,21 @@
 // crates/tools/gpt5-reasoner/src/logging.rs
 use agentic_logging::TokenUsage;
+use async_openai::types::chat::CompletionUsage;
 use async_openai::types::chat::CreateChatCompletionResponse;
 use std::time::Duration;
 
-/// Extract TokenUsage (including optional reasoning_tokens) from an OpenAI chat response.
-pub fn extract_token_usage(resp: &CreateChatCompletionResponse) -> Option<TokenUsage> {
-    let usage = resp.usage.as_ref()?;
+/// Convert streamed completion usage into the shared logging shape.
+pub fn token_usage_from_completion_usage(usage: &CompletionUsage) -> TokenUsage {
     let reasoning_tokens = usage
         .completion_tokens_details
         .as_ref()
         .and_then(|d| d.reasoning_tokens);
-    Some(TokenUsage {
+    TokenUsage {
         prompt: usage.prompt_tokens,
         completion: usage.completion_tokens,
         total: usage.total_tokens,
         reasoning_tokens,
-    })
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -191,31 +191,19 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_token_usage_parses_all_fields() {
+    fn test_token_usage_from_completion_usage_parses_all_fields() {
         let raw = serde_json::json!({
-            "id": "chatcmpl-1",
-            "object": "chat.completion",
-            "created": 1234567890,
-            "model": "openai/gpt-5.2",
-            "choices": [{
-                "index": 0,
-                "message": { "role": "assistant", "content": "ok" },
-                "logprobs": null,
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 20,
-                "total_tokens": 30,
-                "completion_tokens_details": { "reasoning_tokens": 7 }
-            }
+            "prompt_tokens": 11,
+            "completion_tokens": 21,
+            "total_tokens": 32,
+            "completion_tokens_details": { "reasoning_tokens": 8 }
         });
-        let resp: CreateChatCompletionResponse = serde_json::from_value(raw).unwrap();
+        let usage: CompletionUsage = serde_json::from_value(raw).unwrap();
 
-        let usage = extract_token_usage(&resp).expect("usage present");
-        assert_eq!(usage.prompt, 10);
-        assert_eq!(usage.completion, 20);
-        assert_eq!(usage.total, 30);
-        assert_eq!(usage.reasoning_tokens, Some(7));
+        let parsed = token_usage_from_completion_usage(&usage);
+        assert_eq!(parsed.prompt, 11);
+        assert_eq!(parsed.completion, 21);
+        assert_eq!(parsed.total, 32);
+        assert_eq!(parsed.reasoning_tokens, Some(8));
     }
 }

--- a/crates/tools/gpt5-reasoner/tests/api_base_url.rs
+++ b/crates/tools/gpt5-reasoner/tests/api_base_url.rs
@@ -8,6 +8,28 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
+struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(prev) => unsafe { std::env::set_var(self.key, prev) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
 #[tokio::test]
 #[serial(env)]
 async fn orclient_honors_api_base_url() {
@@ -28,7 +50,7 @@ async fn orclient_honors_api_base_url() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("OPENROUTER_API_KEY", "test") };
+    let _api_key_guard = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
 
     let client =
         gpt5_reasoner::client::OrClient::from_env(Some(&format!("{}/api/v1", server.uri())))

--- a/crates/tools/gpt5-reasoner/tests/api_base_url.rs
+++ b/crates/tools/gpt5-reasoner/tests/api_base_url.rs
@@ -1,0 +1,53 @@
+use async_openai::types::chat::ChatCompletionRequestMessage;
+use async_openai::types::chat::ChatCompletionRequestUserMessageArgs;
+use async_openai::types::chat::CreateChatCompletionRequestArgs;
+use serial_test::serial;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+#[tokio::test]
+#[serial(env)]
+async fn orclient_honors_api_base_url() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{
+              "id":"chatcmpl-1",
+              "object":"chat.completion",
+              "created":0,
+              "model":"test",
+              "choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+            }"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    unsafe { std::env::set_var("OPENROUTER_API_KEY", "test") };
+
+    let client =
+        gpt5_reasoner::client::OrClient::from_env(Some(&format!("{}/api/v1", server.uri())))
+            .unwrap();
+
+    let user_msg = ChatCompletionRequestUserMessageArgs::default()
+        .content("hi")
+        .build()
+        .unwrap();
+
+    let req = CreateChatCompletionRequestArgs::default()
+        .model("test-model")
+        .messages([ChatCompletionRequestMessage::User(user_msg)])
+        .build()
+        .unwrap();
+
+    let resp = client.client.chat().create(req).await.unwrap();
+    assert_eq!(resp.choices[0].message.content.as_deref(), Some("ok"));
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+}

--- a/crates/tools/gpt5-reasoner/tests/executor_streaming_recovery.rs
+++ b/crates/tools/gpt5-reasoner/tests/executor_streaming_recovery.rs
@@ -1,0 +1,598 @@
+use agentic_config::types::ReasoningConfig;
+use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use gpt5_reasoner::PromptType;
+use gpt5_reasoner::gpt5_reasoner_impl;
+use serial_test::serial;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use wiremock::Match;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::Request;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+const PARTIAL_REASONING_MARKER: &str = "> **Warning:** Partial response (executor stream interrupted). Content below may be incomplete.\n\n";
+const PARTIAL_PLAN_MARKER: &str = "**WARNING: INCOMPLETE PLAN**\nThe plan below may be incomplete because the executor stream ended unexpectedly.\n\n---\n\n";
+
+#[derive(Debug)]
+struct ModelMatcher(&'static str);
+
+impl Match for ModelMatcher {
+    fn matches(&self, request: &Request) -> bool {
+        serde_json::from_slice::<serde_json::Value>(&request.body)
+            .ok()
+            .and_then(|body| {
+                body.get("model")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            })
+            .as_deref()
+            == Some(self.0)
+    }
+}
+
+struct EnvVarGuard {
+    key: String,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(prev) => unsafe { std::env::set_var(&self.key, prev) },
+            None => unsafe { std::env::remove_var(&self.key) },
+        }
+    }
+}
+
+struct CwdGuard {
+    prev: PathBuf,
+}
+
+impl CwdGuard {
+    fn set(path: &Path) -> Self {
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self { prev }
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.prev).unwrap();
+    }
+}
+
+fn optimizer_response_body() -> String {
+    let content = r#"
+FILE_GROUPING
+```yaml
+file_groups:
+  - name: implementation_targets
+    files: []
+```
+
+OPTIMIZED_TEMPLATE
+```xml
+<context>
+  <!-- GROUP: implementation_targets -->
+</context>
+```
+"#;
+
+    format!(
+        r#"{{
+  "id":"chatcmpl-opt",
+  "object":"chat.completion",
+  "created":0,
+  "model":"opt",
+  "choices":[{{"index":0,"message":{{"role":"assistant","content":{content_json}}},"finish_reason":"stop"}}]
+}}"#,
+        content_json = serde_json::to_string(content).unwrap()
+    )
+}
+
+fn sse(lines: &[&str]) -> String {
+    lines.join("\n")
+}
+
+fn base_cfg(server: &MockServer) -> ReasoningConfig {
+    base_cfg_from_uri(format!("{}/api/v1", server.uri()))
+}
+
+fn base_cfg_from_uri(api_base_url: String) -> ReasoningConfig {
+    ReasoningConfig {
+        api_base_url: Some(api_base_url),
+        optimizer_model: "opt".into(),
+        executor_model: "exec".into(),
+        executor_timeout_secs: 5,
+        stream_heartbeat_secs: 1,
+        ..ReasoningConfig::default()
+    }
+}
+
+fn mount_optimizer_mock(server: &MockServer) -> impl std::future::Future<Output = ()> + '_ {
+    Mock::given(method("POST"))
+        .and(path("/api/v1/chat/completions"))
+        .and(ModelMatcher("opt"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(optimizer_response_body(), "application/json"),
+        )
+        .mount(server)
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed:\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_plan_write_env(filename: &str) -> (TempDir, EnvVarGuard, CwdGuard, PathBuf, String) {
+    let temp = TempDir::new().unwrap();
+    let code_repo = temp.path().join("code_repo");
+    let thoughts_repo = temp.path().join("thoughts_repo");
+    let xdg_config_home = temp.path().join("xdg");
+    std::fs::create_dir_all(&code_repo).unwrap();
+    std::fs::create_dir_all(&thoughts_repo).unwrap();
+    std::fs::create_dir_all(xdg_config_home.join("agentic")).unwrap();
+
+    git_ok(&code_repo, &["init"]);
+    git_ok(&code_repo, &["config", "user.email", "test@example.com"]);
+    git_ok(&code_repo, &["config", "user.name", "Test User"]);
+    std::fs::write(code_repo.join("README.md"), "test repo\n").unwrap();
+    git_ok(&code_repo, &["add", "README.md"]);
+    git_ok(&code_repo, &["commit", "-m", "init"]);
+    git_ok(&code_repo, &["checkout", "-b", "feature-streaming-test"]);
+
+    std::fs::create_dir_all(code_repo.join(".thoughts")).unwrap();
+    std::fs::write(
+        code_repo.join(".thoughts/config.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "version": "2.0",
+            "mount_dirs": {},
+            "context_mounts": [],
+            "references": [],
+            "thoughts_mount": {
+                "remote": "https://github.com/example/thoughts.git",
+                "sync": "auto"
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        xdg_config_home.join("agentic/repos.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "version": "1.0",
+            "mappings": {
+                "https://github.com/example/thoughts.git": {
+                    "path": thoughts_repo.clone(),
+                    "auto_managed": false
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg_config_home.to_str().unwrap());
+    let cwd_guard = CwdGuard::set(&code_repo);
+
+    let expected_relative = "./thoughts/feature-streaming-test/plans/".to_string() + filename;
+    let expected_absolute = thoughts_repo
+        .join("feature-streaming-test")
+        .join("plans")
+        .join(filename);
+
+    (
+        temp,
+        xdg_guard,
+        cwd_guard,
+        expected_absolute,
+        expected_relative,
+    )
+}
+
+async fn received_model_requests(server: &MockServer, model: &str) -> Vec<serde_json::Value> {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter_map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).ok())
+        .filter(|body| body.get("model").and_then(serde_json::Value::as_str) == Some(model))
+        .collect()
+}
+
+struct RawChatServer {
+    uri: String,
+    task: JoinHandle<()>,
+    requests: Arc<Mutex<Vec<serde_json::Value>>>,
+}
+
+impl RawChatServer {
+    async fn start_partial_failure(first_event: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let requests_for_task = Arc::clone(&requests);
+        let task = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let requests = Arc::clone(&requests_for_task);
+                let first_event = first_event.clone();
+                tokio::spawn(async move {
+                    let body = read_request_json(&mut socket).await.unwrap();
+                    requests.lock().unwrap().push(body.clone());
+                    match body.get("model").and_then(serde_json::Value::as_str) {
+                        Some("opt") => {
+                            write_json_response(&mut socket, &optimizer_response_body())
+                                .await
+                                .unwrap();
+                        }
+                        Some("exec") => {
+                            write_partial_failure_stream(&mut socket, &first_event)
+                                .await
+                                .unwrap();
+                        }
+                        other => panic!("unexpected model in raw server: {other:?}"),
+                    }
+                });
+            }
+        });
+
+        Self {
+            uri: format!("http://{addr}"),
+            task,
+            requests,
+        }
+    }
+
+    fn api_base_url(&self) -> String {
+        format!("{}/api/v1", self.uri)
+    }
+
+    fn received_model_requests(&self, model: &str) -> Vec<serde_json::Value> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|body| body.get("model").and_then(serde_json::Value::as_str) == Some(model))
+            .cloned()
+            .collect()
+    }
+}
+
+impl Drop for RawChatServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn read_request_json(
+    stream: &mut tokio::net::TcpStream,
+) -> std::io::Result<serde_json::Value> {
+    let mut buf = Vec::new();
+    let mut scratch = [0_u8; 4096];
+
+    loop {
+        let n = stream.read(&mut scratch).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "request ended before headers completed",
+            ));
+        }
+        buf.extend_from_slice(&scratch[..n]);
+
+        if let Some(headers_end) = buf.windows(4).position(|window| window == b"\r\n\r\n") {
+            let body_start = headers_end + 4;
+            let headers = std::str::from_utf8(&buf[..body_start]).unwrap();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("Content-Length: ")
+                        .or_else(|| line.strip_prefix("content-length: "))
+                })
+                .unwrap()
+                .trim()
+                .parse::<usize>()
+                .unwrap();
+
+            while buf.len() < body_start + content_length {
+                let n = stream.read(&mut scratch).await?;
+                if n == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "request ended before body completed",
+                    ));
+                }
+                buf.extend_from_slice(&scratch[..n]);
+            }
+
+            return Ok(
+                serde_json::from_slice(&buf[body_start..body_start + content_length]).unwrap(),
+            );
+        }
+    }
+}
+
+async fn write_json_response(
+    stream: &mut tokio::net::TcpStream,
+    body: &str,
+) -> std::io::Result<()> {
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(headers.as_bytes()).await?;
+    stream.write_all(body.as_bytes()).await?;
+    stream.flush().await
+}
+
+async fn write_chunk(stream: &mut tokio::net::TcpStream, bytes: &[u8]) -> std::io::Result<()> {
+    let header = format!("{:X}\r\n", bytes.len());
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(bytes).await?;
+    stream.write_all(b"\r\n").await?;
+    stream.flush().await
+}
+
+async fn write_partial_failure_stream(
+    stream: &mut tokio::net::TcpStream,
+    first_event: &str,
+) -> std::io::Result<()> {
+    stream
+        .write_all(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+        )
+        .await?;
+    write_chunk(stream, first_event.as_bytes()).await?;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    stream.write_all(b"Z\r\n").await?;
+    stream.flush().await?;
+    stream.shutdown().await
+}
+
+#[tokio::test]
+#[serial(env)]
+async fn executor_stream_success_accumulates_and_uses_usage() {
+    let server = MockServer::start().await;
+    let _api_key = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
+    mount_optimizer_mock(&server).await;
+
+    let sse_body = sse(&[
+        r#"data: {"id":"chatcmpl-exec","object":"chat.completion.chunk","created":0,"model":"exec","choices":[{"index":0,"delta":{"content":"Hello "}}],"usage":null}"#,
+        "",
+        r#"data: {"id":"chatcmpl-exec","object":"chat.completion.chunk","created":0,"model":"exec","choices":[{"index":0,"delta":{"content":"world"}}],"usage":null}"#,
+        "",
+        r#"data: {"id":"chatcmpl-exec","object":"chat.completion.chunk","created":0,"model":"exec","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"completion_tokens_details":{"reasoning_tokens":1}}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/chat/completions"))
+        .and(ModelMatcher("exec"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(sse_body, "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let cfg = base_cfg(&server);
+    let out = gpt5_reasoner_impl(
+        "ignored".into(),
+        vec![],
+        None,
+        &cfg,
+        PromptType::Reasoning,
+        None,
+        &ToolContext::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(out, "Hello world");
+
+    let exec_requests = received_model_requests(&server, "exec").await;
+    assert_eq!(exec_requests.len(), 1);
+    assert_eq!(
+        exec_requests[0]["stream_options"]["include_usage"].as_bool(),
+        Some(true)
+    );
+}
+
+#[tokio::test]
+#[serial(env)]
+async fn executor_stream_error_after_content_salvages_reasoning_with_prepend_marker() {
+    let server = RawChatServer::start_partial_failure(
+        sse(&[
+            r#"data: {"id":"chatcmpl-exec","object":"chat.completion.chunk","created":0,"model":"exec","choices":[{"index":0,"delta":{"content":"Partial answer"}}],"usage":null}"#,
+            "",
+            "",
+        ]),
+    )
+    .await;
+    let _api_key = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
+    let cfg = base_cfg_from_uri(server.api_base_url());
+    let out = gpt5_reasoner_impl(
+        "ignored".into(),
+        vec![],
+        None,
+        &cfg,
+        PromptType::Reasoning,
+        None,
+        &ToolContext::default(),
+    )
+    .await
+    .unwrap();
+
+    assert!(out.starts_with(PARTIAL_REASONING_MARKER));
+    assert!(out.contains("Partial answer"));
+    assert!(!out.contains("StreamError"));
+    assert!(!out.contains("executor_timeout"));
+    assert_eq!(server.received_model_requests("exec").len(), 1);
+}
+
+#[tokio::test]
+#[serial(env)]
+async fn plan_mode_output_filename_stream_error_writes_partial_file_and_returns_path() {
+    let server = RawChatServer::start_partial_failure(
+        sse(&[
+            r##"data: {"id":"chatcmpl-exec","object":"chat.completion.chunk","created":0,"model":"exec","choices":[{"index":0,"delta":{"content":"# Partial plan\n"}}],"usage":null}"##,
+            "",
+            "",
+        ]),
+    )
+    .await;
+    let _api_key = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
+    let (_temp, _xdg, _cwd, expected_absolute, expected_relative) =
+        setup_plan_write_env("partial_plan.md");
+    let cfg = base_cfg_from_uri(server.api_base_url());
+    let out = gpt5_reasoner_impl(
+        "ignored".into(),
+        vec![],
+        None,
+        &cfg,
+        PromptType::Plan,
+        Some("partial_plan.md".into()),
+        &ToolContext::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(out, expected_relative);
+    assert!(expected_absolute.exists());
+    let written = std::fs::read_to_string(expected_absolute).unwrap();
+    assert!(written.starts_with(PARTIAL_PLAN_MARKER));
+    assert!(written.contains("# Partial plan"));
+    assert!(!written.contains("StreamError"));
+    assert_eq!(server.received_model_requests("exec").len(), 1);
+}
+
+#[tokio::test]
+#[serial(env)]
+async fn cancellation_while_waiting_for_stream_next_returns_cancelled_no_salvage() {
+    let server = MockServer::start().await;
+    let _api_key = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
+    let (_temp, _xdg, _cwd, expected_absolute, _expected_relative) =
+        setup_plan_write_env("cancelled_plan.md");
+    mount_optimizer_mock(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/chat/completions"))
+        .and(ModelMatcher("exec"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&server)
+        .await;
+
+    let cfg = base_cfg(&server);
+    let ctx = ToolContext::default();
+    let cancel = ctx.cancellation_token();
+    let task = tokio::spawn({
+        let ctx = ctx.clone();
+        let cfg = cfg.clone();
+        async move {
+            gpt5_reasoner_impl(
+                "ignored".into(),
+                vec![],
+                None,
+                &cfg,
+                PromptType::Plan,
+                Some("cancelled_plan.md".into()),
+                &ctx,
+            )
+            .await
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    cancel.cancel();
+
+    let err = task.await.unwrap().unwrap_err();
+    assert!(matches!(err, ToolError::Cancelled { .. }));
+    assert!(!expected_absolute.exists());
+}
+
+#[tokio::test]
+#[serial(env)]
+async fn empty_clean_completion_after_long_attempt_does_not_retry() {
+    let server = MockServer::start().await;
+    let _api_key = EnvVarGuard::set("OPENROUTER_API_KEY", "test");
+    mount_optimizer_mock(&server).await;
+
+    let done_only = sse(&["data: [DONE]", ""]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/chat/completions"))
+        .and(ModelMatcher("exec"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(1))
+                .set_body_raw(done_only, "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut cfg = base_cfg(&server);
+    cfg.empty_response_no_retry_after_secs = 0;
+
+    let err = gpt5_reasoner_impl(
+        "ignored".into(),
+        vec![],
+        None,
+        &cfg,
+        PromptType::Reasoning,
+        None,
+        &ToolContext::default(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("retry suppressed"));
+
+    let exec_requests = received_model_requests(&server, "exec").await;
+    assert_eq!(exec_requests.len(), 1);
+}


### PR DESCRIPTION
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

This PR fixes [ENG-726](https://linear.app/allisoneer/issue/ENG-726), where `gpt5_reasoner` reasoning calls could sit for a very long time with no visible progress and eventually fail with an internal error. The concrete failure pattern we found was not a vague hang: cross-branch log archaeology captured 10 `stage=empty_response` failures across 4 branches, all on `openai/gpt-5.2`, all ending "after 2 attempt(s)" after each attempt spent roughly 13-29 minutes returning empty content.

That made the current executor path expensive in two ways: the HTTP call was fully non-streaming, so there was no progress signal while a long attempt was in flight, and the executor's retry-once policy doubled the wall-clock waste whenever attempt 1 eventually came back empty. Depending on the branch, that meant roughly 26-58 minutes of wasted runtime before the caller saw a failure.

Research and planning artifacts that drove the fix:
- Primary feasibility research: [`eng-726-streaming-feasibility.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/research/eng-726-streaming-feasibility.md)
- Historical failure analysis: [`eng-726-historical-log-analysis.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/artifacts/eng-726-historical-log-analysis.md)
- Root-cause research: [`eng-726-gpt5-reasoner-root-cause-investigation.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/research/eng-726-gpt5-reasoner-root-cause-investigation.md)
- Addendum: [`eng-726-gpt5-reasoner-root-cause-investigation_additional.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/research/eng-726-gpt5-reasoner-root-cause-investigation_additional.md)
- Requirements: [`eng-726_executor_streaming_recovery_requirements.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/plans/eng-726_executor_streaming_recovery_requirements.md)
- Implementation plan: [`eng-726_executor_streaming_recovery_implementation.md`](https://github.com/allisoneer/agentic_auxilary/blob/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/context/personal_thoughts/projects/agentic_auxilary_thoughts/allison-eng-726-reasoning-tool-occasionally-fails-fix-it/plans/eng-726_executor_streaming_recovery_implementation.md)

Related investigation fallout: tooling issues found while doing the ENG-726 archaeology were filed separately in [ENG-774](https://linear.app/allisoneer/issue/ENG-774).

## What user-facing changes did I ship?

- Executor calls now use HTTP streaming internally, so the tool can accumulate content progressively instead of waiting on one long non-streaming response.
- The MCP tool surface is unchanged: `ask_reasoning_model` still returns a single final `String`, and plan mode still returns a path when writing a plan file.
- If the executor stream fails or times out after content has already started arriving, the tool now salvages that buffered content and returns it as a success-with-warning instead of discarding it.
- Cancellation remains intentionally distinct from transport failure: a cancelled call returns `ToolError::Cancelled` and does not salvage partial content or write partial plan files.
- Clean-but-empty completions no longer automatically trigger a second long attempt after a long first attempt; a configurable threshold now suppresses that retry.
- `reasoning.api_base_url` is now honored, which also makes the executor path testable against local mock servers.
- Stream-aware diagnostics now land in `ToolCallRecord.summary`, which should make future failures much easier to diagnose from logs.

## How I implemented it

- Reworked only the executor path to use `chat().create_stream(...)`; the optimizer remains non-streaming because its output still has to parse as structured content and partial optimizer output is not useful.
- Added per-attempt streaming state to accumulate content, usage, chunk count, and time-to-first-content, plus heartbeat logging while a long stream is still active.
- Wrapped executor attempts in a configurable timeout and split terminal behavior into four clear paths:
  - clean completion with content -> success
  - clean completion with empty content -> retry once only if the attempt was short enough
  - transport/stream failure after content -> salvage buffered content as a partial success
  - cancellation -> return cancelled with no salvage
- Reused the existing `ToolCallRecord.summary` field to persist stream diagnostics such as attempt number, duration, chunk count, character count, first-content latency, whether usage was present, whether the result was partial, whether a timeout fired, and the stream error classification.
- Added new `[reasoning]` defaults, all overridable via `AGENTIC_REASONING_*` env vars:
  - `executor_timeout_secs = 2700`
  - `empty_response_no_retry_after_secs = 600`
  - `stream_heartbeat_secs = 30`
- Fixed the ignored `reasoning.api_base_url` plumbing bug while touching the executor client path.
- Added `wiremock` as a dev-dependency plus a small raw TCP test helper for the two mid-stream-after-content cases that were not deterministic enough under `wiremock` alone.

Main reviewer callouts:
- Core branching logic: `crates/tools/gpt5-reasoner/src/engine/orchestration.rs`
- Raw TCP streaming test helper: `crates/tools/gpt5-reasoner/tests/executor_streaming_recovery.rs`
- Diagnostic payload shape: `ToolCallRecord.summary` usage in `crates/tools/gpt5-reasoner/src/engine/orchestration.rs`

Deliberately out of scope here:
- optimizer streaming
- provider migration or direct Anthropic/Codex work
- OpenRouter routing-constraint changes
- MCP per-tool timeout exposure (`ENG-759`)

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- `just check`
- `just test`
- Automated coverage now includes 5 new streaming integration tests and 1 `api_base_url` integration test, covering success accumulation, mid-stream partial salvage in reasoning mode, mid-stream partial salvage in plan-file mode, cancellation semantics, and long-empty retry suppression.
- [ ] Manual/live verification against real OpenRouter was not run for this PR.

## Description for the changelog

Stream `gpt5_reasoner` executor responses so long reasoning calls can surface partial results, avoid wasteful long empty retries, and emit better diagnostics for future failures.
<!-- END:describe_pr:autogen -->