### PR TITLE
fix(opencode-orchestrator-mcp): harden permission reply bridge

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -70,6 +70,12 @@ struct RunOutcome {
     log_meta: ToolLogMeta,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum PermissionPreflightMode {
+    Strict,
+    RespondPermissionContinuation,
+}
+
 fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
     let reason = match decision {
         CommandPolicyDecision::Allowed => {
@@ -333,10 +339,41 @@ impl OrchestratorRunTool {
         }
     }
 
+    async fn preflight_pending_permission(
+        client: &opencode_rs::Client,
+        session_id: &str,
+        mode: PermissionPreflightMode,
+        warnings: &mut Vec<String>,
+    ) -> Result<Option<opencode_rs::types::permission::PermissionRequest>, ToolError> {
+        match client.permissions().list().await {
+            Ok(pending_permissions) => Ok(pending_permissions
+                .into_iter()
+                .find(|permission| permission.session_id == session_id)),
+            Err(error)
+                if matches!(mode, PermissionPreflightMode::RespondPermissionContinuation)
+                    && error.is_validation_error() =>
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %error,
+                    "failed to list permissions during respond_permission continuation; falling back to polling"
+                );
+                warnings.push(format!(
+                    "Permission refresh failed after reply ({error}); continuing with polling fallback."
+                ));
+                Ok(None)
+            }
+            Err(error) => Err(ToolError::Internal(format!(
+                "Failed to list permissions: {error}"
+            ))),
+        }
+    }
+
     async fn run_impl_outcome(
         &self,
         input: OrchestratorRunInput,
         ctx: &ToolContext,
+        permission_preflight_mode: PermissionPreflightMode,
     ) -> Result<RunOutcome, ToolError> {
         // Input validation
         if input.session_id.is_none() && input.message.is_none() && input.command.is_none() {
@@ -421,6 +458,8 @@ impl OrchestratorRunTool {
 
         tracing::info!(session_id = %session_id, "run: session resolved");
 
+        let mut warnings = Vec::new();
+
         // 2. Check if session is already idle (for resume-only case)
         let status = client
             .sessions()
@@ -431,17 +470,14 @@ impl OrchestratorRunTool {
         let is_idle = matches!(status, SessionStatusInfo::Idle);
 
         // 3. Check for pending permissions before doing anything else
-        let pending_permissions = client
-            .permissions()
-            .list()
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to list permissions: {e}")))?;
-
-        let my_permission = pending_permissions
-            .into_iter()
-            .find(|p| p.session_id == session_id);
-
-        if let Some(perm) = my_permission {
+        if let Some(perm) = Self::preflight_pending_permission(
+            client,
+            &session_id,
+            permission_preflight_mode,
+            &mut warnings,
+        )
+        .await?
+        {
             tracing::info!(
                 session_id = %session_id,
                 permission_type = %perm.permission,
@@ -457,7 +493,7 @@ impl OrchestratorRunTool {
                 permission_patterns: perm.patterns,
                 question_request_id: None,
                 questions: vec![],
-                warnings: vec![],
+                warnings,
             }));
         }
 
@@ -473,10 +509,7 @@ impl OrchestratorRunTool {
         {
             tracing::info!(session_id = %session_id, question_id = %question.id, "run: pending question found");
             return Ok(RunOutcome::without_tokens(Self::question_required_output(
-                session_id,
-                None,
-                &question,
-                vec![],
+                session_id, None, &question, warnings,
             )));
         }
 
@@ -566,7 +599,6 @@ impl OrchestratorRunTool {
         tracing::debug!(session_id = %session_id, "run: entering event loop");
         let mut token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
         let mut partial_response = String::new();
-        let warnings = Vec::new();
 
         let mut poll_interval = tokio::time::interval(Duration::from_secs(1));
         poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -973,7 +1005,10 @@ Examples:
         let ctx = ctx.clone();
         Box::pin(async move {
             let timer = CallTimer::start();
-            match this.run_impl_outcome(input.clone(), &ctx).await {
+            match this
+                .run_impl_outcome(input.clone(), &ctx, PermissionPreflightMode::Strict)
+                .await
+            {
                 Ok(outcome) => {
                     log_tool_success(
                         &timer,
@@ -1423,72 +1458,87 @@ Parameters:
                     .map_err(|e| ToolError::Internal(e.to_string()))?;
 
                 let client = server.client();
+                let mut pre_warnings: Vec<String> = Vec::new();
 
-                // Find the pending permission for this session
-                let mut pending =
-                    client.permissions().list().await.map_err(|e| {
-                        ToolError::Internal(format!("Failed to list permissions: {e}"))
-                    })?;
+                let (permission_request_id, permission_type, permission_patterns) =
+                    if let Some(req_id) = input.permission_request_id.as_deref() {
+                        match client.permissions().list().await {
+                            Ok(mut pending) => {
+                                let idx = pending.iter().position(|p| p.id == req_id).ok_or_else(|| {
+                                    ToolError::InvalidInput(format!(
+                                        "No pending permission found with id '{req_id}'. \
+                                     (session_id='{}')",
+                                        input.session_id
+                                    ))
+                                })?;
 
-                let perm = if let Some(req_id) = input.permission_request_id.as_deref() {
-                    let idx = pending.iter().position(|p| p.id == req_id).ok_or_else(|| {
-                        ToolError::InvalidInput(format!(
-                            "No pending permission found with id '{req_id}'. \
-                         (session_id='{}')",
-                            input.session_id
-                        ))
-                    })?;
+                                let perm = pending.remove(idx);
 
-                    let perm = pending.remove(idx);
+                                if perm.session_id != input.session_id {
+                                    return Err(ToolError::InvalidInput(format!(
+                                        "Permission request '{req_id}' belongs to session '{}', not '{}'.",
+                                        perm.session_id, input.session_id
+                                    )));
+                                }
 
-                    if perm.session_id != input.session_id {
-                        return Err(ToolError::InvalidInput(format!(
-                            "Permission request '{req_id}' belongs to session '{}', not '{}'.",
-                            perm.session_id, input.session_id
-                        )));
-                    }
-
-                    perm
-                } else {
-                    let mut perms: Vec<_> = pending
-                        .into_iter()
-                        .filter(|p| p.session_id == input.session_id)
-                        .collect();
-
-                    match perms.as_slice() {
-                        [] => {
-                            return Err(ToolError::InvalidInput(format!(
-                                "No pending permission found for session '{}'. \
-                             The permission may have already been responded to.",
-                                input.session_id
-                            )));
+                                (perm.id, perm.permission, perm.patterns)
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    session_id = %input.session_id,
+                                    permission_request_id = %req_id,
+                                    error = %error,
+                                    "permission validation failed for known request id; proceeding with provided id"
+                                );
+                                pre_warnings.push(format!(
+                                    "Permission validation failed for request '{req_id}' ({error}); submitting reply using the provided request id."
+                                ));
+                                (req_id.to_string(), "unknown".to_string(), Vec::new())
+                            }
                         }
-                        [_single] => perms.swap_remove(0),
-                        multiple => {
-                            let ids = multiple
-                                .iter()
-                                .map(|p| p.id.as_str())
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            return Err(ToolError::InvalidInput(format!(
-                                "Multiple pending permissions found for session '{}': {ids}. \
-                             Please retry with permission_request_id (returned by run).",
-                                input.session_id
-                            )));
+                    } else {
+                        // Find the pending permission for this session when discovery is required.
+                        let pending = client.permissions().list().await.map_err(|e| {
+                            ToolError::Internal(format!("Failed to list permissions: {e}"))
+                        })?;
+
+                        let mut perms: Vec<_> = pending
+                            .into_iter()
+                            .filter(|p| p.session_id == input.session_id)
+                            .collect();
+
+                        match perms.as_slice() {
+                            [] => {
+                                return Err(ToolError::InvalidInput(format!(
+                                    "No pending permission found for session '{}'. \
+                                 The permission may have already been responded to.",
+                                    input.session_id
+                                )));
+                            }
+                            [_single] => {
+                                let perm = perms.swap_remove(0);
+                                (perm.id, perm.permission, perm.patterns)
+                            }
+                            multiple => {
+                                let ids = multiple
+                                    .iter()
+                                    .map(|p| p.id.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                return Err(ToolError::InvalidInput(format!(
+                                    "Multiple pending permissions found for session '{}': {ids}. \
+                                 Please retry with permission_request_id (returned by run).",
+                                    input.session_id
+                                )));
+                            }
                         }
-                    }
-                };
+                    };
 
                 // Track if this is a rejection for post-processing
                 let is_reject = matches!(input.reply, PermissionReply::Reject);
 
-                // Capture permission details for warning message
-                let permission_type = perm.permission.clone();
-                let permission_patterns = perm.patterns.clone();
-
                 // Capture baseline assistant text BEFORE sending reject
                 // This lets us detect stale text after rejection
-                let mut pre_warnings: Vec<String> = Vec::new();
                 let baseline = if is_reject {
                     match client.messages().list(&input.session_id).await {
                         Ok(msgs) => OrchestratorServer::extract_assistant_text(&msgs),
@@ -1512,7 +1562,7 @@ Parameters:
                 client
                     .permissions()
                     .reply(
-                        &perm.id,
+                        &permission_request_id,
                         &PermissionReplyRequest {
                             reply: api_reply,
                             message: input.message,
@@ -1535,6 +1585,7 @@ Parameters:
                             wait_for_activity,
                         },
                         &ctx,
+                        PermissionPreflightMode::RespondPermissionContinuation,
                     )
                     .await?;
                 let mut out = outcome.output;
@@ -1710,7 +1761,7 @@ Parameters:
                             command: None,
                             message: None,
                             wait_for_activity: Some(true),
-                        }, &ctx)
+                        }, &ctx, PermissionPreflightMode::Strict)
                         .await?;
                     Ok((outcome.output, outcome.log_meta))
                 }
@@ -1725,7 +1776,7 @@ Parameters:
                             command: None,
                             message: None,
                             wait_for_activity: None,
-                        }, &ctx)
+                        }, &ctx, PermissionPreflightMode::Strict)
                         .await?;
                     Ok((outcome.output, outcome.log_meta))
                 }

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -1483,7 +1483,7 @@ Parameters:
 
                                 (perm.id, perm.permission, perm.patterns)
                             }
-                            Err(error) => {
+                            Err(error) if error.is_validation_error() => {
                                 tracing::warn!(
                                     session_id = %input.session_id,
                                     permission_request_id = %req_id,
@@ -1494,6 +1494,11 @@ Parameters:
                                     "Permission validation failed for request '{req_id}' ({error}); submitting reply using the provided request id."
                                 ));
                                 (req_id.to_string(), "unknown".to_string(), Vec::new())
+                            }
+                            Err(error) => {
+                                return Err(ToolError::Internal(format!(
+                                    "Failed to list permissions: {error}"
+                                )));
                             }
                         }
                     } else {

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -6,6 +6,7 @@ mod support;
 
 use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
 use opencode_orchestrator_mcp::config::OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
 use opencode_orchestrator_mcp::tools::RespondPermissionTool;
@@ -24,11 +25,16 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::path_regex;
+use wiremock::matchers::query_param;
 
 use support::SequenceResponder;
 use support::messages_fixture;
+use support::patch_file_metadata_fixture;
 use support::permission_fixture;
+use support::permission_fixture_with_metadata;
+use support::permission_patch_file_array_bad_request_fixture;
 use support::session_fixture;
+use support::status_v2_busy;
 use support::status_v2_idle;
 use support::test_orchestrator_server;
 
@@ -215,4 +221,275 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
 
     assert!(matches!(result.status, RunStatus::Completed));
     assert_eq!(result.response.as_deref(), Some("RESUME_DONE"));
+}
+
+#[tokio::test]
+async fn respond_permission_known_id_replies_even_when_permission_list_bad_requests() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "permission-pre-reply-wedge";
+    let perm_id = "perm-patch-pre";
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .and(query_param("directory", "/tmp"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_json(permission_patch_file_array_bad_request_fixture()),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    let status_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(status_seq)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("PRE_REPLY_DONE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(2),
+        tool.call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: Some(perm_id.into()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("known-id continuation should not hang")
+    .expect("respond_permission should succeed with provided request id");
+
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("PRE_REPLY_DONE"));
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Permission validation failed")),
+        "expected validation warning, got {:?}",
+        result.warnings
+    );
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
+        "reply POST should be observed with a known request id: {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn respond_permission_continues_after_reply_when_follow_up_permission_list_bad_requests() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "permission-post-reply-wedge";
+    let perm_id = "perm-patch-post";
+
+    let permission_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            permission_fixture_with_metadata(
+                perm_id,
+                sid,
+                "edit",
+                &["src/lib.rs"],
+                &serde_json::json!({"files": [patch_file_metadata_fixture()]}),
+            )
+        ])),
+        ResponseTemplate::new(400).set_body_json(permission_patch_file_array_bad_request_fixture()),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .and(query_param("directory", "/tmp"))
+        .respond_with(permission_seq)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(messages_fixture(sid, Some("POST_REPLY_DONE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(2),
+        tool.call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: Some(perm_id.into()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("post-reply continuation should not hang")
+    .expect("respond_permission should keep monitoring after the follow-up 400");
+
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("POST_REPLY_DONE"));
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Permission refresh failed after reply")),
+        "expected continuation warning, got {:?}",
+        result.warnings
+    );
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
+        "reply POST should be observed before the follow-up failure: {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn run_still_errors_on_initial_permission_list_bad_request() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "permission-strict-run";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .and(query_param("directory", "/tmp"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_json(permission_patch_file_array_bad_request_fixture()),
+        )
+        .mount(&mock)
+        .await;
+
+    let err = timeout(
+        Duration::from_secs(2),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: None,
+                message: None,
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("strict run regression should not hang")
+    .expect_err("run should remain strict on initial permission-list failures");
+
+    assert!(matches!(err, ToolError::Internal(_)));
 }

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -225,6 +225,11 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
 
 #[tokio::test]
 async fn respond_permission_known_id_replies_even_when_permission_list_bad_requests() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
     let tool = RespondPermissionTool::new(Arc::clone(&server));
@@ -332,6 +337,11 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
 
 #[tokio::test]
 async fn respond_permission_continues_after_reply_when_follow_up_permission_list_bad_requests() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
     let tool = RespondPermissionTool::new(Arc::clone(&server));
@@ -448,6 +458,11 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
 
 #[tokio::test]
 async fn run_still_errors_on_initial_permission_list_bad_request() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -48,6 +48,7 @@ pub async fn test_orchestrator_server_with_config(
     let base_url = mock.uri().trim_end_matches('/').to_string();
     let client = opencode_rs::ClientBuilder::new()
         .base_url(&base_url)
+        .directory("/tmp".to_string())
         .timeout_secs(5) // Short timeout for tests
         .build()
         .unwrap();
@@ -244,6 +245,30 @@ pub fn permission_fixture(
     permission: &str,
     patterns: &[&str],
 ) -> serde_json::Value {
+    permission_fixture_with_metadata(id, session_id, permission, patterns, &Value::Null)
+}
+
+/// Create a realistic patch-file metadata entry.
+pub fn patch_file_metadata_fixture() -> Value {
+    serde_json::json!({
+        "filePath": "/tmp/src/lib.rs",
+        "relativePath": "src/lib.rs",
+        "type": "update",
+        "patch": "Index: src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        "additions": 1,
+        "deletions": 1,
+        "movePath": null,
+    })
+}
+
+/// Create a permission fixture with explicit metadata.
+pub fn permission_fixture_with_metadata(
+    id: &str,
+    session_id: &str,
+    permission: &str,
+    patterns: &[&str],
+    metadata: &Value,
+) -> serde_json::Value {
     serde_json::json!({
         "id": id,
         "sessionID": session_id,  // Note: sessionID not sessionId (matches opencode-rs types)
@@ -251,8 +276,13 @@ pub fn permission_fixture(
         "patterns": patterns,
         "always": [],
         "tool": null,
-        "metadata": null
+        "metadata": metadata
     })
+}
+
+/// Create the live-confirmed 400 response body array for patch-file metadata.
+pub fn permission_patch_file_array_bad_request_fixture() -> Value {
+    serde_json::json!([patch_file_metadata_fixture()])
 }
 
 /// Create a question fixture.

--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 pub(crate) const MISE_PATH: &str = "mise.toml";
 
-const TOOL_PINS_BLOCK: &str = "claude = \"2.1.154\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
+const TOOL_PINS_BLOCK: &str = "claude = \"2.1.160\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
 
 const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("linux-x64", "x86_64-unknown-linux-gnu"),

--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 pub(crate) const MISE_PATH: &str = "mise.toml";
 
-const TOOL_PINS_BLOCK: &str = "claude = \"2.1.116\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
+const TOOL_PINS_BLOCK: &str = "claude = \"2.1.154\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
 
 const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("linux-x64", "x86_64-unknown-linux-gnu"),

--- a/crates/services/opencode-rs/src/http/permissions.rs
+++ b/crates/services/opencode-rs/src/http/permissions.rs
@@ -53,6 +53,7 @@ impl PermissionsApi {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::OpencodeError;
     use crate::http::HttpConfig;
     use crate::types::permission::PermissionReply;
     use std::time::Duration;
@@ -61,6 +62,16 @@ mod tests {
     use wiremock::ResponseTemplate;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
+    use wiremock::matchers::query_param;
+
+    fn patch_file_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "filePath": "/tmp/src/lib.rs",
+            "relativePath": "src/lib.rs",
+            "type": "update",
+            "patch": "Index: src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        })
+    }
 
     #[tokio::test]
     async fn test_list_permissions_success() {
@@ -183,5 +194,35 @@ mod tests {
             .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().is_not_found());
+    }
+
+    #[tokio::test]
+    async fn test_list_permissions_surfaces_patch_file_array_bad_request() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/permission"))
+            .and(query_param("directory", "/tmp"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!([patch_file_fixture()])),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: Some("/tmp".to_string()),
+            workspace: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let permissions = PermissionsApi::new(http);
+        let err = permissions.list().await.unwrap_err();
+
+        match err {
+            OpencodeError::Http { status, .. } => assert_eq!(status, 400),
+            other => panic!("expected HTTP error, got {other:?}"),
+        }
     }
 }

--- a/mise.lock
+++ b/mise.lock
@@ -484,35 +484,35 @@ version = "0.4.6"
 backend = "cargo:systemfd"
 
 [[tools.claude]]
-version = "2.1.154"
+version = "2.1.160"
 backend = "aqua:anthropics/claude-code"
 
 [tools.claude."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64/claude"
 
 [tools.claude."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-arm64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64-musl/claude"
 
 [tools.claude."platforms.linux-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
 
 [tools.claude."platforms.linux-x64-musl-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
 
 [tools.claude."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-arm64/claude"
 
 [tools.claude."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
 
 [tools.claude."platforms.macos-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
 
 [[tools."github:anomalyco/opencode"]]
 version = "1.15.7"

--- a/mise.lock
+++ b/mise.lock
@@ -640,56 +640,67 @@ backend = "github:cargo-bins/cargo-binstall"
 checksum = "sha256:f6ec6ac6e5782327863bcaa1b0acdd0ad81caee05c79b0074549829c41ffd52e"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-gnu.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392671"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-arm64-musl"]
 checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392646"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64"]
 checksum = "sha256:6cfb065d6a5ee29dea185e9878d1e055357744ec1339987ca34d6f86853d537a"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-gnu.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392385"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64-baseline"]
 checksum = "sha256:6cfb065d6a5ee29dea185e9878d1e055357744ec1339987ca34d6f86853d537a"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-gnu.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392385"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64-musl"]
 checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392355"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392355"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.macos-arm64"]
 checksum = "sha256:955abf167994c90f3547e233edace4c0f794465dd4aa408249b38999aa5ca3cf"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392739"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.macos-x64"]
 checksum = "sha256:e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392447"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.macos-x64-baseline"]
 checksum = "sha256:e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392447"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.windows-x64"]
 checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392416"
+provenance = "github-attestations"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.windows-x64-baseline"]
 checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392416"
+provenance = "github-attestations"
 
 [[tools."github:nextest-rs/nextest"]]
 version = "0.9.72"

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ _.path = ["tools/bin"]
 # instead of compiling from source. Using github backend for proper lockfile support.
 "github:cargo-bins/cargo-binstall" = "latest"
 # BEGIN:xtask:autogen mise:tool-pins
-claude = "2.1.154"
+claude = "2.1.160"
 "github:anomalyco/opencode" = "1.15.7"
 # END:xtask:autogen
 just = "latest"


### PR DESCRIPTION
Allow respond_permission to keep working when permission listing fails after apply_patch-style requests.

Add SDK and orchestrator regressions that lock down the directory-scoped request shape and the 400 patch-metadata failure mode.

## My Notes (preserved)

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

`respond_permission` could get stuck around apply-patch style permission requests when OpenCode returned a `400` from `GET /permission` instead of a normal permission list payload.

This showed up in two places:

- before sending the reply, when the caller already had a known `permission_request_id` but the orchestrator still tried to re-list permissions for validation
- after sending the reply, when the orchestrator re-entered normal run monitoring and hit the same permission-list validation failure again

The fix also needed to preserve the existing strict behavior for normal `run` preflight, so initial permission-list failures still surface instead of being silently ignored.

## What user-facing changes did I ship?

- `respond_permission` now still submits a reply when a caller provides `permission_request_id`, even if the permission list endpoint fails validation first.
- After a permission reply is sent, the orchestrator now falls back to normal session polling if the follow-up permission refresh fails with that validation error, and returns a warning explaining what happened.
- Normal `run` behavior stays strict: an initial permission-list failure still returns an error instead of continuing.
- No breaking changes or migration steps are required.

## How I implemented it

- Added a `PermissionPreflightMode` in `apps/opencode-orchestrator-mcp/src/tools.rs` so the shared run path can distinguish strict permission preflight from post-`respond_permission` continuation behavior.
- Extracted permission preflight into `preflight_pending_permission()`, keeping strict mode unchanged while allowing continuation mode to downgrade validation errors into warnings and continue polling.
- Updated `RespondPermissionTool` so a known `permission_request_id` is still validated when possible, but if permission listing itself fails, the tool now logs a warning and replies with the provided request id instead of bailing out.
- Kept the fallback scoped to `respond_permission` continuation only; the regular `run` flow still treats the same failure as an internal error.
- Added wiremock regressions covering:
  - known-id reply succeeds even when the pre-reply permission list returns `400`
  - post-reply monitoring continues when the follow-up permission refresh returns `400`
  - normal `run` remains strict on the same initial failure mode
- Added SDK coverage in `crates/services/opencode-rs/src/http/permissions.rs` to confirm `PermissionsApi::list()` still surfaces the raw `400`, so the resilience lives in the orchestrator layer rather than hiding the HTTP failure in the client.
- Expanded test fixtures to use a real directory-scoped permission request shape and patch-file metadata payloads that match the observed failing response.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

## Description for the changelog

Harden `respond_permission` so permission replies and post-reply monitoring keep working when apply-patch permission refreshes fail validation, while preserving strict initial `run` preflight behavior.
<!-- END:describe_pr:autogen -->

