### PR TITLE
chore: use GitHub opencode mise pin

### DIFF
--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 pub(crate) const MISE_PATH: &str = "mise.toml";
 
-const TOOL_PINS_BLOCK: &str = "claude = \"2.1.116\"\n\"npm:opencode-ai\" = \"1.15.7\"";
+const TOOL_PINS_BLOCK: &str = "claude = \"2.1.116\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
 
 const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("linux-x64", "x86_64-unknown-linux-gnu"),

--- a/mise.lock
+++ b/mise.lock
@@ -514,6 +514,65 @@ url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d
 [tools.claude."platforms.macos-x64-baseline"]
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-x64/claude"
 
+[[tools."github:anomalyco/opencode"]]
+version = "1.15.7"
+backend = "github:anomalyco/opencode"
+
+[tools."github:anomalyco/opencode"."platforms.linux-arm64"]
+checksum = "sha256:d2ca40f11b0eb1648cbffaf9850c122a83062b21ada18e5db29558c6bfafee0f"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253982"
+
+[tools."github:anomalyco/opencode"."platforms.linux-arm64-musl"]
+checksum = "sha256:aae45df3aa8981875059045d87028926e7313d99998ac65598f1f95732d171f3"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254007"
+
+[tools."github:anomalyco/opencode"."platforms.linux-x64"]
+checksum = "sha256:6f7f95f13917b9aab8421dbb7e121abf2fecfecdccd16fd5b497f522f454f928"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253984"
+
+[tools."github:anomalyco/opencode"."platforms.linux-x64-baseline"]
+checksum = "sha256:6f7f95f13917b9aab8421dbb7e121abf2fecfecdccd16fd5b497f522f454f928"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253984"
+
+[tools."github:anomalyco/opencode"."platforms.linux-x64-musl"]
+checksum = "sha256:7966e6f2fcde07b8390d5759d5d76097f6c3b8e2a1c8a479977b51e5f601abdb"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254009"
+
+[tools."github:anomalyco/opencode"."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:7966e6f2fcde07b8390d5759d5d76097f6c3b8e2a1c8a479977b51e5f601abdb"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254009"
+
+[tools."github:anomalyco/opencode"."platforms.macos-arm64"]
+checksum = "sha256:335307ee87d3dac84986bf8f0bd4273a43c35fcb9b124556c2f4fad4a510e3a4"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-arm64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253936"
+
+[tools."github:anomalyco/opencode"."platforms.macos-x64"]
+checksum = "sha256:12e4a562bcd6e691eb846ceedc5c1f7bad88f047df3775be21aaf979bda959d7"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253938"
+
+[tools."github:anomalyco/opencode"."platforms.macos-x64-baseline"]
+checksum = "sha256:12e4a562bcd6e691eb846ceedc5c1f7bad88f047df3775be21aaf979bda959d7"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253938"
+
+[tools."github:anomalyco/opencode"."platforms.windows-x64"]
+checksum = "sha256:8ac96b52692a3daeb84a20295cc7ed43aa3c698078e802926a47aef83748eab2"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426255364"
+
+[tools."github:anomalyco/opencode"."platforms.windows-x64-baseline"]
+checksum = "sha256:8ac96b52692a3daeb84a20295cc7ed43aa3c698078e802926a47aef83748eab2"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426255364"
+
 [[tools."github:bnjbvr/cargo-machete"]]
 version = "0.9.1"
 backend = "github:bnjbvr/cargo-machete"
@@ -817,10 +876,6 @@ url = "https://github.com/casey/just/releases/download/1.49.0/just-1.49.0-x86_64
 [tools.just."platforms.windows-x64-baseline"]
 checksum = "sha256:657338772efd17a31d67285bb5ed691da87741e44311c0366273c6cb7d913b15"
 url = "https://github.com/casey/just/releases/download/1.49.0/just-1.49.0-x86_64-pc-windows-msvc.zip"
-
-[[tools."npm:opencode-ai"]]
-version = "1.15.7"
-backend = "npm:opencode-ai"
 
 [[tools.opencode-orchestrator-mcp]]
 version = "0.6.5"

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,7 @@ _.path = ["tools/bin"]
 "github:cargo-bins/cargo-binstall" = "latest"
 # BEGIN:xtask:autogen mise:tool-pins
 claude = "2.1.154"
-"npm:opencode-ai" = "1.15.7"
+"github:anomalyco/opencode" = "1.15.7"
 # END:xtask:autogen
 just = "latest"
 shellcheck = "0.11.0"


### PR DESCRIPTION
## Summary
- Switch the mise opencode pin from the npm package to the GitHub release backend.
- Update the mise lockfile entries and xtask-generated pin source to match.

## Verification
- `just xtask-sync-check`
- `just crate-check xtask`
- `just crate-test xtask` was started but aborted before completion.