### PR TITLE
Fix orchestrator permission reply errors

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -431,11 +431,17 @@ impl OrchestratorRunTool {
         let is_idle = matches!(status, SessionStatusInfo::Idle);
 
         // 3. Check for pending permissions before doing anything else
-        let pending_permissions = client
-            .permissions()
-            .list()
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to list permissions: {e}")))?;
+        let pending_permissions = match client.permissions().list().await {
+            Ok(permissions) => permissions,
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "failed to list permissions during run preflight"
+                );
+                vec![]
+            }
+        };
 
         let my_permission = pending_permissions
             .into_iter()
@@ -1424,68 +1430,51 @@ Parameters:
 
                 let client = server.client();
 
-                // Find the pending permission for this session
-                let mut pending =
-                    client.permissions().list().await.map_err(|e| {
-                        ToolError::Internal(format!("Failed to list permissions: {e}"))
-                    })?;
+                let (permission_request_id, permission_type, permission_patterns) =
+                    if let Some(req_id) = input.permission_request_id.as_deref() {
+                        (req_id.to_owned(), None, vec![])
+                    } else {
+                        let pending = client.permissions().list().await.map_err(|e| {
+                            ToolError::Internal(format!(
+                                "Failed to list permissions: {e}. Retry with permission_request_id returned by run to bypass permission listing."
+                            ))
+                        })?;
 
-                let perm = if let Some(req_id) = input.permission_request_id.as_deref() {
-                    let idx = pending.iter().position(|p| p.id == req_id).ok_or_else(|| {
-                        ToolError::InvalidInput(format!(
-                            "No pending permission found with id '{req_id}'. \
-                         (session_id='{}')",
-                            input.session_id
-                        ))
-                    })?;
+                        let mut perms: Vec<_> = pending
+                            .into_iter()
+                            .filter(|p| p.session_id == input.session_id)
+                            .collect();
 
-                    let perm = pending.remove(idx);
+                        let perm = match perms.as_slice() {
+                            [] => {
+                                return Err(ToolError::InvalidInput(format!(
+                                    "No pending permission found for session '{}'. \
+                                 The permission may have already been responded to.",
+                                    input.session_id
+                                )));
+                            }
+                            [_single] => perms.swap_remove(0),
+                            multiple => {
+                                let ids = multiple
+                                    .iter()
+                                    .map(|p| p.id.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                return Err(ToolError::InvalidInput(format!(
+                                    "Multiple pending permissions found for session '{}': {ids}. \
+                                 Please retry with permission_request_id (returned by run).",
+                                    input.session_id
+                                )));
+                            }
+                        };
 
-                    if perm.session_id != input.session_id {
-                        return Err(ToolError::InvalidInput(format!(
-                            "Permission request '{req_id}' belongs to session '{}', not '{}'.",
-                            perm.session_id, input.session_id
-                        )));
-                    }
-
-                    perm
-                } else {
-                    let mut perms: Vec<_> = pending
-                        .into_iter()
-                        .filter(|p| p.session_id == input.session_id)
-                        .collect();
-
-                    match perms.as_slice() {
-                        [] => {
-                            return Err(ToolError::InvalidInput(format!(
-                                "No pending permission found for session '{}'. \
-                             The permission may have already been responded to.",
-                                input.session_id
-                            )));
-                        }
-                        [_single] => perms.swap_remove(0),
-                        multiple => {
-                            let ids = multiple
-                                .iter()
-                                .map(|p| p.id.as_str())
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            return Err(ToolError::InvalidInput(format!(
-                                "Multiple pending permissions found for session '{}': {ids}. \
-                             Please retry with permission_request_id (returned by run).",
-                                input.session_id
-                            )));
-                        }
-                    }
-                };
+                        (perm.id, Some(perm.permission), perm.patterns)
+                    };
 
                 // Track if this is a rejection for post-processing
                 let is_reject = matches!(input.reply, PermissionReply::Reject);
 
                 // Capture permission details for warning message
-                let permission_type = perm.permission.clone();
-                let permission_patterns = perm.patterns.clone();
-
                 // Capture baseline assistant text BEFORE sending reject
                 // This lets us detect stale text after rejection
                 let mut pre_warnings: Vec<String> = Vec::new();
@@ -1512,7 +1501,7 @@ Parameters:
                 client
                     .permissions()
                     .reply(
-                        &perm.id,
+                        &permission_request_id,
                         &PermissionReplyRequest {
                             reply: api_reply,
                             message: input.message,
@@ -1520,7 +1509,14 @@ Parameters:
                     )
                     .await
                     .map_err(|e| {
-                        ToolError::Internal(format!("Failed to reply to permission: {e}"))
+                        if e.is_not_found() {
+                            ToolError::InvalidInput(format!(
+                                "No pending permission found with id '{}' for session '{}'.",
+                                permission_request_id, input.session_id
+                            ))
+                        } else {
+                            ToolError::Internal(format!("Failed to reply to permission: {e}"))
+                        }
                     })?;
 
                 // Now continue monitoring the session using run logic
@@ -1550,17 +1546,22 @@ Parameters:
                     // If response unchanged or None, it's stale pre-rejection text
                     if final_resp.is_none() || final_resp == baseline_resp {
                         out.response = None;
-                        let patterns_str = if permission_patterns.is_empty() {
-                            "(none)".to_string()
+                        let permission_target = permission_type
+                            .as_deref()
+                            .map_or_else(|| format!("request '{permission_request_id}'"), |permission| format!("'{permission}'"));
+                        let warning = if permission_patterns.is_empty() {
+                            format!(
+                                "Permission rejected for {permission_target}. Session stopped without generating a new assistant response."
+                            )
                         } else {
-                            permission_patterns.join(", ")
+                            format!(
+                                "Permission rejected for {permission_target}. Patterns: {}. Session stopped without generating a new assistant response.",
+                                permission_patterns.join(", ")
+                            )
                         };
-                        out.warnings.push(format!(
-                        "Permission rejected for '{permission_type}'. Patterns: {patterns_str}. \
-                         Session stopped without generating a new assistant response."
-                    ));
+                        out.warnings.push(warning);
                         tracing::debug!(
-                            permission_type = %permission_type,
+                            permission_request_id = %permission_request_id,
                             "rejection override applied: response set to None"
                         );
                     }

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -21,9 +21,7 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::path_regex;
 
-use support::SequenceResponder;
 use support::commands_list_fixture;
-use support::permission_fixture;
 use support::session_fixture;
 use support::status_v2_busy;
 use support::test_orchestrator_server;
@@ -117,18 +115,9 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
     let session_id = "cancel-perm";
     let permission_id = "perm-1";
 
-    let permission_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
-            permission_id,
-            session_id,
-            "write",
-            &["src/**"]
-        ),])),
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
-    ]);
     Mock::given(method("GET"))
         .and(path("/permission"))
-        .respond_with(permission_seq)
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("POST"))

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -491,6 +491,107 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     assert_eq!(result.response.as_deref(), Some("POST_PERMISSION_TEXT"));
 }
 
+/// IT-BUG6: `respond_permission` should work even if GET /permission is broken.
+///
+/// Pre-fix behavior: Fails before replying because both `respond_permission` and the
+/// follow-up `run(wait_for_activity=true)` hard-error on GET /permission.
+/// Post-fix behavior: If `permission_request_id` is provided, reply directly and treat
+/// permission-list failures as non-fatal while monitoring completion.
+#[tokio::test]
+async fn it_bug6_respond_permission_with_request_id_bypasses_broken_permission_listing() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let respond_tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "s6";
+    let perm_id = "perm-badrequest";
+
+    Mock::given(method("GET"))
+        .and(path("/session/s6"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    let status_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(status_seq)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "name": "BadRequest",
+            "data": {
+                "message": "Expected JSON value, got [{\"filePath\":\"/tmp/test.txt\",\"relativePath\":\"test.txt\",\"type\":\"update\",\"patch\":\"Index: /tmp/test.txt\"}]",
+                "kind": "Payload"
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/s6/message"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(messages_fixture(sid, Some("AFTER_PERMISSION_RESPONSE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(10),
+        respond_tool.call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: Some(perm_id.into()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("timed out")
+    .expect("tool error");
+
+    assert!(
+        matches!(result.status, RunStatus::Completed),
+        "expected Completed status, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        result.response.as_deref(),
+        Some("AFTER_PERMISSION_RESPONSE")
+    );
+}
+
 /// IT-BUG4: Command dispatch should retry on transport-level timeout.
 ///
 /// Pre-fix behavior: First timeout error propagates immediately.

--- a/crates/infra/thoughts-core/src/utils/paths.rs
+++ b/crates/infra/thoughts-core/src/utils/paths.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use anyhow::anyhow;
 use dirs;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -20,10 +22,58 @@ pub fn expand_path(path: &Path) -> Result<PathBuf> {
 
 /// Ensure a directory exists, creating it if necessary
 pub fn ensure_dir(path: &Path) -> Result<()> {
-    if !path.exists() {
-        std::fs::create_dir_all(path)?;
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(anyhow!(
+            "Path exists but is not a directory: {}",
+            path.display()
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => match std::fs::create_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(create_error) if create_error.kind() == ErrorKind::AlreadyExists => {
+                Err(inaccessible_existing_path_error(path, &create_error))
+            }
+            Err(create_error) => Err(anyhow!(create_error)
+                .context(format!("Failed to create directory: {}", path.display()))),
+        },
+        Err(error) if is_likely_stale_mount_error(&error) => Err(stale_mount_error(path, &error)),
+        Err(error) => Err(anyhow!(error).context(format!(
+            "Failed to access directory path: {}",
+            path.display()
+        ))),
     }
-    Ok(())
+}
+
+fn is_likely_stale_mount_error(error: &std::io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(107 | 116))
+}
+
+fn stale_mount_error(path: &Path, error: &std::io::Error) -> anyhow::Error {
+    anyhow!(
+        "Failed to access {}: mountpoint exists but is not accessible\n\
+This may be a stale/disconnected FUSE mount (for example mergerfs; \"{}\").\n\
+Repair or unmount/remount the stale mount, then run:\n\
+  thoughts mount update\n\
+or:\n\
+  thoughts sync\n\
+If this repository is already initialized, you likely do not need to run `thoughts init` again.",
+        path.display(),
+        error
+    )
+}
+
+fn inaccessible_existing_path_error(path: &Path, error: &std::io::Error) -> anyhow::Error {
+    anyhow!(
+        "Failed to access {}: path already exists but is not accessible\n\
+This may be a stale/disconnected FUSE mount (for example mergerfs; \"{}\").\n\
+Repair or unmount/remount the stale mount, then run:\n\
+  thoughts mount update\n\
+or:\n\
+  thoughts sync\n\
+If this repository is already initialized, you likely do not need to run `thoughts init` again.",
+        path.display(),
+        error
+    )
 }
 
 /// Sanitize a directory name for use in filesystem
@@ -131,5 +181,41 @@ mod tests {
             sanitize_dir_name("bad/name:with*chars?"),
             "bad_name_with_chars_"
         );
+    }
+
+    #[test]
+    fn test_ensure_dir_creates_missing_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("new-dir");
+
+        ensure_dir(&path).unwrap();
+
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn test_ensure_dir_rejects_existing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        std::fs::write(&path, "not a directory").unwrap();
+
+        let error = ensure_dir(&path).unwrap_err().to_string();
+
+        assert!(error.contains("Path exists but is not a directory"));
+        assert!(error.contains(&path.display().to_string()));
+    }
+
+    #[test]
+    fn test_inaccessible_existing_path_error_is_actionable() {
+        let path = Path::new(".thoughts-data/thoughts");
+        let source_error = std::io::Error::from(ErrorKind::AlreadyExists);
+        let error = inaccessible_existing_path_error(path, &source_error).to_string();
+
+        assert!(error.contains(".thoughts-data/thoughts"));
+        assert!(error.contains("path already exists but is not accessible"));
+        assert!(error.contains("stale/disconnected FUSE mount"));
+        assert!(error.contains("thoughts mount update"));
+        assert!(error.contains("thoughts sync"));
+        assert!(error.contains("do not need to run `thoughts init` again"));
     }
 }


### PR DESCRIPTION
## Summary
- Allow `respond_permission` to reply directly when `permission_request_id` is provided, so broken permission listing no longer blocks the reply path.
- Treat permission-list failures during orchestrator run preflight as non-fatal while monitoring completion, with regression coverage.
- Improve `thoughts` directory setup errors for stale or inaccessible mountpoints.

## Testing
- `just crate-test opencode-orchestrator-mcp`
- `just crate-test thoughts-tool`
- `just crate-check opencode-orchestrator-mcp`
- `just crate-check thoughts-tool`

## Related
Relates to https://linear.app/general-wisdom/issue/ENG-910/orchestrator-error