### PR TITLE
fix(thoughts): mount diagnostics

### DIFF
--- a/apps/thoughts/src/commands/init.rs
+++ b/apps/thoughts/src/commands/init.rs
@@ -3,8 +3,8 @@ use crate::git::utils::get_control_repo_root;
 use crate::git::utils::get_current_repo;
 use crate::git::utils::get_main_repo_for_worktree;
 use crate::git::utils::is_worktree;
+use crate::mount::ensure_mount_dir;
 use crate::utils::git::ensure_gitignore_entry;
-use crate::utils::paths::ensure_dir;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -263,15 +263,15 @@ pub async fn execute(force: bool) -> Result<()> {
 
     // Create the actual thoughts directory structure
     let thoughts_dir = repo_root.join(".thoughts-data");
-    ensure_dir(&thoughts_dir)?;
+    ensure_mount_dir(&thoughts_dir)?;
 
     let thoughts_target_dir = thoughts_dir.join(&mount_dirs.thoughts);
     let context_target_dir = thoughts_dir.join(&mount_dirs.context);
     let references_target_dir = thoughts_dir.join(&mount_dirs.references);
 
-    ensure_dir(&thoughts_target_dir)?;
-    ensure_dir(&context_target_dir)?;
-    ensure_dir(&references_target_dir)?;
+    ensure_mount_dir(&thoughts_target_dir)?;
+    ensure_mount_dir(&context_target_dir)?;
+    ensure_mount_dir(&references_target_dir)?;
 
     // Resolve symlink targets and ensure idempotently
     let thoughts_link = repo_root.join(&mount_dirs.thoughts);

--- a/crates/infra/thoughts-core/src/mount/auto_mount.rs
+++ b/crates/infra/thoughts-core/src/mount/auto_mount.rs
@@ -10,9 +10,9 @@ use crate::git::utils::get_control_repo_root;
 use crate::mount::MountOptions;
 use crate::mount::MountResolver;
 use crate::mount::MountSpace;
+use crate::mount::ensure_mount_dir;
 use crate::mount::get_mount_manager;
 use crate::platform::detect_platform;
-use crate::utils::paths::ensure_dir;
 use anyhow::Result;
 use colored::Colorize;
 use std::collections::HashMap;
@@ -37,7 +37,7 @@ pub async fn update_active_mounts() -> Result<()> {
         );
     }
 
-    ensure_dir(&base)?;
+    ensure_mount_dir(&base)?;
 
     // Canonicalize base for mount comparison
     let base_canon = std::fs::canonicalize(&base).unwrap_or_else(|_| base.clone());
@@ -46,9 +46,9 @@ pub async fn update_active_mounts() -> Result<()> {
     let thoughts_dir = base.join(&desired.mount_dirs.thoughts);
     let context_dir = base.join(&desired.mount_dirs.context);
     let references_dir = base.join(&desired.mount_dirs.references);
-    ensure_dir(&thoughts_dir)?;
-    ensure_dir(&context_dir)?;
-    ensure_dir(&references_dir)?;
+    ensure_mount_dir(&thoughts_dir)?;
+    ensure_mount_dir(&context_dir)?;
+    ensure_mount_dir(&references_dir)?;
 
     println!("{} filesystem mounts...", "Synchronizing".cyan());
 
@@ -136,7 +136,7 @@ pub async fn update_active_mounts() -> Result<()> {
             let parent = target.parent().ok_or_else(|| {
                 anyhow::anyhow!("mount target has no parent directory: {}", target.display())
             })?;
-            ensure_dir(parent)?;
+            ensure_mount_dir(parent)?;
 
             // Resolve mount source
             let src = match (space, m) {

--- a/crates/infra/thoughts-core/src/mount/diagnostics.rs
+++ b/crates/infra/thoughts-core/src/mount/diagnostics.rs
@@ -1,0 +1,82 @@
+use crate::utils::paths::ensure_dir;
+use anyhow::Result;
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub fn ensure_mount_dir(path: &Path) -> Result<()> {
+    ensure_dir(path).map_err(|error| add_mount_repair_context(path, error))
+}
+
+fn add_mount_repair_context(path: &Path, error: anyhow::Error) -> anyhow::Error {
+    if is_likely_inaccessible_mount_error(&error) {
+        error.context(format!(
+            "Mount directory {} exists but is not accessible.\n\
+This may be a stale/disconnected FUSE mount (for example mergerfs).\n\
+Repair or unmount/remount the stale mount, then run:\n\
+  thoughts mount update\n\
+or:\n\
+  thoughts sync\n\
+If this repository is already initialized, you likely do not need to run `thoughts init` again.",
+            path.display()
+        ))
+    } else {
+        error
+    }
+}
+
+fn is_likely_inaccessible_mount_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(is_likely_inaccessible_mount_io_error)
+    })
+}
+
+fn is_likely_inaccessible_mount_io_error(error: &std::io::Error) -> bool {
+    matches!(error.kind(), ErrorKind::AlreadyExists) || is_disconnected_mount_raw_error(error)
+}
+
+fn is_disconnected_mount_raw_error(error: &std::io::Error) -> bool {
+    error
+        .raw_os_error()
+        .is_some_and(|raw| DISCONNECTED_MOUNT_RAW_ERRORS.contains(&raw))
+}
+
+#[cfg(target_os = "linux")]
+const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[107, 116];
+
+#[cfg(target_os = "macos")]
+const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[57, 70];
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_mount_repair_context_is_actionable_for_existing_inaccessible_dir() {
+        let path = Path::new(".thoughts-data/thoughts");
+        let error = anyhow::anyhow!(std::io::Error::from(ErrorKind::AlreadyExists));
+        let error = add_mount_repair_context(path, error).to_string();
+
+        assert!(error.contains(".thoughts-data/thoughts"));
+        assert!(error.contains("stale/disconnected FUSE mount"));
+        assert!(error.contains("thoughts mount update"));
+        assert!(error.contains("thoughts sync"));
+        assert!(error.contains("do not need to run `thoughts init` again"));
+    }
+
+    #[test]
+    fn test_add_mount_repair_context_leaves_unrelated_errors_unchanged() {
+        let path = Path::new(".thoughts-data/thoughts");
+        let error = anyhow::anyhow!("Path exists but is not a directory: {}", path.display());
+        let error = add_mount_repair_context(path, error).to_string();
+
+        assert_eq!(
+            error,
+            "Path exists but is not a directory: .thoughts-data/thoughts"
+        );
+    }
+}

--- a/crates/infra/thoughts-core/src/mount/diagnostics.rs
+++ b/crates/infra/thoughts-core/src/mount/diagnostics.rs
@@ -43,12 +43,15 @@ fn is_disconnected_mount_raw_error(error: &std::io::Error) -> bool {
 }
 
 #[cfg(target_os = "linux")]
+// Linux errno values: ENOTCONN = 107, ESTALE = 116.
 const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[107, 116];
 
 #[cfg(target_os = "macos")]
+// Darwin errno values: ENOTCONN = 57, ESTALE = 70.
 const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[57, 70];
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+// No disconnected-mount raw errno mappings are defined on unsupported targets.
 const DISCONNECTED_MOUNT_RAW_ERRORS: &[i32] = &[];
 
 #[cfg(test)]
@@ -66,6 +69,20 @@ mod tests {
         assert!(error.contains("thoughts mount update"));
         assert!(error.contains("thoughts sync"));
         assert!(error.contains("do not need to run `thoughts init` again"));
+    }
+
+    #[test]
+    fn test_add_mount_repair_context_is_actionable_for_disconnected_mount_raw_error() {
+        let Some(raw) = DISCONNECTED_MOUNT_RAW_ERRORS.first() else {
+            return;
+        };
+        let path = Path::new(".thoughts-data/thoughts");
+        let error = anyhow::anyhow!(std::io::Error::from_raw_os_error(*raw));
+        let error = add_mount_repair_context(path, error).to_string();
+
+        assert!(error.contains(".thoughts-data/thoughts"));
+        assert!(error.contains("stale/disconnected FUSE mount"));
+        assert!(error.contains("thoughts mount update"));
     }
 
     #[test]

--- a/crates/infra/thoughts-core/src/mount/mod.rs
+++ b/crates/infra/thoughts-core/src/mount/mod.rs
@@ -1,4 +1,5 @@
 pub mod auto_mount;
+mod diagnostics;
 mod manager;
 pub mod resolver;
 mod types;
@@ -13,6 +14,7 @@ mod fuse_t;
 #[cfg(test)]
 mod mock;
 
+pub use diagnostics::ensure_mount_dir;
 pub use manager::get_mount_manager;
 pub use resolver::MountResolver;
 pub use types::*;

--- a/crates/infra/thoughts-core/src/utils/paths.rs
+++ b/crates/infra/thoughts-core/src/utils/paths.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use anyhow::anyhow;
 use dirs;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -20,10 +22,35 @@ pub fn expand_path(path: &Path) -> Result<PathBuf> {
 
 /// Ensure a directory exists, creating it if necessary
 pub fn ensure_dir(path: &Path) -> Result<()> {
-    if !path.exists() {
-        std::fs::create_dir_all(path)?;
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(anyhow!(
+            "Path exists but is not a directory: {}",
+            path.display()
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => match std::fs::create_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(create_error) if create_error.kind() == ErrorKind::AlreadyExists => {
+                match std::fs::metadata(path) {
+                    Ok(metadata) if metadata.is_dir() => Ok(()),
+                    Ok(_) => Err(anyhow!(
+                        "Path exists but is not a directory: {}",
+                        path.display()
+                    )),
+                    Err(_) => Err(anyhow!(create_error).context(format!(
+                        "Path already exists but could not be accessed as a directory: {}",
+                        path.display()
+                    ))),
+                }
+            }
+            Err(create_error) => Err(anyhow!(create_error)
+                .context(format!("Failed to create directory: {}", path.display()))),
+        },
+        Err(error) => Err(anyhow!(error).context(format!(
+            "Failed to access directory path: {}",
+            path.display()
+        ))),
     }
-    Ok(())
 }
 
 /// Sanitize a directory name for use in filesystem
@@ -131,5 +158,27 @@ mod tests {
             sanitize_dir_name("bad/name:with*chars?"),
             "bad_name_with_chars_"
         );
+    }
+
+    #[test]
+    fn test_ensure_dir_creates_missing_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("new-dir");
+
+        ensure_dir(&path).unwrap();
+
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn test_ensure_dir_rejects_existing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        std::fs::write(&path, "not a directory").unwrap();
+
+        let error = ensure_dir(&path).unwrap_err().to_string();
+
+        assert!(error.contains("Path exists but is not a directory"));
+        assert!(error.contains(&path.display().to_string()));
     }
 }


### PR DESCRIPTION
## My Notes (preserved)

i got a contextless 'file exists' error.  hoping this would lead to the situation and fix more quickly.

## What problem(s) was I solving?

The stale-mount error handling was useful, but generic directory creation should not know about thoughts mount recovery commands.

## What user-facing changes did I ship?

- Mount directory failures during init and mount update still include actionable stale/disconnected FUSE guidance.
- Generic directory creation errors no longer mention mounts or thoughts-specific recovery commands.

## How I implemented it

- Added a mount-layer `ensure_mount_dir` wrapper around `utils::paths::ensure_dir`.
- Moved stale/disconnected FUSE diagnostics into the mount module.
- Updated init and auto-mount directory setup to call the mount-aware wrapper.
- Kept `ensure_dir` focused on generic filesystem behavior.

## How to verify it

- [ ] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Manual verification run:

- `cargo +nightly fmt --all --check`
- `cargo clippy -p thoughts-tool -p thoughts-bin --all-targets -- -D warnings`
- `cargo test -p thoughts-tool -p thoughts-bin`

Note: `just fmt` was attempted but could not complete because `taplo` is not installed in this environment.

## Description for the changelog

Keep stale mount repair advice in the mount layer instead of generic path utilities.