### PR TITLE
Always disallow Claude LSP tool

### DIFF
--- a/crates/services/claudecode-rs/src/client.rs
+++ b/crates/services/claudecode-rs/src/client.rs
@@ -13,9 +13,28 @@ use tempfile::NamedTempFile;
 use tokio::fs;
 use tracing::debug;
 
+const ALWAYS_DISALLOWED_TOOLS: &[&str] = &["LSP"];
+
 #[derive(Debug, Clone)]
 pub struct Client {
     claude_path: PathBuf,
+}
+
+fn merged_disallowed_tools(config: &SessionConfig) -> Vec<String> {
+    let mut tools: Vec<String> = ALWAYS_DISALLOWED_TOOLS
+        .iter()
+        .map(|tool| (*tool).to_string())
+        .collect();
+
+    if let Some(extra_tools) = &config.disallowed_tools {
+        for tool in extra_tools {
+            if !tools.contains(tool) {
+                tools.push(tool.clone());
+            }
+        }
+    }
+
+    tools
 }
 
 impl Client {
@@ -161,10 +180,9 @@ impl Client {
             args.push("--allowedTools".to_string());
             args.push(tools.join(","));
         }
-        if let Some(ref tools) = config.disallowed_tools {
-            args.push("--disallowedTools".to_string());
-            args.push(tools.join(","));
-        }
+        let disallowed_tools = merged_disallowed_tools(config);
+        args.push("--disallowedTools".to_string());
+        args.push(disallowed_tools.join(","));
 
         // Output shaping
         if let Some(ref schema) = config.json_schema {
@@ -297,6 +315,8 @@ mod tests {
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--output-format".to_string()));
         assert!(args.contains(&"text".to_string()));
+        let disallowed_pos = args.iter().position(|a| a == "--disallowedTools").unwrap();
+        assert_eq!(args[disallowed_pos + 1], "LSP");
         assert!(args.contains(&"--".to_string()));
         assert!(args.contains(&"test query".to_string()));
     }
@@ -358,7 +378,22 @@ mod tests {
         assert_eq!(args[allowed_pos + 1], "Bash");
 
         let disallowed_pos = args.iter().position(|a| a == "--disallowedTools").unwrap();
-        assert_eq!(args[disallowed_pos + 1], "WebSearch");
+        assert_eq!(args[disallowed_pos + 1], "LSP,WebSearch");
+    }
+
+    #[tokio::test]
+    async fn test_build_args_deduplicates_default_disallowed_tools() {
+        let client = create_test_client();
+        let config = SessionConfig::builder("test")
+            .disallowed_tools(vec!["LSP".to_string(), "WebSearch".to_string()])
+            .output_format(OutputFormat::Text)
+            .build()
+            .unwrap();
+
+        let (args, _) = client.build_args(&config).await.unwrap();
+
+        let disallowed_pos = args.iter().position(|a| a == "--disallowedTools").unwrap();
+        assert_eq!(args[disallowed_pos + 1], "LSP,WebSearch");
     }
 
     #[tokio::test]

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -144,6 +144,7 @@ This repo's Claude settings are intentionally narrow. The point is to allow only
       "Write",
       "Edit",
       "Glob",
+      "LSP",
       "Grep",
       "Agent",
       "Skill",

--- a/tools/bin/orchestrator
+++ b/tools/bin/orchestrator
@@ -1,6 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+append_disallowed_tools() {
+	local value="$1"
+	local IFS=,
+	local tool
+	local parsed_tools=()
+
+	read -r -a parsed_tools <<<"$value"
+	for tool in "${parsed_tools[@]}"; do
+		[[ -z "$tool" ]] && continue
+
+		case ",$disallowed_tools," in
+		*",$tool,"*) ;;
+		*) disallowed_tools+=",$tool" ;;
+		esac
+	done
+}
+
+run_claude() {
+	local disallowed_tools="LSP"
+	local arg
+	local -a args=()
+
+	while (($#)); do
+		arg="$1"
+		shift
+
+		case "$arg" in
+		--)
+			args+=("$arg" "$@")
+			break
+			;;
+		--disallowedTools=*)
+			append_disallowed_tools "${arg#--disallowedTools=}"
+			;;
+		--disallowedTools)
+			if (($# == 0)) || [[ "$1" == "--" ]]; then
+				args+=("$arg")
+			else
+				append_disallowed_tools "$1"
+				shift
+			fi
+			;;
+		*)
+			args+=("$arg")
+			;;
+		esac
+	done
+
+	exec claude --disallowedTools "$disallowed_tools" "${args[@]}"
+}
+
 for arg in "$@"; do
 	[[ "$arg" == "--" ]] && break
 
@@ -9,7 +60,7 @@ for arg in "$@"; do
 		--system-prompt-file | --system-prompt-file=* | \
 		--append-system-prompt | --append-system-prompt=* | \
 		--append-system-prompt-file | --append-system-prompt-file=*)
-		exec claude "$@"
+		run_claude "$@"
 		;;
 	esac
 done
@@ -27,4 +78,4 @@ if [[ ! -f "$prompt_file" ]]; then
 	exit 1
 fi
 
-exec claude --system-prompt-file "$prompt_file" "$@"
+run_claude --system-prompt-file "$prompt_file" "$@"


### PR DESCRIPTION
## Summary
- Force claudecode launches to include `LSP` in `--disallowedTools` while preserving caller-specified disallowed tools.
- Route orchestrator wrapper Claude invocations through a helper that merges `LSP` with any provided `--disallowedTools`.
- Update setup docs and argument-builder tests for the default deny behavior.

## Tests
- `just crate-check claudecode`
- `just crate-test claudecode`
- `bash -n tools/bin/orchestrator`