### PR TITLE
feat(opencode-orchestrator-mcp): add command filtering

### DIFF
--- a/agentic.schema.json
+++ b/agentic.schema.json
@@ -35,6 +35,10 @@
       "description": "Orchestrator session and timing configuration.",
       "$ref": "#/$defs/OrchestratorConfig",
       "default": {
+        "commands": {
+          "allow": [],
+          "deny": []
+        },
         "compaction_threshold": 0.8,
         "inactivity_timeout_secs": 300,
         "session_deadline_secs": 3600
@@ -176,10 +180,40 @@
         }
       }
     },
+    "OrchestratorCommandsConfig": {
+      "description": "Command filtering policy for orchestrator-exposed `OpenCode` commands.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Exact case-sensitive command names to allow. Empty means no allowlist restriction.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Exact case-sensitive command names to deny. Deny wins over allow.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "OrchestratorConfig": {
       "description": "Configuration for opencode-orchestrator-mcp.",
       "type": "object",
       "properties": {
+        "commands": {
+          "description": "Command filtering policy for orchestrator-exposed `OpenCode` commands.",
+          "$ref": "#/$defs/OrchestratorCommandsConfig",
+          "default": {
+            "allow": [],
+            "deny": []
+          }
+        },
         "compaction_threshold": {
           "description": "Context compaction threshold as fraction 0.0-1.0 (default: 0.80).",
           "type": "number",

--- a/agentic.toml.example
+++ b/agentic.toml.example
@@ -43,6 +43,17 @@ inactivity_timeout_secs = 300
 # Context compaction threshold as fraction 0.0-1.0 (default: 0.80)
 compaction_threshold = 0.80
 
+[orchestrator.commands]
+# Exact, case-sensitive command names that remain visible/executable.
+# Empty allowlist means "do not restrict by allowlist".
+allow = []
+# Exact, case-sensitive command names that are always blocked.
+# Entries are trimmed before comparison, and deny wins over allow.
+deny = []
+# Example:
+# allow = ["research", "implement_plan"]
+# deny = ["commit"]
+
 # =============================================================================
 # Web Retrieval - Configuration for web_fetch and web_search tools
 # =============================================================================

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -87,6 +87,20 @@ pub enum RecoveryMode {
     External,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandPolicyDecision {
+    Allowed,
+    DeniedByAllowlist,
+    DeniedByDenylist,
+}
+
+impl CommandPolicyDecision {
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
 impl RecoveryMode {
     fn as_str(self) -> &'static str {
         match self {
@@ -506,6 +520,41 @@ pub struct OrchestratorServer {
 }
 
 impl OrchestratorServer {
+    pub fn command_policy_decision(&self, command: &str) -> CommandPolicyDecision {
+        let deny_matches = self
+            .config
+            .commands
+            .deny
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| entry == command);
+        if deny_matches {
+            return CommandPolicyDecision::DeniedByDenylist;
+        }
+
+        let mut allow_entries = self
+            .config
+            .commands
+            .allow
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .peekable();
+
+        if allow_entries.peek().is_some() && !allow_entries.any(|entry| entry == command) {
+            return CommandPolicyDecision::DeniedByAllowlist;
+        }
+
+        CommandPolicyDecision::Allowed
+    }
+
+    pub fn is_command_allowed(&self, command: &str) -> bool {
+        self.command_policy_decision(command).is_allowed()
+    }
+
     /// Start a new managed `OpenCode` server and build the client.
     ///
     /// This is the eager initialization path that spawns the server immediately.
@@ -865,20 +914,45 @@ impl OrchestratorServer {
         Arc::new(Self::from_client_unshared(client, base_url, mode))
     }
 
+    pub fn from_client_with_config(
+        client: Client,
+        base_url: impl Into<String>,
+        mode: RecoveryMode,
+        config: OrchestratorConfig,
+    ) -> Arc<Self> {
+        Arc::new(Self::from_client_unshared_with_config(
+            client, base_url, mode, config,
+        ))
+    }
+
     /// Build an `OrchestratorServer` wrapper returning `Self` (not `Arc<Self>`).
     ///
     /// Useful for tests that need to preseed an `OrchestratorServerHandle` directly.
     pub fn from_client_unshared(
         client: Client,
         base_url: impl Into<String>,
+        mode: RecoveryMode,
+    ) -> Self {
+        Self::from_client_unshared_with_config(
+            client,
+            base_url,
+            mode,
+            OrchestratorConfig::default(),
+        )
+    }
+
+    pub fn from_client_unshared_with_config(
+        client: Client,
+        base_url: impl Into<String>,
         _mode: RecoveryMode,
+        config: OrchestratorConfig,
     ) -> Self {
         Self {
             managed_server: StdMutex::new(None),
             client,
             model_context_limits: HashMap::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
-            config: OrchestratorConfig::default(),
+            config,
             spawned_sessions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
@@ -888,12 +962,26 @@ impl OrchestratorServer {
         client: Client,
         base_url: impl Into<String>,
     ) -> Self {
+        Self::from_managed_for_testing_with_config(
+            managed,
+            client,
+            base_url,
+            OrchestratorConfig::default(),
+        )
+    }
+
+    pub fn from_managed_for_testing_with_config(
+        managed: ManagedServer,
+        client: Client,
+        base_url: impl Into<String>,
+        config: OrchestratorConfig,
+    ) -> Self {
         Self {
             managed_server: StdMutex::new(Some(managed)),
             client,
             model_context_limits: HashMap::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
-            config: OrchestratorConfig::default(),
+            config,
             spawned_sessions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
@@ -914,6 +1002,7 @@ impl OrchestratorServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentic_config::types::OrchestratorCommandsConfig;
     use serial_test::serial;
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
@@ -988,6 +1077,18 @@ mod tests {
         )
     }
 
+    fn external_server_with_config(
+        base_url: &str,
+        config: OrchestratorConfig,
+    ) -> OrchestratorServer {
+        OrchestratorServer::from_client_unshared_with_config(
+            test_client(base_url),
+            base_url,
+            RecoveryMode::External,
+            config,
+        )
+    }
+
     async fn exited_child() -> tokio::process::Child {
         let mut child = Command::new("sh").arg("-c").arg("exit 0").spawn().unwrap();
         let _status = child.wait().await.unwrap();
@@ -997,6 +1098,73 @@ mod tests {
     async fn managed_server_with_exited_child(base_url: &str) -> OrchestratorServer {
         let managed = ManagedServer::from_child_for_testing(exited_child().await, base_url, 9);
         OrchestratorServer::from_managed_for_testing(managed, test_client(base_url), base_url)
+    }
+
+    #[test]
+    fn command_policy_allows_all_when_allowlist_is_empty() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                commands: OrchestratorCommandsConfig {
+                    allow: vec![],
+                    deny: vec!["blocked".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.command_policy_decision("plan"),
+            CommandPolicyDecision::Allowed
+        );
+        assert_eq!(
+            server.command_policy_decision("blocked"),
+            CommandPolicyDecision::DeniedByDenylist
+        );
+    }
+
+    #[test]
+    fn command_policy_trims_entries_and_deny_wins() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                commands: OrchestratorCommandsConfig {
+                    allow: vec!["  plan  ".into()],
+                    deny: vec!["plan".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.command_policy_decision("plan"),
+            CommandPolicyDecision::DeniedByDenylist
+        );
+    }
+
+    #[test]
+    fn command_policy_matching_is_case_sensitive() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                commands: OrchestratorCommandsConfig {
+                    allow: vec!["Plan".into()],
+                    deny: vec!["blocked".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.command_policy_decision("Plan"),
+            CommandPolicyDecision::Allowed
+        );
+        assert_eq!(
+            server.command_policy_decision("plan"),
+            CommandPolicyDecision::DeniedByAllowlist
+        );
+        assert!(server.is_command_allowed("Plan"));
+        assert!(!server.is_command_allowed("plan"));
     }
 
     struct BlockingHealthServer {

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -2,6 +2,7 @@
 
 use crate::config;
 use crate::logging;
+use crate::server::CommandPolicyDecision;
 use crate::server::OrchestratorServer;
 use crate::server::OrchestratorServerHandle;
 use crate::token_tracker::TokenTracker;
@@ -67,6 +68,22 @@ struct ToolLogMeta {
 struct RunOutcome {
     output: OrchestratorRunOutput,
     log_meta: ToolLogMeta,
+}
+
+fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
+    let reason = match decision {
+        CommandPolicyDecision::Allowed => {
+            return ToolError::Internal("command unexpectedly allowed".into());
+        }
+        CommandPolicyDecision::DeniedByAllowlist => {
+            "it is not present in orchestrator.commands.allow"
+        }
+        CommandPolicyDecision::DeniedByDenylist => "it is blocked by orchestrator.commands.deny",
+    };
+
+    ToolError::InvalidInput(format!(
+        "Command '{command}' cannot be run because {reason}."
+    ))
 }
 
 impl RunOutcome {
@@ -351,6 +368,13 @@ impl OrchestratorRunTool {
             .acquire()
             .await
             .map_err(|e| ToolError::Internal(e.to_string()))?;
+
+        if let Some(command) = input.command.as_deref() {
+            let decision = server.command_policy_decision(command);
+            if !decision.is_allowed() {
+                return Err(blocked_command_error(command, decision));
+            }
+        }
 
         let client = server.client();
 
@@ -1312,6 +1336,7 @@ impl Tool for ListCommandsTool {
 
                 let command_infos: Vec<CommandInfo> = commands
                     .into_iter()
+                    .filter(|command| server.is_command_allowed(&command.name))
                     .map(|c| CommandInfo {
                         name: c.name,
                         description: c.description,

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -1,0 +1,178 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod support;
+
+use agentic_config::types::OrchestratorCommandsConfig;
+use agentic_config::types::OrchestratorConfig;
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use opencode_orchestrator_mcp::tools::ListCommandsTool;
+use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
+use opencode_orchestrator_mcp::types::ListCommandsInput;
+use opencode_orchestrator_mcp::types::OrchestratorRunInput;
+use serde_json::json;
+use std::sync::Arc;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+use support::test_orchestrator_server_with_config;
+
+fn orchestrator_config(allow: &[&str], deny: &[&str]) -> OrchestratorConfig {
+    OrchestratorConfig {
+        commands: OrchestratorCommandsConfig {
+            allow: allow.iter().map(|entry| (*entry).to_string()).collect(),
+            deny: deny.iter().map(|entry| (*entry).to_string()).collect(),
+        },
+        ..OrchestratorConfig::default()
+    }
+}
+
+fn command_list(names: &[&str]) -> serde_json::Value {
+    json!(
+        names
+            .iter()
+            .map(|name| json!({"name": name, "description": format!("{name} description")}))
+            .collect::<Vec<_>>()
+    )
+}
+
+async fn list_commands_with_config(mock: &MockServer, config: OrchestratorConfig) -> Vec<String> {
+    let server = test_orchestrator_server_with_config(mock, config).await;
+    let tool = ListCommandsTool::new(Arc::clone(&server));
+
+    tool.call(ListCommandsInput {}, &ToolContext::default())
+        .await
+        .expect("list_commands should succeed")
+        .commands
+        .into_iter()
+        .map(|command| command.name)
+        .collect()
+}
+
+#[tokio::test]
+async fn list_commands_filters_deny_only_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_commands_with_config(&mock, orchestrator_config(&[], &["build"])).await;
+
+    assert_eq!(names, vec!["test", "lint"]);
+}
+
+#[tokio::test]
+async fn list_commands_filters_allow_only_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_commands_with_config(&mock, orchestrator_config(&["build"], &[])).await;
+
+    assert_eq!(names, vec!["build"]);
+}
+
+#[tokio::test]
+async fn list_commands_applies_deny_wins_overlap_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names =
+        list_commands_with_config(&mock, orchestrator_config(&["test", "build"], &["build"])).await;
+
+    assert_eq!(names, vec!["test"]);
+}
+
+#[tokio::test]
+async fn list_commands_trims_configured_entries() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_commands_with_config(&mock, orchestrator_config(&[], &[" build "])).await;
+
+    assert_eq!(names, vec!["test", "lint"]);
+}
+
+#[tokio::test]
+async fn list_commands_matching_is_case_sensitive() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(command_list(&["Build", "build"])))
+        .mount(&mock)
+        .await;
+
+    let names = list_commands_with_config(&mock, orchestrator_config(&[], &["Build"])).await;
+
+    assert_eq!(names, vec!["build"]);
+}
+
+#[tokio::test]
+async fn blocked_run_command_fails_before_session_resolution_or_dispatch() {
+    let mock = MockServer::start().await;
+    let server =
+        test_orchestrator_server_with_config(&mock, orchestrator_config(&[], &["research"])).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+
+    let err = tool
+        .call(
+            OrchestratorRunInput {
+                session_id: None,
+                command: Some("research".into()),
+                message: Some("blocked arguments".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("blocked command should fail before dispatch");
+
+    assert!(matches!(err, ToolError::InvalidInput(_)));
+    assert!(err.to_string().contains("orchestrator.commands.deny"));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        !requests
+            .iter()
+            .any(|request| request.url.path().starts_with("/session")),
+        "unexpected session request(s): {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|request| request.url.path() == "/event"),
+        "unexpected event subscription request"
+    );
+}

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(dead_code)]
 
+use agentic_config::types::OrchestratorConfig;
 use opencode_orchestrator_mcp::server::OrchestratorServer;
 use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
 use opencode_orchestrator_mcp::server::RecoveryMode;
@@ -26,6 +27,15 @@ use wiremock::matchers::path;
 /// The handle is pre-initialized with a server backed by the mock.
 /// Uses a short 5-second timeout suitable for tests.
 pub async fn test_orchestrator_server(mock: &MockServer) -> Arc<OrchestratorServerHandle> {
+    test_orchestrator_server_with_config(mock, OrchestratorConfig::default()).await
+}
+
+/// Build an `OrchestratorServerHandle` connected to a wiremock `MockServer`
+/// with explicit orchestrator config.
+pub async fn test_orchestrator_server_with_config(
+    mock: &MockServer,
+    config: OrchestratorConfig,
+) -> Arc<OrchestratorServerHandle> {
     Mock::given(method("GET"))
         .and(path("/global/health"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -43,7 +53,12 @@ pub async fn test_orchestrator_server(mock: &MockServer) -> Arc<OrchestratorServ
         .unwrap();
 
     Arc::new(OrchestratorServerHandle::from_server_unshared(
-        OrchestratorServer::from_client_unshared(client, base_url, RecoveryMode::External),
+        OrchestratorServer::from_client_unshared_with_config(
+            client,
+            base_url,
+            RecoveryMode::External,
+            config,
+        ),
     ))
 }
 

--- a/crates/infra/agentic-config/src/schema.rs
+++ b/crates/infra/agentic-config/src/schema.rs
@@ -36,6 +36,13 @@ mod tests {
 
         // Check that the schema has definitions for our types
         assert!(json.get("$defs").is_some() || json.get("definitions").is_some());
+
+        let orchestrator_properties = &json["$defs"]["OrchestratorConfig"]["properties"];
+        assert!(orchestrator_properties.get("commands").is_some());
+
+        let command_properties = &json["$defs"]["OrchestratorCommandsConfig"]["properties"];
+        assert!(command_properties.get("allow").is_some());
+        assert!(command_properties.get("deny").is_some());
     }
 
     #[test]

--- a/crates/infra/agentic-config/src/types.rs
+++ b/crates/infra/agentic-config/src/types.rs
@@ -159,6 +159,18 @@ pub struct OrchestratorConfig {
     pub inactivity_timeout_secs: u64,
     /// Context compaction threshold as fraction 0.0-1.0 (default: 0.80).
     pub compaction_threshold: f64,
+    /// Command filtering policy for orchestrator-exposed `OpenCode` commands.
+    pub commands: OrchestratorCommandsConfig,
+}
+
+/// Command filtering policy for orchestrator-exposed `OpenCode` commands.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct OrchestratorCommandsConfig {
+    /// Exact case-sensitive command names to allow. Empty means no allowlist restriction.
+    pub allow: Vec<String>,
+    /// Exact case-sensitive command names to deny. Deny wins over allow.
+    pub deny: Vec<String>,
 }
 
 impl Default for OrchestratorConfig {
@@ -167,6 +179,7 @@ impl Default for OrchestratorConfig {
             session_deadline_secs: 3600,
             inactivity_timeout_secs: 300,
             compaction_threshold: 0.80,
+            commands: OrchestratorCommandsConfig::default(),
         }
     }
 }
@@ -353,6 +366,7 @@ mod tests {
         assert!(toml_str.contains("[services.anthropic]"));
         assert!(toml_str.contains("[services.exa]"));
         assert!(toml_str.contains("[orchestrator]"));
+        assert!(toml_str.contains("[orchestrator.commands]"));
         assert!(toml_str.contains("[web_retrieval]"));
         assert!(toml_str.contains("[cli_tools]"));
         assert!(toml_str.contains("[logging]"));
@@ -386,6 +400,22 @@ locator_model = "custom-model"
             config.services.anthropic.base_url,
             "https://api.anthropic.com"
         );
+        assert!(config.orchestrator.commands.allow.is_empty());
+        assert!(config.orchestrator.commands.deny.is_empty());
+    }
+
+    #[test]
+    fn test_orchestrator_commands_deserialize() {
+        let toml_str = r#"
+[orchestrator.commands]
+allow = ["plan", "research"]
+deny = ["commit"]
+"#;
+
+        let config: AgenticConfig = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(config.orchestrator.commands.allow, ["plan", "research"]);
+        assert_eq!(config.orchestrator.commands.deny, ["commit"]);
     }
 
     #[test]
@@ -425,6 +455,8 @@ locator_model = "custom-model"
         assert_eq!(cfg.session_deadline_secs, 3600);
         assert_eq!(cfg.inactivity_timeout_secs, 300);
         assert!((cfg.compaction_threshold - 0.80).abs() < f64::EPSILON);
+        assert!(cfg.commands.allow.is_empty());
+        assert!(cfg.commands.deny.is_empty());
     }
 
     #[test]

--- a/crates/infra/agentic-config/src/validation.rs
+++ b/crates/infra/agentic-config/src/validation.rs
@@ -5,6 +5,7 @@
 //! configs while still surfacing potential issues.
 
 use crate::types::AgenticConfig;
+use std::collections::BTreeSet;
 
 /// An advisory warning about a configuration issue.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -260,6 +261,18 @@ pub fn validate(cfg: &AgenticConfig) -> Vec<AdvisoryWarning> {
         ));
     }
 
+    validate_command_entries(
+        &cfg.orchestrator.commands.allow,
+        "orchestrator.commands.allow",
+        &mut warnings,
+    );
+    validate_command_entries(
+        &cfg.orchestrator.commands.deny,
+        "orchestrator.commands.deny",
+        &mut warnings,
+    );
+    validate_command_overlap(cfg, &mut warnings);
+
     // Validate web_retrieval: default_search_results <= max_search_results
     if cfg.web_retrieval.default_search_results > cfg.web_retrieval.max_search_results {
         warnings.push(AdvisoryWarning::new(
@@ -288,6 +301,98 @@ pub fn validate(cfg: &AgenticConfig) -> Vec<AdvisoryWarning> {
     }
 
     warnings
+}
+
+fn validate_command_entries(
+    entries: &[String],
+    path: &'static str,
+    warnings: &mut Vec<AdvisoryWarning>,
+) {
+    let mut seen = BTreeSet::new();
+    let mut duplicates = BTreeSet::new();
+
+    for entry in entries {
+        let trimmed = entry.trim();
+
+        if trimmed.is_empty() {
+            warnings.push(AdvisoryWarning::new(
+                if path.ends_with("allow") {
+                    "orchestrator.commands.allow.empty_entry"
+                } else {
+                    "orchestrator.commands.deny.empty_entry"
+                },
+                path,
+                format!("entry {entry:?} becomes empty after trimming"),
+            ));
+            continue;
+        }
+
+        if trimmed != entry {
+            warnings.push(AdvisoryWarning::new(
+                if path.ends_with("allow") {
+                    "orchestrator.commands.allow.trimmed_entry"
+                } else {
+                    "orchestrator.commands.deny.trimmed_entry"
+                },
+                path,
+                format!(
+                    "entry {entry:?} has surrounding whitespace; effective value is {trimmed:?}"
+                ),
+            ));
+        }
+
+        if !seen.insert(trimmed.to_string()) {
+            duplicates.insert(trimmed.to_string());
+        }
+    }
+
+    if !duplicates.is_empty() {
+        let duplicates = duplicates.into_iter().collect::<Vec<_>>().join(", ");
+        warnings.push(AdvisoryWarning::new(
+            if path.ends_with("allow") {
+                "orchestrator.commands.allow.duplicate"
+            } else {
+                "orchestrator.commands.deny.duplicate"
+            },
+            path,
+            format!("duplicate command entries after trimming: {duplicates}"),
+        ));
+    }
+}
+
+fn validate_command_overlap(cfg: &AgenticConfig, warnings: &mut Vec<AdvisoryWarning>) {
+    let allow = cfg
+        .orchestrator
+        .commands
+        .allow
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    let deny = cfg
+        .orchestrator
+        .commands
+        .deny
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+
+    let overlap = allow.intersection(&deny).cloned().collect::<Vec<_>>();
+    if overlap.is_empty() {
+        return;
+    }
+
+    warnings.push(AdvisoryWarning::new(
+        "orchestrator.commands.overlap",
+        "orchestrator.commands",
+        format!(
+            "commands appear in both allow and deny: {}. deny wins at runtime",
+            overlap.join(", ")
+        ),
+    ));
 }
 
 fn validate_url(
@@ -425,6 +530,68 @@ mod tests {
                 .iter()
                 .any(|w| w.code == "orchestrator.compaction_threshold.out_of_range")
         );
+    }
+
+    #[test]
+    fn test_orchestrator_allow_empty_entry_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.commands.allow = vec!["   ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.commands.allow.empty_entry")
+            .expect("empty allow warning expected");
+
+        assert_eq!(warning.path, "orchestrator.commands.allow");
+        assert!(warning.message.contains("becomes empty after trimming"));
+    }
+
+    #[test]
+    fn test_orchestrator_deny_trimmed_entry_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.commands.deny = vec!["  plan  ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.commands.deny.trimmed_entry")
+            .expect("trimmed deny warning expected");
+
+        assert_eq!(warning.path, "orchestrator.commands.deny");
+        assert!(warning.message.contains("effective value is \"plan\""));
+    }
+
+    #[test]
+    fn test_orchestrator_allow_duplicate_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.commands.allow = vec!["plan".into(), " plan ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.commands.allow.duplicate")
+            .expect("duplicate allow warning expected");
+
+        assert_eq!(warning.path, "orchestrator.commands.allow");
+        assert!(warning.message.contains("plan"));
+    }
+
+    #[test]
+    fn test_orchestrator_command_overlap_warns_with_deny_wins_message() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.commands.allow = vec!["plan".into()];
+        config.orchestrator.commands.deny = vec![" plan ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.commands.overlap")
+            .expect("overlap warning expected");
+
+        assert_eq!(warning.path, "orchestrator.commands");
+        assert!(warning.message.contains("plan"));
+        assert!(warning.message.contains("deny wins at runtime"));
     }
 
     #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,26 @@ level = "info"
 
 Think of this as orientation and defaults, not secret storage. Models, base URLs, timeouts, and logging belong here; API keys do not.
 
+### `orchestrator.commands`
+
+`opencode-orchestrator-mcp` can filter which upstream `OpenCode` commands are shown by `list_commands` and which named commands may be executed through `run(command=...)`:
+
+```toml
+[orchestrator.commands]
+allow = ["research", "implement_plan"]
+deny = ["commit"]
+```
+
+Runtime semantics:
+
+- `deny` wins over `allow`
+- `allow = []` means there is no allowlist restriction
+- matching is exact and case-sensitive
+- configured entries are trimmed before comparison, so `" build "` matches `build`
+- this policy applies to `list_commands` and `run(command=...)`, but not raw `run(message=...)`
+
+One merge caveat matters here: TOML tables merge, but arrays replace rather than append. If a local `agentic.toml` sets `allow = []`, that clears any inherited allowlist instead of extending it.
+
 ## `.thoughts/config.json` (per repo, v2 only)
 
 This file lives at `<repo>/.thoughts/config.json` and tells `thoughts` what the repo wants to mount. Current runtime expects `version: "2.0"`; older v1 configs are not supported anymore.


### PR DESCRIPTION
## Summary
- add `[orchestrator.commands]` allow/deny config for OpenCode command filtering
- enforce command policy in both `list_commands` and `run(command=...)`
- add validation warnings, schema/docs/example updates, and wiremock coverage

## Verification
- just crate-check agentic-config
- just crate-test agentic-config
- just crate-check opencode-orchestrator-mcp
- just crate-test opencode-orchestrator-mcp
- just check
- just test
- just xtask-verify-check


<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

`opencode-orchestrator-mcp` previously exposed every upstream OpenCode command through `list_commands` and allowed any named command through `run(command=...)`, with no orchestrator-side policy boundary.

That made it hard to restrict what a session could discover or execute from repository config alone. This change adds a config-driven allow/deny policy so teams can hide or block specific commands at the orchestrator layer without changing MCP inputs or relying on downstream callers to self-police.

## What user-facing changes did I ship?

- Added `[orchestrator.commands]` config with `allow` and `deny` arrays.
- `list_commands` now hides commands blocked by that policy.
- `run(command=...)` now rejects blocked commands with a clear invalid-input error that explains whether the command was excluded by the allowlist or blocked by the denylist.
- Documented the runtime rules:
  - `deny` wins over `allow`
  - an empty `allow` list means "no allowlist restriction"
  - matching is exact and case-sensitive
  - configured entries are trimmed before comparison
  - the policy applies to named commands, not raw `run(message=...)` prompts
- Added config validation warnings for empty, trimmed, duplicate, and overlapping command entries.

## How I implemented it

- Extended `OrchestratorConfig` with a new `OrchestratorCommandsConfig` and updated the generated schema and example config so the new settings are visible in config tooling.
- Added advisory validation in `agentic-config` for malformed command entries and overlap between `allow` and `deny`, while keeping config loading non-fatal.
- Centralized runtime policy evaluation in `OrchestratorServer` with explicit decisions for allowed, denied-by-allowlist, and denied-by-denylist.
- Applied that policy in both places where command exposure matters:
  - filter the upstream `/command` response before returning `list_commands`
  - reject blocked `run(command=...)` requests before dispatching session work
- Added focused unit and wiremock coverage for deny-only, allow-only, deny-wins overlap, trimming, case sensitivity, and the guarantee that blocked named commands fail before session/event requests are made.
- Updated config docs to explain behavior and TOML merge caveats for command arrays.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog

Add orchestrator command allow/deny filtering so repositories can restrict which OpenCode commands are listed or executable through `opencode-orchestrator-mcp`.
<!-- END:describe_pr:autogen -->
