### PR TITLE
feat(opencode-orchestrator-mcp): add explicit agent listing and selection

### DIFF
--- a/agentic.schema.json
+++ b/agentic.schema.json
@@ -37,6 +37,10 @@
       "description": "Orchestrator session and timing configuration.",
       "$ref": "#/$defs/OrchestratorConfig",
       "default": {
+        "agents": {
+          "allow": [],
+          "deny": []
+        },
         "commands": {
           "allow": [],
           "deny": []
@@ -263,6 +267,28 @@
         }
       }
     },
+    "OrchestratorAgentsConfig": {
+      "description": "Agent filtering policy for explicit orchestrator agent listing/selection.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Exact case-sensitive agent names to allow. Empty means no allowlist restriction.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Exact case-sensitive agent names to deny. Deny wins over allow.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "OrchestratorCommandsConfig": {
       "description": "Command filtering policy for orchestrator-exposed `OpenCode` commands.",
       "type": "object",
@@ -289,6 +315,14 @@
       "description": "Configuration for opencode-orchestrator-mcp.",
       "type": "object",
       "properties": {
+        "agents": {
+          "description": "Agent filtering policy for explicit orchestrator agent listing/selection.",
+          "$ref": "#/$defs/OrchestratorAgentsConfig",
+          "default": {
+            "allow": [],
+            "deny": []
+          }
+        },
         "commands": {
           "description": "Command filtering policy for orchestrator-exposed `OpenCode` commands.",
           "$ref": "#/$defs/OrchestratorCommandsConfig",

--- a/agentic.toml.example
+++ b/agentic.toml.example
@@ -56,6 +56,18 @@ deny = []
 # allow = ["research", "implement_plan"]
 # deny = ["commit"]
 
+[orchestrator.agents]
+# Exact, case-sensitive agent names that remain visible/selectable via orchestrator_list_agents
+# and orchestrator_run(message=..., agent=...).
+# Empty allowlist means "do not restrict by allowlist".
+allow = []
+# Exact, case-sensitive agent names that are always blocked.
+# Entries are trimmed before comparison, and deny wins over allow.
+deny = []
+# Example:
+# allow = ["Plan", "Research"]
+# deny = ["Bash"]
+
 # =============================================================================
 # Web Retrieval - Configuration for web_fetch and web_search tools
 # =============================================================================

--- a/apps/opencode-orchestrator-mcp/src/main.rs
+++ b/apps/opencode-orchestrator-mcp/src/main.rs
@@ -1,9 +1,10 @@
 //! MCP server for orchestrator-style agents to spawn and manage `OpenCode` sessions.
 //!
-//! This binary exposes six tools for orchestrator agents:
+//! This binary exposes seven tools for orchestrator agents:
 //! - `run` - start or resume an `OpenCode` session
 //! - `list_sessions` - list existing sessions
 //! - `get_session_state` - inspect a session's status, tool calls, and pending work
+//! - `list_agents` - discover available visible `OpenCode` agents
 //! - `list_commands` - discover available `OpenCode` commands
 //! - `respond_permission` - reply to permission requests
 //! - `respond_question` - reply to question requests

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -101,6 +101,20 @@ impl CommandPolicyDecision {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPolicyDecision {
+    Allowed,
+    DeniedByAllowlist,
+    DeniedByDenylist,
+}
+
+impl AgentPolicyDecision {
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
 impl RecoveryMode {
     fn as_str(self) -> &'static str {
         match self {
@@ -555,6 +569,41 @@ impl OrchestratorServer {
         self.command_policy_decision(command).is_allowed()
     }
 
+    pub fn agent_policy_decision(&self, agent: &str) -> AgentPolicyDecision {
+        let deny_matches = self
+            .config
+            .agents
+            .deny
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| entry == agent);
+        if deny_matches {
+            return AgentPolicyDecision::DeniedByDenylist;
+        }
+
+        let mut allow_entries = self
+            .config
+            .agents
+            .allow
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .peekable();
+
+        if allow_entries.peek().is_some() && !allow_entries.any(|entry| entry == agent) {
+            return AgentPolicyDecision::DeniedByAllowlist;
+        }
+
+        AgentPolicyDecision::Allowed
+    }
+
+    pub fn is_agent_allowed(&self, agent: &str) -> bool {
+        self.agent_policy_decision(agent).is_allowed()
+    }
+
     /// Start a new managed `OpenCode` server and build the client.
     ///
     /// This is the eager initialization path that spawns the server immediately.
@@ -1002,6 +1051,7 @@ impl OrchestratorServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentic_config::types::OrchestratorAgentsConfig;
     use agentic_config::types::OrchestratorCommandsConfig;
     use serial_test::serial;
     use std::sync::Arc;
@@ -1165,6 +1215,73 @@ mod tests {
         );
         assert!(server.is_command_allowed("Plan"));
         assert!(!server.is_command_allowed("plan"));
+    }
+
+    #[test]
+    fn agent_policy_allows_all_when_allowlist_is_empty() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                agents: OrchestratorAgentsConfig {
+                    allow: vec![],
+                    deny: vec!["Bash".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.agent_policy_decision("Plan"),
+            AgentPolicyDecision::Allowed
+        );
+        assert_eq!(
+            server.agent_policy_decision("Bash"),
+            AgentPolicyDecision::DeniedByDenylist
+        );
+    }
+
+    #[test]
+    fn agent_policy_trims_entries_and_deny_wins() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                agents: OrchestratorAgentsConfig {
+                    allow: vec!["  Plan  ".into()],
+                    deny: vec!["Plan".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.agent_policy_decision("Plan"),
+            AgentPolicyDecision::DeniedByDenylist
+        );
+    }
+
+    #[test]
+    fn agent_policy_matching_is_case_sensitive() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                agents: OrchestratorAgentsConfig {
+                    allow: vec!["Plan".into()],
+                    deny: vec!["Bash".into()],
+                },
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(
+            server.agent_policy_decision("Plan"),
+            AgentPolicyDecision::Allowed
+        );
+        assert_eq!(
+            server.agent_policy_decision("plan"),
+            AgentPolicyDecision::DeniedByAllowlist
+        );
+        assert!(server.is_agent_allowed("Plan"));
+        assert!(!server.is_agent_allowed("plan"));
     }
 
     struct BlockingHealthServer {

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -2,14 +2,18 @@
 
 use crate::config;
 use crate::logging;
+use crate::server::AgentPolicyDecision;
 use crate::server::CommandPolicyDecision;
 use crate::server::OrchestratorServer;
 use crate::server::OrchestratorServerHandle;
 use crate::token_tracker::TokenTracker;
+use crate::types::AgentInfo;
 use crate::types::ChangeStats;
 use crate::types::CommandInfo;
 use crate::types::GetSessionStateInput;
 use crate::types::GetSessionStateOutput;
+use crate::types::ListAgentsInput;
+use crate::types::ListAgentsOutput;
 use crate::types::ListCommandsInput;
 use crate::types::ListCommandsOutput;
 use crate::types::ListSessionsInput;
@@ -90,6 +94,18 @@ fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> Tool
     ToolError::InvalidInput(format!(
         "Command '{command}' cannot be run because {reason}."
     ))
+}
+
+fn blocked_agent_error(agent: &str, decision: AgentPolicyDecision) -> ToolError {
+    let reason = match decision {
+        AgentPolicyDecision::Allowed => {
+            return ToolError::Internal("agent unexpectedly allowed".into());
+        }
+        AgentPolicyDecision::DeniedByAllowlist => "it is not present in orchestrator.agents.allow",
+        AgentPolicyDecision::DeniedByDenylist => "it is blocked by orchestrator.agents.deny",
+    };
+
+    ToolError::InvalidInput(format!("Agent '{agent}' cannot be used because {reason}."))
 }
 
 impl RunOutcome {
@@ -390,6 +406,12 @@ impl OrchestratorRunTool {
             ));
         }
 
+        if input.command.is_some() && input.agent.is_some() {
+            return Err(ToolError::InvalidInput(
+                "agent cannot be provided when command is specified".into(),
+            ));
+        }
+
         // Trim and validate message content
         let message = input.message.map(|m| m.trim().to_string());
         if let Some(ref m) = message
@@ -397,6 +419,15 @@ impl OrchestratorRunTool {
         {
             return Err(ToolError::InvalidInput(
                 "message cannot be empty or whitespace-only".into(),
+            ));
+        }
+
+        let agent = input.agent.map(|value| value.trim().to_string());
+        if let Some(ref agent) = agent
+            && agent.is_empty()
+        {
+            return Err(ToolError::InvalidInput(
+                "agent cannot be empty or whitespace-only".into(),
             ));
         }
 
@@ -413,6 +444,13 @@ impl OrchestratorRunTool {
             let decision = server.command_policy_decision(command);
             if !decision.is_allowed() {
                 return Err(blocked_command_error(command, decision));
+            }
+        }
+
+        if let Some(agent) = agent.as_deref() {
+            let decision = server.agent_policy_decision(agent);
+            if !decision.is_allowed() {
+                return Err(blocked_agent_error(agent, decision));
             }
         }
 
@@ -575,7 +613,7 @@ impl OrchestratorRunTool {
                 }],
                 message_id: None,
                 model: None,
-                agent: None,
+                agent: agent.clone(),
                 no_reply: None,
                 system: None,
                 variant: None,
@@ -988,10 +1026,12 @@ Returns when:
 Parameters:
 - session_id: Existing session to resume (omit to create new)
 - command: OpenCode command name (e.g., "research", "implement_plan")
+- agent: Explicit agent for raw-prompt execution only. Invalid with command.
 - message: Prompt text or $ARGUMENTS for command template
 
 Examples:
 - New session with prompt: run(message="explain this code")
+- New session with prompt and agent: run(message="explain this code", agent="Plan")
 - New session with command: run(command="research", message="caching strategies")
 - Resume session: run(session_id="...", message="continue")
 - Check status: run(session_id="...")"#;
@@ -1331,6 +1371,87 @@ impl Tool for GetSessionStateTool {
 }
 
 // ============================================================================
+// list_agents
+// ============================================================================
+
+/// Tool for listing available visible `OpenCode` agents that can be selected explicitly.
+#[derive(Clone)]
+pub struct ListAgentsTool {
+    server: Arc<OrchestratorServerHandle>,
+}
+
+impl ListAgentsTool {
+    /// Create a new `ListAgentsTool` with the shared server handle.
+    pub fn new(server: Arc<OrchestratorServerHandle>) -> Self {
+        Self { server }
+    }
+}
+
+impl Tool for ListAgentsTool {
+    type Input = ListAgentsInput;
+    type Output = ListAgentsOutput;
+    const NAME: &'static str = "list_agents";
+    const DESCRIPTION: &'static str =
+        "List available visible OpenCode agents that can be used with run(message=..., agent=...).";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let server_handle = Arc::clone(&self.server);
+        Box::pin(async move {
+            let timer = CallTimer::start();
+            let result: Result<ListAgentsOutput, ToolError> =
+                async {
+                    let server = server_handle
+                        .acquire()
+                        .await
+                        .map_err(|e| ToolError::Internal(e.to_string()))?;
+
+                    let agents =
+                        server.client().tools().agents().await.map_err(|e| {
+                            ToolError::Internal(format!("Failed to list agents: {e}"))
+                        })?;
+
+                    let agent_infos: Vec<AgentInfo> = agents
+                        .into_iter()
+                        .filter(|agent| !agent.hidden.unwrap_or(false))
+                        .filter(|agent| server.is_agent_allowed(&agent.name))
+                        .map(|agent| AgentInfo {
+                            name: agent.name,
+                            description: agent.description,
+                        })
+                        .collect();
+
+                    Ok(ListAgentsOutput {
+                        agents: agent_infos,
+                    })
+                }
+                .await;
+
+            match result {
+                Ok(output) => {
+                    log_tool_success(
+                        &timer,
+                        Self::NAME,
+                        &input,
+                        &output,
+                        ToolLogMeta::default(),
+                        false,
+                    );
+                    Ok(output)
+                }
+                Err(error) => {
+                    log_tool_error(&timer, Self::NAME, &input, &error);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+// ============================================================================
 // list_commands
 // ============================================================================
 
@@ -1586,6 +1707,7 @@ Parameters:
                         OrchestratorRunInput {
                             session_id: Some(input.session_id),
                             command: None,
+                            agent: None,
                             message: None,
                             wait_for_activity,
                         },
@@ -1764,6 +1886,7 @@ Parameters:
                         .run_impl_outcome(OrchestratorRunInput {
                             session_id: Some(input.session_id),
                             command: None,
+                            agent: None,
                             message: None,
                             wait_for_activity: Some(true),
                         }, &ctx, PermissionPreflightMode::Strict)
@@ -1779,6 +1902,7 @@ Parameters:
                         .run_impl_outcome(OrchestratorRunInput {
                             session_id: Some(input.session_id),
                             command: None,
+                            agent: None,
                             message: None,
                             wait_for_activity: None,
                         }, &ctx, PermissionPreflightMode::Strict)
@@ -1815,6 +1939,7 @@ pub fn build_registry(server: &Arc<OrchestratorServerHandle>) -> ToolRegistry {
         .register::<OrchestratorRunTool, ()>(OrchestratorRunTool::new(Arc::clone(server)))
         .register::<ListSessionsTool, ()>(ListSessionsTool::new(Arc::clone(server)))
         .register::<GetSessionStateTool, ()>(GetSessionStateTool::new(Arc::clone(server)))
+        .register::<ListAgentsTool, ()>(ListAgentsTool::new(Arc::clone(server)))
         .register::<ListCommandsTool, ()>(ListCommandsTool::new(Arc::clone(server)))
         .register::<RespondPermissionTool, ()>(RespondPermissionTool::new(Arc::clone(server)))
         .register::<RespondQuestionTool, ()>(RespondQuestionTool::new(Arc::clone(server)))

--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -24,6 +24,11 @@ pub struct OrchestratorRunInput {
     #[serde(default)]
     pub command: Option<String>,
 
+    /// Explicit agent name for raw-prompt execution.
+    /// Unsupported when `command` is provided.
+    #[serde(default)]
+    pub agent: Option<String>,
+
     /// The message/prompt to send. Required for new sessions or when sending new work.
     /// For resume-only calls (checking status), can be omitted.
     #[serde(default)]
@@ -452,6 +457,54 @@ impl TextFormat for ListCommandsOutput {
 }
 
 // ============================================================================
+// list_agents
+// ============================================================================
+
+/// Input for the `list_agents` tool.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct ListAgentsInput {}
+
+/// Information about an available agent.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentInfo {
+    /// Agent name.
+    pub name: String,
+    /// Agent description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Output from the `list_agents` tool.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ListAgentsOutput {
+    /// List of available visible agents.
+    pub agents: Vec<AgentInfo>,
+}
+
+impl TextFormat for ListAgentsOutput {
+    fn fmt_text(&self, _opts: &TextOptions) -> String {
+        let mut out = String::from("Available agents:\n");
+
+        for agent in &self.agents {
+            let _ = write!(out, "  {}", agent.name);
+            if let Some(desc) = &agent.description
+                && let Some(first_line) = desc.lines().next()
+            {
+                let _ = write!(out, " - {first_line}");
+            }
+            out.push('\n');
+        }
+
+        if self.agents.is_empty() {
+            out.push_str("  (no agents available)\n");
+        }
+
+        out.push_str("\nUse orchestrator_run(message=<prompt>, agent=<name>) for raw prompts\n");
+        out
+    }
+}
+
+// ============================================================================
 // respond_permission
 // ============================================================================
 
@@ -673,5 +726,23 @@ mod tests {
         assert!(text.contains("research"));
         assert!(text.contains("Run research workflow"));
         assert!(text.contains("orchestrator_run"));
+    }
+
+    #[test]
+    fn list_agents_text_format() {
+        let out = ListAgentsOutput {
+            agents: vec![AgentInfo {
+                name: "Plan".into(),
+                description: Some("Use for planning tasks\nExtra detail".into()),
+            }],
+        };
+
+        let text = out.fmt_text(&TextOptions::default());
+        assert!(text.contains("Available agents"));
+        assert!(text.contains("Plan"));
+        assert!(text.contains("Use for planning tasks"));
+        assert!(!text.contains("Extra detail"));
+        assert!(text.contains("orchestrator_run"));
+        assert!(text.contains("agent=<name>"));
     }
 }

--- a/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
@@ -121,6 +121,7 @@ async fn it_times_out_after_5_min_inactivity() {
                 OrchestratorRunInput {
                     session_id: Some("s1".into()),
                     command: None,
+                    agent: None,
                     message: Some("test prompt".into()),
                     wait_for_activity: None,
                 },
@@ -200,6 +201,7 @@ async fn it_does_not_timeout_while_busy() {
                 OrchestratorRunInput {
                     session_id: Some("s1".into()),
                     command: None,
+                    agent: None,
                     message: Some("test prompt".into()),
                     wait_for_activity: None,
                 },

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -82,6 +82,7 @@ async fn run_returns_cancelled_when_request_context_is_cancelled() {
             OrchestratorRunInput {
                 session_id: Some(session_id.into()),
                 command: Some("research".into()),
+                agent: None,
                 message: Some("test".into()),
                 wait_for_activity: None,
             },

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -2,36 +2,73 @@
 
 mod support;
 
+use agentic_config::types::OrchestratorAgentsConfig;
 use agentic_config::types::OrchestratorCommandsConfig;
 use agentic_config::types::OrchestratorConfig;
 use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
+use opencode_orchestrator_mcp::tools::ListAgentsTool;
 use opencode_orchestrator_mcp::tools::ListCommandsTool;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
+use opencode_orchestrator_mcp::types::ListAgentsInput;
 use opencode_orchestrator_mcp::types::ListCommandsInput;
 use opencode_orchestrator_mcp::types::OrchestratorRunInput;
 use serde_json::json;
 use std::sync::Arc;
+use std::time::Duration;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
+use support::messages_fixture;
+use support::session_fixture;
+use support::status_v2_idle;
 use support::test_orchestrator_server_with_config;
 
-fn orchestrator_config(allow: &[&str], deny: &[&str]) -> OrchestratorConfig {
+fn orchestrator_config(
+    command_allow: &[&str],
+    command_deny: &[&str],
+    agent_allow: &[&str],
+    agent_deny: &[&str],
+) -> OrchestratorConfig {
     OrchestratorConfig {
         commands: OrchestratorCommandsConfig {
-            allow: allow.iter().map(|entry| (*entry).to_string()).collect(),
-            deny: deny.iter().map(|entry| (*entry).to_string()).collect(),
+            allow: command_allow
+                .iter()
+                .map(|entry| (*entry).to_string())
+                .collect(),
+            deny: command_deny
+                .iter()
+                .map(|entry| (*entry).to_string())
+                .collect(),
+        },
+        agents: OrchestratorAgentsConfig {
+            allow: agent_allow
+                .iter()
+                .map(|entry| (*entry).to_string())
+                .collect(),
+            deny: agent_deny
+                .iter()
+                .map(|entry| (*entry).to_string())
+                .collect(),
         },
         ..OrchestratorConfig::default()
     }
 }
 
 fn command_list(names: &[&str]) -> serde_json::Value {
+    json!(
+        names
+            .iter()
+            .map(|name| json!({"name": name, "description": format!("{name} description")}))
+            .collect::<Vec<_>>()
+    )
+}
+
+fn agent_list(names: &[&str]) -> serde_json::Value {
     json!(
         names
             .iter()
@@ -53,6 +90,19 @@ async fn list_commands_with_config(mock: &MockServer, config: OrchestratorConfig
         .collect()
 }
 
+async fn list_agents_with_config(mock: &MockServer, config: OrchestratorConfig) -> Vec<String> {
+    let server = test_orchestrator_server_with_config(mock, config).await;
+    let tool = ListAgentsTool::new(Arc::clone(&server));
+
+    tool.call(ListAgentsInput {}, &ToolContext::default())
+        .await
+        .expect("list_agents should succeed")
+        .agents
+        .into_iter()
+        .map(|agent| agent.name)
+        .collect()
+}
+
 #[tokio::test]
 async fn list_commands_filters_deny_only_policy() {
     let mock = MockServer::start().await;
@@ -64,7 +114,8 @@ async fn list_commands_filters_deny_only_policy() {
         .mount(&mock)
         .await;
 
-    let names = list_commands_with_config(&mock, orchestrator_config(&[], &["build"])).await;
+    let names =
+        list_commands_with_config(&mock, orchestrator_config(&[], &["build"], &[], &[])).await;
 
     assert_eq!(names, vec!["test", "lint"]);
 }
@@ -80,7 +131,8 @@ async fn list_commands_filters_allow_only_policy() {
         .mount(&mock)
         .await;
 
-    let names = list_commands_with_config(&mock, orchestrator_config(&["build"], &[])).await;
+    let names =
+        list_commands_with_config(&mock, orchestrator_config(&["build"], &[], &[], &[])).await;
 
     assert_eq!(names, vec!["build"]);
 }
@@ -96,8 +148,11 @@ async fn list_commands_applies_deny_wins_overlap_policy() {
         .mount(&mock)
         .await;
 
-    let names =
-        list_commands_with_config(&mock, orchestrator_config(&["test", "build"], &["build"])).await;
+    let names = list_commands_with_config(
+        &mock,
+        orchestrator_config(&["test", "build"], &["build"], &[], &[]),
+    )
+    .await;
 
     assert_eq!(names, vec!["test"]);
 }
@@ -113,7 +168,8 @@ async fn list_commands_trims_configured_entries() {
         .mount(&mock)
         .await;
 
-    let names = list_commands_with_config(&mock, orchestrator_config(&[], &[" build "])).await;
+    let names =
+        list_commands_with_config(&mock, orchestrator_config(&[], &[" build "], &[], &[])).await;
 
     assert_eq!(names, vec!["test", "lint"]);
 }
@@ -127,7 +183,8 @@ async fn list_commands_matching_is_case_sensitive() {
         .mount(&mock)
         .await;
 
-    let names = list_commands_with_config(&mock, orchestrator_config(&[], &["Build"])).await;
+    let names =
+        list_commands_with_config(&mock, orchestrator_config(&[], &["Build"], &[], &[])).await;
 
     assert_eq!(names, vec!["build"]);
 }
@@ -135,8 +192,11 @@ async fn list_commands_matching_is_case_sensitive() {
 #[tokio::test]
 async fn blocked_run_command_fails_before_session_resolution_or_dispatch() {
     let mock = MockServer::start().await;
-    let server =
-        test_orchestrator_server_with_config(&mock, orchestrator_config(&[], &["research"])).await;
+    let server = test_orchestrator_server_with_config(
+        &mock,
+        orchestrator_config(&[], &["research"], &[], &[]),
+    )
+    .await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
 
     let err = tool
@@ -144,6 +204,7 @@ async fn blocked_run_command_fails_before_session_resolution_or_dispatch() {
             OrchestratorRunInput {
                 session_id: None,
                 command: Some("research".into()),
+                agent: None,
                 message: Some("blocked arguments".into()),
                 wait_for_activity: None,
             },
@@ -175,4 +236,252 @@ async fn blocked_run_command_fails_before_session_resolution_or_dispatch() {
             .any(|request| request.url.path() == "/event"),
         "unexpected event subscription request"
     );
+}
+
+#[tokio::test]
+async fn list_agents_filters_deny_only_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_agents_with_config(&mock, orchestrator_config(&[], &[], &[], &["Bash"])).await;
+
+    assert_eq!(names, vec!["Plan", "Research"]);
+}
+
+#[tokio::test]
+async fn list_agents_filters_allow_only_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_agents_with_config(&mock, orchestrator_config(&[], &[], &["Bash"], &[])).await;
+
+    assert_eq!(names, vec!["Bash"]);
+}
+
+#[tokio::test]
+async fn list_agents_applies_deny_wins_overlap_policy() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
+        )
+        .mount(&mock)
+        .await;
+
+    let names = list_agents_with_config(
+        &mock,
+        orchestrator_config(&[], &[], &["Plan", "Bash"], &["Bash"]),
+    )
+    .await;
+
+    assert_eq!(names, vec!["Plan"]);
+}
+
+#[tokio::test]
+async fn list_agents_trims_configured_entries() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash"])))
+        .mount(&mock)
+        .await;
+
+    let names =
+        list_agents_with_config(&mock, orchestrator_config(&[], &[], &[], &[" Bash "])).await;
+
+    assert_eq!(names, vec!["Plan"]);
+}
+
+#[tokio::test]
+async fn list_agents_matching_is_case_sensitive() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(agent_list(&["Bash", "bash"])))
+        .mount(&mock)
+        .await;
+
+    let names = list_agents_with_config(&mock, orchestrator_config(&[], &[], &[], &["Bash"])).await;
+
+    assert_eq!(names, vec!["bash"]);
+}
+
+#[tokio::test]
+async fn blocked_run_agent_fails_before_session_resolution_or_dispatch() {
+    let mock = MockServer::start().await;
+    let server =
+        test_orchestrator_server_with_config(&mock, orchestrator_config(&[], &[], &[], &["Bash"]))
+            .await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+
+    let err = tool
+        .call(
+            OrchestratorRunInput {
+                session_id: None,
+                command: None,
+                agent: Some("Bash".into()),
+                message: Some("blocked prompt".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("blocked agent should fail before dispatch");
+
+    assert!(matches!(err, ToolError::InvalidInput(_)));
+    assert!(err.to_string().contains("orchestrator.agents.deny"));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        !requests
+            .iter()
+            .any(|request| request.url.path().starts_with("/session")),
+        "unexpected session request(s): {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|request| request.url.path() == "/event"),
+        "unexpected event subscription request"
+    );
+}
+
+#[tokio::test]
+async fn run_prompt_forwards_agent_in_prompt_request() {
+    let mock = MockServer::start().await;
+    let server =
+        test_orchestrator_server_with_config(&mock, orchestrator_config(&[], &[], &["Plan"], &[]))
+            .await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+
+    Mock::given(method("GET"))
+        .and(path("/session/s1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("s1")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/session/s1/prompt_async"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/s1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture("s1", Some("ok"))))
+        .mount(&mock)
+        .await;
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(3),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some("s1".into()),
+                command: None,
+                agent: Some("Plan".into()),
+                message: Some("say ok".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("run should complete before timeout")
+    .expect("run should succeed");
+
+    assert!(matches!(
+        result.status,
+        opencode_orchestrator_mcp::types::RunStatus::Completed
+    ));
+    assert_eq!(result.response.as_deref(), Some("ok"));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let prompt_request = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "POST" && request.url.path() == "/session/s1/prompt_async"
+        })
+        .expect("prompt request should be sent");
+    let body: serde_json::Value = serde_json::from_slice(&prompt_request.body)
+        .expect("prompt request body should be valid json");
+    assert_eq!(body["agent"], json!("Plan"));
+}
+
+#[tokio::test]
+async fn run_command_and_agent_is_invalid_without_http_calls() {
+    let mock = MockServer::start().await;
+    let server =
+        test_orchestrator_server_with_config(&mock, orchestrator_config(&[], &[], &[], &[])).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+
+    let err = tool
+        .call(
+            OrchestratorRunInput {
+                session_id: None,
+                command: Some("research".into()),
+                agent: Some("Plan".into()),
+                message: Some("args".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("command + agent should be rejected");
+
+    assert!(matches!(err, ToolError::InvalidInput(_)));
+    assert!(
+        err.to_string()
+            .contains("agent cannot be provided when command is specified")
+    );
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(requests.is_empty(), "unexpected requests: {requests:?}");
 }

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -119,6 +119,7 @@ async fn fast_idle_prompt_completes_without_hanging() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: Some("say hello".into()),
                 wait_for_activity: None,
             },
@@ -496,6 +497,7 @@ async fn run_still_errors_on_initial_permission_list_bad_request() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: None,
                 wait_for_activity: None,
             },

--- a/apps/opencode-orchestrator-mcp/tests/integration.rs
+++ b/apps/opencode-orchestrator-mcp/tests/integration.rs
@@ -136,6 +136,7 @@ async fn unknown_command_errors_fast() {
     let input = OrchestratorRunInput {
         session_id: Some(session_id.clone()),
         command: Some("___definitely_not_a_real_command___".into()),
+        agent: None,
         message: Some("test argument".into()),
         wait_for_activity: None,
     };
@@ -179,6 +180,7 @@ async fn prompt_completes_and_extracts_response() {
     let input = OrchestratorRunInput {
         session_id: Some(session_id.clone()),
         command: None,
+        agent: None,
         message: Some("Say exactly 'hello' and nothing else.".into()),
         wait_for_activity: None,
     };
@@ -238,6 +240,7 @@ async fn session_resumption_works() {
     let input1 = OrchestratorRunInput {
         session_id: Some(session_id.clone()),
         command: None,
+        agent: None,
         message: Some("Say 'first' and nothing else.".into()),
         wait_for_activity: None,
     };
@@ -255,6 +258,7 @@ async fn session_resumption_works() {
     let input2 = OrchestratorRunInput {
         session_id: Some(session_id.clone()),
         command: None,
+        agent: None,
         message: Some("Say 'second' and nothing else.".into()),
         wait_for_activity: None,
     };
@@ -311,6 +315,7 @@ async fn permission_request_returns_status() {
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
                 command: None,
+                agent: None,
                 message: Some(prompt),
                 wait_for_activity: None,
             },
@@ -392,6 +397,7 @@ async fn permission_response_resumes_and_completes() {
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
                 command: None,
+                agent: None,
                 message: Some(prompt),
                 wait_for_activity: None,
             },
@@ -520,6 +526,7 @@ async fn permission_reject_returns_none_with_warning() {
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
                 command: None,
+                agent: None,
                 message: Some(prompt),
                 wait_for_activity: None,
             },
@@ -633,6 +640,7 @@ async fn live_question_tool_infrastructure() {
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
                 command: None,
+                agent: None,
                 message: Some("Say 'config test passed' and nothing else.".into()),
                 wait_for_activity: None,
             },

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -8,9 +8,11 @@ use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use opencode_orchestrator_mcp::tools::GetSessionStateTool;
+use opencode_orchestrator_mcp::tools::ListAgentsTool;
 use opencode_orchestrator_mcp::tools::ListCommandsTool;
 use opencode_orchestrator_mcp::tools::ListSessionsTool;
 use opencode_orchestrator_mcp::types::GetSessionStateInput;
+use opencode_orchestrator_mcp::types::ListAgentsInput;
 use opencode_orchestrator_mcp::types::ListCommandsInput;
 use opencode_orchestrator_mcp::types::ListSessionsInput;
 use opencode_orchestrator_mcp::types::SessionStatusSummary;
@@ -740,4 +742,74 @@ async fn list_commands_returns_empty_list() {
         .expect("list_commands should succeed");
 
     assert!(result.commands.is_empty());
+}
+
+#[tokio::test]
+async fn list_agents_returns_visible_agents() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "name": "Plan",
+                "description": "Planning agent",
+                "hidden": false
+            },
+            {
+                "name": "Research",
+                "description": "Research agent"
+            }
+        ])))
+        .mount(&mock)
+        .await;
+
+    let tool = ListAgentsTool::new(Arc::clone(&server));
+
+    let result = tool
+        .call(ListAgentsInput {}, &ToolContext::default())
+        .await
+        .expect("list_agents should succeed");
+
+    assert_eq!(result.agents.len(), 2);
+    assert_eq!(result.agents[0].name, "Plan");
+    assert_eq!(
+        result.agents[0].description.as_deref(),
+        Some("Planning agent")
+    );
+    assert_eq!(result.agents[1].name, "Research");
+}
+
+#[tokio::test]
+async fn list_agents_omits_hidden_agents() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+
+    Mock::given(method("GET"))
+        .and(path("/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "name": "Plan",
+                "description": "Planning agent",
+                "hidden": false
+            },
+            {
+                "name": "HiddenAgent",
+                "description": "Internal agent",
+                "hidden": true
+            }
+        ])))
+        .mount(&mock)
+        .await;
+
+    let tool = ListAgentsTool::new(Arc::clone(&server));
+
+    let result = tool
+        .call(ListAgentsInput {}, &ToolContext::default())
+        .await
+        .expect("list_agents should succeed");
+
+    assert_eq!(result.agents.len(), 1);
+    assert_eq!(result.agents[0].name, "Plan");
 }

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -126,6 +126,7 @@ async fn it_bug1_completion_retries_messages_until_visible() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: Some("test prompt".into()),
                 wait_for_activity: None,
             },
@@ -608,6 +609,7 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: Some("test_cmd".into()),
+                agent: None,
                 message: Some("test args".into()),
                 wait_for_activity: None,
             },

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -83,6 +83,7 @@ async fn pending_question_preflight_returns_question_required() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: None,
                 wait_for_activity: None,
             },
@@ -159,6 +160,7 @@ async fn poll_detected_question_returns_question_required() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: Some("Do the work".into()),
                 wait_for_activity: None,
             },
@@ -377,6 +379,7 @@ async fn permission_priority_wins_over_question() {
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
                 command: None,
+                agent: None,
                 message: None,
                 wait_for_activity: None,
             },

--- a/crates/infra/agentic-config/src/schema.rs
+++ b/crates/infra/agentic-config/src/schema.rs
@@ -39,10 +39,15 @@ mod tests {
 
         let orchestrator_properties = &json["$defs"]["OrchestratorConfig"]["properties"];
         assert!(orchestrator_properties.get("commands").is_some());
+        assert!(orchestrator_properties.get("agents").is_some());
 
         let command_properties = &json["$defs"]["OrchestratorCommandsConfig"]["properties"];
         assert!(command_properties.get("allow").is_some());
         assert!(command_properties.get("deny").is_some());
+
+        let agent_properties = &json["$defs"]["OrchestratorAgentsConfig"]["properties"];
+        assert!(agent_properties.get("allow").is_some());
+        assert!(agent_properties.get("deny").is_some());
 
         let subagents_properties = &json["$defs"]["SubagentsConfig"]["properties"];
         assert!(subagents_properties.get("runtime_timeout_secs").is_some());

--- a/crates/infra/agentic-config/src/types.rs
+++ b/crates/infra/agentic-config/src/types.rs
@@ -170,6 +170,8 @@ pub struct OrchestratorConfig {
     pub compaction_threshold: f64,
     /// Command filtering policy for orchestrator-exposed `OpenCode` commands.
     pub commands: OrchestratorCommandsConfig,
+    /// Agent filtering policy for explicit orchestrator agent listing/selection.
+    pub agents: OrchestratorAgentsConfig,
 }
 
 /// Command filtering policy for orchestrator-exposed `OpenCode` commands.
@@ -182,6 +184,16 @@ pub struct OrchestratorCommandsConfig {
     pub deny: Vec<String>,
 }
 
+/// Agent filtering policy for explicit orchestrator agent listing/selection.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct OrchestratorAgentsConfig {
+    /// Exact case-sensitive agent names to allow. Empty means no allowlist restriction.
+    pub allow: Vec<String>,
+    /// Exact case-sensitive agent names to deny. Deny wins over allow.
+    pub deny: Vec<String>,
+}
+
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
@@ -189,6 +201,7 @@ impl Default for OrchestratorConfig {
             inactivity_timeout_secs: 300,
             compaction_threshold: 0.80,
             commands: OrchestratorCommandsConfig::default(),
+            agents: OrchestratorAgentsConfig::default(),
         }
     }
 }
@@ -475,6 +488,7 @@ mod tests {
         assert!(toml_str.contains("[thoughts]"));
         assert!(toml_str.contains("[orchestrator]"));
         assert!(toml_str.contains("[orchestrator.commands]"));
+        assert!(toml_str.contains("[orchestrator.agents]"));
         assert!(toml_str.contains("[web_retrieval]"));
         assert!(toml_str.contains("[cli_tools]"));
         assert!(toml_str.contains("[logging]"));
@@ -514,6 +528,8 @@ locator_model = "custom-model"
         );
         assert!(config.orchestrator.commands.allow.is_empty());
         assert!(config.orchestrator.commands.deny.is_empty());
+        assert!(config.orchestrator.agents.allow.is_empty());
+        assert!(config.orchestrator.agents.deny.is_empty());
     }
 
     #[test]
@@ -528,6 +544,40 @@ deny = ["commit"]
 
         assert_eq!(config.orchestrator.commands.allow, ["plan", "research"]);
         assert_eq!(config.orchestrator.commands.deny, ["commit"]);
+    }
+
+    #[test]
+    fn test_orchestrator_agents_partial_deserializes_to_empty_lists() {
+        let toml_str = r"
+[orchestrator.agents]
+";
+
+        let config: AgenticConfig = toml::from_str(toml_str).unwrap();
+
+        assert!(config.orchestrator.agents.allow.is_empty());
+        assert!(config.orchestrator.agents.deny.is_empty());
+    }
+
+    #[test]
+    fn test_orchestrator_agents_round_trip() {
+        let toml_str = r#"
+[orchestrator.agents]
+allow = ["Plan", "Research"]
+deny = ["Bash"]
+"#;
+
+        let config: AgenticConfig = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(config.orchestrator.agents.allow, ["Plan", "Research"]);
+        assert_eq!(config.orchestrator.agents.deny, ["Bash"]);
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(serialized.contains("[orchestrator.agents]"));
+        assert!(serialized.contains("allow = ["));
+        assert!(serialized.contains("\"Plan\""));
+        assert!(serialized.contains("\"Research\""));
+        assert!(serialized.contains("deny = ["));
+        assert!(serialized.contains("\"Bash\""));
     }
 
     #[test]
@@ -571,6 +621,8 @@ deny = ["commit"]
         assert!((cfg.compaction_threshold - 0.80).abs() < f64::EPSILON);
         assert!(cfg.commands.allow.is_empty());
         assert!(cfg.commands.deny.is_empty());
+        assert!(cfg.agents.allow.is_empty());
+        assert!(cfg.agents.deny.is_empty());
     }
 
     #[test]

--- a/crates/infra/agentic-config/src/validation.rs
+++ b/crates/infra/agentic-config/src/validation.rs
@@ -294,6 +294,17 @@ pub fn validate(cfg: &AgenticConfig) -> Vec<AdvisoryWarning> {
         &mut warnings,
     );
     validate_command_overlap(cfg, &mut warnings);
+    validate_agent_entries(
+        &cfg.orchestrator.agents.allow,
+        "orchestrator.agents.allow",
+        &mut warnings,
+    );
+    validate_agent_entries(
+        &cfg.orchestrator.agents.deny,
+        "orchestrator.agents.deny",
+        &mut warnings,
+    );
+    validate_agent_overlap(cfg, &mut warnings);
 
     // Validate web_retrieval: default_search_results <= max_search_results
     if cfg.web_retrieval.default_search_results > cfg.web_retrieval.max_search_results {
@@ -480,6 +491,98 @@ fn validate_command_overlap(cfg: &AgenticConfig, warnings: &mut Vec<AdvisoryWarn
         "orchestrator.commands",
         format!(
             "commands appear in both allow and deny: {}. deny wins at runtime",
+            overlap.join(", ")
+        ),
+    ));
+}
+
+fn validate_agent_entries(
+    entries: &[String],
+    path: &'static str,
+    warnings: &mut Vec<AdvisoryWarning>,
+) {
+    let mut seen = BTreeSet::new();
+    let mut duplicates = BTreeSet::new();
+
+    for entry in entries {
+        let trimmed = entry.trim();
+
+        if trimmed.is_empty() {
+            warnings.push(AdvisoryWarning::new(
+                if path.ends_with("allow") {
+                    "orchestrator.agents.allow.empty_entry"
+                } else {
+                    "orchestrator.agents.deny.empty_entry"
+                },
+                path,
+                format!("entry {entry:?} becomes empty after trimming"),
+            ));
+            continue;
+        }
+
+        if trimmed != entry {
+            warnings.push(AdvisoryWarning::new(
+                if path.ends_with("allow") {
+                    "orchestrator.agents.allow.trimmed_entry"
+                } else {
+                    "orchestrator.agents.deny.trimmed_entry"
+                },
+                path,
+                format!(
+                    "entry {entry:?} has surrounding whitespace; effective value is {trimmed:?}"
+                ),
+            ));
+        }
+
+        if !seen.insert(trimmed.to_string()) {
+            duplicates.insert(trimmed.to_string());
+        }
+    }
+
+    if !duplicates.is_empty() {
+        let duplicates = duplicates.into_iter().collect::<Vec<_>>().join(", ");
+        warnings.push(AdvisoryWarning::new(
+            if path.ends_with("allow") {
+                "orchestrator.agents.allow.duplicate"
+            } else {
+                "orchestrator.agents.deny.duplicate"
+            },
+            path,
+            format!("duplicate agent entries after trimming: {duplicates}"),
+        ));
+    }
+}
+
+fn validate_agent_overlap(cfg: &AgenticConfig, warnings: &mut Vec<AdvisoryWarning>) {
+    let allow = cfg
+        .orchestrator
+        .agents
+        .allow
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    let deny = cfg
+        .orchestrator
+        .agents
+        .deny
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+
+    let overlap = allow.intersection(&deny).cloned().collect::<Vec<_>>();
+    if overlap.is_empty() {
+        return;
+    }
+
+    warnings.push(AdvisoryWarning::new(
+        "orchestrator.agents.overlap",
+        "orchestrator.agents",
+        format!(
+            "agents appear in both allow and deny: {}. deny wins at runtime",
             overlap.join(", ")
         ),
     ));
@@ -700,6 +803,68 @@ mod tests {
 
         assert_eq!(warning.path, "orchestrator.commands");
         assert!(warning.message.contains("plan"));
+        assert!(warning.message.contains("deny wins at runtime"));
+    }
+
+    #[test]
+    fn test_orchestrator_agents_allow_empty_entry_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.agents.allow = vec!["   ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.agents.allow.empty_entry")
+            .expect("empty allow warning expected");
+
+        assert_eq!(warning.path, "orchestrator.agents.allow");
+        assert!(warning.message.contains("becomes empty after trimming"));
+    }
+
+    #[test]
+    fn test_orchestrator_agents_deny_trimmed_entry_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.agents.deny = vec!["  Bash  ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.agents.deny.trimmed_entry")
+            .expect("trimmed deny warning expected");
+
+        assert_eq!(warning.path, "orchestrator.agents.deny");
+        assert!(warning.message.contains("effective value is \"Bash\""));
+    }
+
+    #[test]
+    fn test_orchestrator_agents_allow_duplicate_warns() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.agents.allow = vec!["Bash".into(), " Bash ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.agents.allow.duplicate")
+            .expect("duplicate allow warning expected");
+
+        assert_eq!(warning.path, "orchestrator.agents.allow");
+        assert!(warning.message.contains("Bash"));
+    }
+
+    #[test]
+    fn test_orchestrator_agent_overlap_warns_with_deny_wins_message() {
+        let mut config = AgenticConfig::default();
+        config.orchestrator.agents.allow = vec!["Bash".into()];
+        config.orchestrator.agents.deny = vec![" Bash ".into()];
+
+        let warnings = validate(&config);
+        let warning = warnings
+            .iter()
+            .find(|w| w.code == "orchestrator.agents.overlap")
+            .expect("overlap warning expected");
+
+        assert_eq!(warning.path, "orchestrator.agents");
+        assert!(warning.message.contains("Bash"));
         assert!(warning.message.contains("deny wins at runtime"));
     }
 


### PR DESCRIPTION
Implements ENG-715 scoped support for orchestrator agent discovery, raw-prompt agent selection, and mirrored agent allow/deny policy. A generated PR description will be added after creation.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-715 needed orchestrator-side agent discovery and explicit raw-prompt agent selection without changing existing command-frontmatter behavior.

Before this change:
- `opencode-orchestrator-mcp` exposed command discovery, but not agent discovery.
- `orchestrator_run` could not accept an explicit agent even though the underlying prompt request already supported one.
- There was no orchestrator-level allow/deny policy for explicit agent listing or selection.
- Hidden upstream agents could have been exposed if a listing surface was added naively.
- `command + agent` would have been ambiguous because upstream commands can remain hard-bound by frontmatter.

## What user-facing changes did I ship?

- Added `orchestrator_list_agents` so callers can discover visible OpenCode agents separately from commands.
- Added optional `agent` support on `orchestrator_run` for raw prompt requests.
- Rejected `orchestrator_run(command=..., agent=...)` as invalid input to avoid misleading semantics.
- Added mirrored `[orchestrator.agents] allow/deny` policy with the same semantics as `[orchestrator.commands]`:
  - exact case-sensitive matching
  - whitespace trimming of configured entries
  - empty allowlist means unrestricted
  - deny wins over allow
- Filtered hidden agents out of `orchestrator_list_agents` before applying policy filtering.
- Updated example config and tool descriptions to document the new behavior.

## How I implemented it

- Extended `agentic-config` to model `[orchestrator.agents]` and added schema and advisory validation coverage for duplicates, whitespace, empty entries, and allow/deny overlap.
- Added runtime `AgentPolicyDecision`, `agent_policy_decision()`, and `is_agent_allowed()` helpers in the orchestrator server alongside the existing command policy logic.
- Extended `OrchestratorRunInput` with `agent: Option<String>` and added `ListAgentsInput`, `AgentInfo`, and `ListAgentsOutput` plus text formatting.
- Implemented `ListAgentsTool` backed by `GET /agent` / `tools().agents()`.
- Updated `OrchestratorRunTool` to:
  - reject `command + agent` during input validation
  - validate and policy-check raw-prompt agent selection early
  - forward the selected agent only on the raw prompt path
- Kept command execution semantics unchanged so command-frontmatter agent bindings still behave as before.
- Added and updated wiremock coverage for:
  - visible agent listing
  - hidden-agent suppression
  - allow/deny filtering
  - blocked raw-prompt agent selection before dispatch
  - prompt body forwarding of `agent`
  - invalid `command + agent`
  - `OrchestratorRunInput` struct literal updates across existing tests

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification run during implementation:
- `just crate-check agentic-config`
- `just crate-test agentic-config`
- `just crate-check opencode-orchestrator-mcp`
- `just crate-test opencode-orchestrator-mcp`
- `just check`
- `just test`

Manual spot checks not run in this workflow:
- `orchestrator_list_agents` against a live OpenCode server to confirm expected visible agents
- `orchestrator_run(message=..., agent=...)` against a live visible allowed agent
- live confirmation that `[orchestrator.agents] deny` removes an agent from listing and blocks raw-prompt selection

## Description for the changelog

Add orchestrator agent discovery, raw-prompt agent selection, and mirrored agent allow/deny filtering.
<!-- END:describe_pr:autogen -->
