### PR TITLE
feat(opencode): upgrade OpenCode SDK and orchestrator to v1.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,6 +4366,7 @@ version = "0.11.2"
 dependencies = [
  "anyhow",
  "backon",
+ "base64",
  "chrono",
  "futures",
  "http",

--- a/apps/opencode-orchestrator-mcp/README.md
+++ b/apps/opencode-orchestrator-mcp/README.md
@@ -16,7 +16,7 @@ just build
 
 Integration tests are `#[ignore]` by default and require a working `opencode` binary plus local provider configuration.
 
-Use the pinned v1.15.7 bunx lane for live integration validation:
+Use the pinned v1.17.2 bunx lane for live integration validation:
 
 ```bash
 just smoke-bunx-stable-version

--- a/apps/opencode-orchestrator-mcp/justfile
+++ b/apps/opencode-orchestrator-mcp/justfile
@@ -37,19 +37,19 @@ integration-test-permissions-debug:
         permission
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Stable v1.15.7 lane (bunx launcher mode, non-interactive)
+# Stable v1.17.2 lane (bunx launcher mode, non-interactive)
 # Uses --yes to skip bunx confirmation prompts for CI/automated contexts
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Full integration tests using bunx opencode-ai@1.15.7 (requires bun installed)
+# Full integration tests using bunx opencode-ai@1.17.2 (requires bun installed)
 # Ignored by default; run manually to validate stable version compatibility
 [no-exit-message]
 integration-test-bunx-stable:
-    @echo "Running integration tests with bunx --yes opencode-ai@1.15.7..."
+    @echo "Running integration tests with bunx --yes opencode-ai@1.17.2..."
     @echo "Requires: bun installed and available in PATH"
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration -- --ignored --nocapture --test-threads=1
 
@@ -58,11 +58,11 @@ integration-test-bunx-stable:
 # Note: Explicitly disables recursion guard to allow running from within orchestrator contexts
 [no-exit-message]
 smoke-bunx-stable-version:
-    @echo "Smoke test: starting managed server via bunx --yes opencode-ai@1.15.7 and validating exact version..."
+    @echo "Smoke test: starting managed server via bunx --yes opencode-ai@1.17.2 and validating exact version..."
     @echo "Requires: bun installed and available in PATH"
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration live_managed_server_reports_exact_pinned_version -- --ignored --nocapture --test-threads=1
 
@@ -71,7 +71,7 @@ integration-test-bunx-stable-verbose:
     RUST_LOG=debug,opencode_orchestrator_mcp=trace,opencode_rs=debug \
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration -- --ignored --nocapture --test-threads=1
 
@@ -82,8 +82,8 @@ integration-test-one-bunx-stable TEST="managed_server_rebuilds_after_forced_stop
     set -euxo pipefail
     : "${OPENCODE_ORCHESTRATOR_INTEGRATION:=1}"
     : "${OPENCODE_BINARY:=bunx}"
-    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.15.7}"
-    bunx --yes opencode-ai@1.15.7 --version
+    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.17.2}"
+    bunx --yes opencode-ai@1.17.2 --version
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY="$OPENCODE_BINARY" \
     OPENCODE_BINARY_ARGS="$OPENCODE_BINARY_ARGS" \

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -7,6 +7,8 @@ use anyhow::Context;
 use opencode_rs::Client;
 use opencode_rs::server::ManagedServer;
 use opencode_rs::server::ServerOptions;
+use opencode_rs::types::message::Message as LegacyMessage;
+use opencode_rs::types::message::Part as LegacyPart;
 use opencode_rs::types::v2::envelope::LocationEnvelope;
 use opencode_rs::types::v2::message::Message as MessageV2;
 use opencode_rs::types::v2::model::ModelInfo;
@@ -683,6 +685,7 @@ impl OrchestratorServer {
         let opts = ServerOptions::default()
             .binary(&launcher_config.binary)
             .launcher_args(launcher_config.launcher_args)
+            .startup_timeout_ms(30_000)
             .directory(cwd.clone());
 
         let managed = ManagedServer::start(opts)
@@ -764,6 +767,7 @@ impl OrchestratorServer {
         let mut opts = ServerOptions::default()
             .binary(&launcher_config.binary)
             .launcher_args(launcher_config.launcher_args)
+            .startup_timeout_ms(30_000)
             .directory(cwd.clone());
 
         // Inject config if provided
@@ -916,6 +920,26 @@ impl OrchestratorServer {
         }
 
         Ok(limits)
+    }
+
+    /// Extract text content from the last assistant message in legacy message lists.
+    pub fn extract_assistant_text_legacy(messages: &[LegacyMessage]) -> Option<String> {
+        let message = messages
+            .iter()
+            .rev()
+            .find(|message| message.info.role == "assistant")?;
+
+        let text = message
+            .parts
+            .iter()
+            .filter_map(|part| match part {
+                LegacyPart::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        (!text.is_empty()).then_some(text)
     }
 
     /// Extract text content from the last assistant message in v1.17.2 context messages.

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -7,9 +7,9 @@ use anyhow::Context;
 use opencode_rs::Client;
 use opencode_rs::server::ManagedServer;
 use opencode_rs::server::ServerOptions;
-use opencode_rs::types::message::Message;
-use opencode_rs::types::message::Part;
-use opencode_rs::types::provider::ProviderListResponse;
+use opencode_rs::types::v2::envelope::LocationEnvelope;
+use opencode_rs::types::v2::message::Message as MessageV2;
+use opencode_rs::types::v2::model::ModelInfo;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -523,7 +523,7 @@ pub struct OrchestratorServer {
     managed_server: StdMutex<Option<ManagedServer>>,
     /// HTTP client for `OpenCode` API
     client: Client,
-    /// Cached model context limits from GET /provider
+    /// Cached model context limits from `GET /api/model`
     model_context_limits: HashMap<ModelKey, u64>,
     /// Base URL of the managed server
     base_url: String,
@@ -698,9 +698,11 @@ impl OrchestratorServer {
             .build()
             .context("Failed to build opencode-rs HTTP client")?;
 
+        // LEGACY_EXCEPTION(OpenCode v1.17.2): startup-only `/global/health` is still required
+        // for exact version validation because `/api/health` does not expose version.
         let health = client
-            .misc()
-            .health()
+            .legacy()
+            .global_health()
             .await
             .context("Failed to fetch /global/health for version validation")?;
 
@@ -782,9 +784,11 @@ impl OrchestratorServer {
             .build()
             .context("Failed to build opencode-rs HTTP client")?;
 
+        // LEGACY_EXCEPTION(OpenCode v1.17.2): startup-only `/global/health` is still required
+        // for exact version validation because `/api/health` does not expose version.
         let health = client
-            .misc()
-            .health()
+            .legacy()
+            .global_health()
             .await
             .context("Failed to fetch /global/health for version validation")?;
 
@@ -886,60 +890,41 @@ impl OrchestratorServer {
             }
         }
 
-        match tokio::time::timeout(health_probe_timeout, self.client.misc().health()).await {
+        match tokio::time::timeout(health_probe_timeout, self.client.api().health().get()).await {
             Ok(Ok(health)) if health.healthy => Ok(ServerEntryState::Healthy),
             Ok(Ok(_health)) => Ok(ServerEntryState::NeedsRecovery {
-                reason: "/global/health reported unhealthy".to_string(),
+                reason: "/api/health reported unhealthy".to_string(),
             }),
             Ok(Err(error)) => Ok(ServerEntryState::NeedsRecovery {
-                reason: format!("/global/health probe failed: {error}"),
+                reason: format!("/api/health probe failed: {error}"),
             }),
             Err(_elapsed) => Ok(ServerEntryState::NeedsRecovery {
-                reason: format!("/global/health probe timed out after {health_probe_timeout:?}"),
+                reason: format!("/api/health probe timed out after {health_probe_timeout:?}"),
             }),
         }
     }
 
-    /// Load model context limits from GET /provider.
+    /// Load model context limits from `GET /api/model`.
     async fn load_model_limits(client: &Client) -> anyhow::Result<HashMap<ModelKey, u64>> {
-        let resp: ProviderListResponse = client.providers().list().await?;
+        let resp: LocationEnvelope<Vec<ModelInfo>> = client.api().model().list().await?;
         let mut limits = HashMap::new();
 
-        for provider in resp.all {
-            for (model_id, model) in provider.models {
-                if let Some(limit) = model.limit.as_ref().and_then(|l| l.context) {
-                    limits.insert((provider.id.clone(), model_id), limit);
-                }
+        for model in resp.data {
+            if let Some(limit) = model.limit.as_ref().and_then(|l| l.context) {
+                limits.insert((model.provider_id.clone(), model.id.clone()), limit);
             }
         }
 
         Ok(limits)
     }
 
-    /// Extract text content from the last assistant message.
-    pub fn extract_assistant_text(messages: &[Message]) -> Option<String> {
-        // Find the last assistant message
-        let assistant_msg = messages.iter().rev().find(|m| m.info.role == "assistant")?;
-
-        // Join all text parts
-        let text: String = assistant_msg
-            .parts
+    /// Extract text content from the last assistant message in v1.17.2 context messages.
+    pub fn extract_assistant_text_v2(messages: &[MessageV2]) -> Option<String> {
+        messages
             .iter()
-            .filter_map(|p| {
-                if let Part::Text { text, .. } = p {
-                    Some(text.as_str())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("");
-
-        if text.trim().is_empty() {
-            None
-        } else {
-            Some(text)
-        }
+            .rev()
+            .find(|message| message.role == "assistant")
+            .and_then(opencode_rs::types::v2::message::Message::assistant_text)
     }
 }
 
@@ -1101,10 +1086,9 @@ mod tests {
     async fn health_mock_server() -> MockServer {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/global/health"))
+            .and(path("/api/health"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "healthy": true,
-                "version": version::PINNED_OPENCODE_VERSION,
             })))
             .mount(&mock)
             .await;
@@ -1504,8 +1488,8 @@ mod tests {
         assert!(
             requests
                 .iter()
-                .any(|request| request.url.path() == "/global/health"),
-            "expected /global/health request"
+                .any(|request| request.url.path() == "/api/health"),
+            "expected /api/health request"
         );
     }
 
@@ -1513,13 +1497,12 @@ mod tests {
     async fn validate_for_tool_entry_times_out_health_probe() {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/global/health"))
+            .and(path("/api/health"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_delay(Duration::from_secs(30))
                     .set_body_json(serde_json::json!({
                         "healthy": true,
-                        "version": version::PINNED_OPENCODE_VERSION,
                     })),
             )
             .mount(&mock)
@@ -1534,9 +1517,51 @@ mod tests {
         assert_eq!(
             state,
             ServerEntryState::NeedsRecovery {
-                reason: "/global/health probe timed out after 25ms".to_string(),
+                reason: "/api/health probe timed out after 25ms".to_string(),
             }
         );
+    }
+
+    #[tokio::test]
+    async fn load_model_limits_uses_api_model() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/model"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "location": {"directory": "/tmp/project"},
+                "data": [
+                    {
+                        "id": "claude-sonnet-4",
+                        "providerID": "anthropic",
+                        "limit": {"context": 200_000}
+                    },
+                    {
+                        "id": "gpt-4.1",
+                        "providerID": "openai",
+                        "limit": {"context": 128_000}
+                    },
+                    {
+                        "id": "no-limit",
+                        "providerID": "test"
+                    }
+                ]
+            })))
+            .mount(&mock)
+            .await;
+
+        let limits = OrchestratorServer::load_model_limits(&test_client(&mock.uri()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            limits.get(&("anthropic".to_string(), "claude-sonnet-4".to_string())),
+            Some(&200_000)
+        );
+        assert_eq!(
+            limits.get(&("openai".to_string(), "gpt-4.1".to_string())),
+            Some(&128_000)
+        );
+        assert!(!limits.contains_key(&("test".to_string(), "no-limit".to_string())));
     }
 
     #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/src/token_tracker.rs
+++ b/apps/opencode-orchestrator-mcp/src/token_tracker.rs
@@ -3,9 +3,14 @@
 //! Monitors token usage during session runs and detects when the 80% threshold
 //! is reached to trigger server-side summarization.
 
+#[cfg(test)]
 use opencode_rs::types::event::Event;
+#[cfg(test)]
 use opencode_rs::types::message::Part;
 use opencode_rs::types::message::TokenUsage;
+use opencode_rs::types::v2::message::ContentPart as ContentPartV2;
+use opencode_rs::types::v2::message::Message as MessageV2;
+use opencode_rs::types::v2::message::TokenUsage as TokenUsageV2;
 
 fn sat_u32(value: u64) -> (u32, bool) {
     if value > u64::from(u32::MAX) {
@@ -66,6 +71,7 @@ impl TokenTracker {
     ///
     /// The `context_limit_lookup` function is called to look up the context limit
     /// for a given (`provider_id`, `model_id`) pair from the cached limits.
+    #[cfg(test)]
     pub fn observe_event<F>(&mut self, ev: &Event, context_limit_lookup: F)
     where
         F: Fn(&str, &str) -> Option<u64>,
@@ -106,9 +112,59 @@ impl TokenTracker {
     }
 
     /// Observe token usage and update threshold flag.
+    #[cfg(test)]
     pub fn observe_tokens(&mut self, tokens: &TokenUsage) {
         self.latest_input_tokens = Some(tokens.input);
         self.latest_tokens = Some(tokens.clone());
+        self.recompute_flag();
+    }
+
+    pub fn observe_context<F>(&mut self, messages: &[MessageV2], context_limit_lookup: F)
+    where
+        F: Fn(&str, &str) -> Option<u64>,
+    {
+        let Some(message) = messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "assistant")
+        else {
+            return;
+        };
+
+        if let Some(model) = &message.model
+            && let (Some(provider_id), Some(model_id)) = (&model.provider_id, &model.model_id)
+        {
+            self.provider_id = Some(provider_id.clone());
+            self.model_id = Some(model_id.clone());
+            self.context_limit = context_limit_lookup(provider_id, model_id);
+        }
+
+        if let Some(tokens) = &message.tokens {
+            self.observe_tokens_v2(tokens);
+            return;
+        }
+
+        if let Some(tokens) = message.content.iter().rev().find_map(|part| match part {
+            ContentPartV2::StepFinish {
+                tokens: Some(tokens),
+                ..
+            } => Some(tokens),
+            _ => None,
+        }) {
+            self.observe_tokens_v2(tokens);
+        }
+    }
+
+    fn observe_tokens_v2(&mut self, tokens: &TokenUsageV2) {
+        self.latest_input_tokens = Some(tokens.input);
+        self.latest_tokens = Some(TokenUsage {
+            total: tokens.total,
+            input: tokens.input,
+            output: tokens.output,
+            reasoning: tokens.reasoning,
+            cache: None,
+            extra: tokens.extra.clone(),
+        });
         self.recompute_flag();
     }
 

--- a/apps/opencode-orchestrator-mcp/src/token_tracker.rs
+++ b/apps/opencode-orchestrator-mcp/src/token_tracker.rs
@@ -5,12 +5,9 @@
 
 #[cfg(test)]
 use opencode_rs::types::event::Event;
-#[cfg(test)]
+use opencode_rs::types::message::Message as LegacyMessage;
 use opencode_rs::types::message::Part;
 use opencode_rs::types::message::TokenUsage;
-use opencode_rs::types::v2::message::ContentPart as ContentPartV2;
-use opencode_rs::types::v2::message::Message as MessageV2;
-use opencode_rs::types::v2::message::TokenUsage as TokenUsageV2;
 
 fn sat_u32(value: u64) -> (u32, bool) {
     if value > u64::from(u32::MAX) {
@@ -112,60 +109,49 @@ impl TokenTracker {
     }
 
     /// Observe token usage and update threshold flag.
-    #[cfg(test)]
     pub fn observe_tokens(&mut self, tokens: &TokenUsage) {
         self.latest_input_tokens = Some(tokens.input);
         self.latest_tokens = Some(tokens.clone());
         self.recompute_flag();
     }
 
-    pub fn observe_context<F>(&mut self, messages: &[MessageV2], context_limit_lookup: F)
-    where
+    pub fn observe_legacy_messages<F>(
+        &mut self,
+        messages: &[LegacyMessage],
+        context_limit_lookup: F,
+    ) where
         F: Fn(&str, &str) -> Option<u64>,
     {
         let Some(message) = messages
             .iter()
             .rev()
-            .find(|message| message.role == "assistant")
+            .find(|message| message.info.role == "assistant")
         else {
             return;
         };
 
-        if let Some(model) = &message.model
-            && let (Some(provider_id), Some(model_id)) = (&model.provider_id, &model.model_id)
+        if let (Some(provider_id), Some(model_id)) =
+            (&message.info.provider_id, &message.info.model_id)
         {
             self.provider_id = Some(provider_id.clone());
             self.model_id = Some(model_id.clone());
             self.context_limit = context_limit_lookup(provider_id, model_id);
         }
 
-        if let Some(tokens) = &message.tokens {
-            self.observe_tokens_v2(tokens);
+        if let Some(tokens) = &message.info.tokens {
+            self.observe_tokens(tokens);
             return;
         }
 
-        if let Some(tokens) = message.content.iter().rev().find_map(|part| match part {
-            ContentPartV2::StepFinish {
+        if let Some(tokens) = message.parts.iter().rev().find_map(|part| match part {
+            Part::StepFinish {
                 tokens: Some(tokens),
                 ..
             } => Some(tokens),
             _ => None,
         }) {
-            self.observe_tokens_v2(tokens);
+            self.observe_tokens(tokens);
         }
-    }
-
-    fn observe_tokens_v2(&mut self, tokens: &TokenUsageV2) {
-        self.latest_input_tokens = Some(tokens.input);
-        self.latest_tokens = Some(TokenUsage {
-            total: tokens.total,
-            input: tokens.input,
-            output: tokens.output,
-            reasoning: tokens.reasoning,
-            cache: None,
-            extra: tokens.extra.clone(),
-        });
-        self.recompute_flag();
     }
 
     pub fn to_log_token_usage(&self) -> (Option<agentic_logging::TokenUsage>, bool) {

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -43,8 +43,13 @@ use agentic_tools_core::fmt::TextFormat;
 use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
 use opencode_rs::types::message::CommandRequest;
+use opencode_rs::types::message::PromptPart;
+use opencode_rs::types::message::PromptRequest;
+use opencode_rs::types::permission::PermissionReply as LegacyPermissionReply;
+use opencode_rs::types::permission::PermissionReplyRequest as LegacyPermissionReplyRequest;
+use opencode_rs::types::permission::PermissionRequest as LegacyPermissionRequest;
 use opencode_rs::types::session::CreateSessionRequest;
-use opencode_rs::types::v2::DataEnvelope;
+use opencode_rs::types::session::SessionStatusInfo;
 use opencode_rs::types::v2::LocationEnvelope;
 use opencode_rs::types::v2::LocationInfo;
 use opencode_rs::types::v2::message::ContentPart as ContentPartV2;
@@ -55,8 +60,6 @@ use opencode_rs::types::v2::permission::PermissionReplyRequest as PermissionRepl
 use opencode_rs::types::v2::permission::PermissionRequest as PermissionRequestV2;
 use opencode_rs::types::v2::question::QuestionReply as QuestionReplyV2;
 use opencode_rs::types::v2::question::QuestionRequest as QuestionRequestV2;
-use opencode_rs::types::v2::session::PromptInput as PromptInputV2;
-use opencode_rs::types::v2::session::PromptRequest as PromptRequestV2;
 use opencode_rs::types::v2::session::SessionInfo as SessionInfoV2;
 use opencode_rs::types::v2::session::SessionListQuery;
 use serde::Serialize;
@@ -81,6 +84,21 @@ struct RunOutcome {
 enum PermissionPreflightMode {
     Strict,
     RespondPermissionContinuation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PermissionApiSource {
+    V2,
+    Legacy,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPermissionInfo {
+    id: String,
+    session_id: String,
+    action: String,
+    resources: Vec<String>,
+    source: PermissionApiSource,
 }
 
 fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
@@ -145,11 +163,35 @@ async fn wait_probe_idle(
 ) -> Result<bool, ToolError> {
     match tokio::time::timeout(timeout, client.api().session().wait(session_id)).await {
         Ok(Ok(())) => Ok(true),
+        // LEGACY_EXCEPTION(OpenCode v1.17.2): `/api/session/:id/wait` is implemented
+        // upstream but currently returns a fixed 503 "Session wait is not available yet".
+        Ok(Err(error)) if matches!(&error, opencode_rs::OpencodeError::Http { status: 503, message, .. } if message == "Session wait is not available yet") => {
+            match tokio::time::timeout(timeout, client.sessions().status_for(session_id)).await {
+                Ok(Ok(SessionStatusInfo::Idle)) => Ok(true),
+                Ok(Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. })) => Ok(false),
+                Ok(Err(error)) => Err(ToolError::Internal(format!(
+                    "Failed to fetch session status after wait fallback: {error}"
+                ))),
+                Err(_elapsed) => Ok(false),
+            }
+        }
         Ok(Err(error)) => Err(ToolError::Internal(format!(
             "Failed to wait for session: {error}"
         ))),
         Err(_elapsed) => Ok(false),
     }
+}
+
+fn is_premature_idle_completion(
+    output: &OrchestratorRunOutput,
+    partial_response: &str,
+    dispatched_new_work: bool,
+    observed_busy: bool,
+) -> bool {
+    dispatched_new_work
+        && !observed_busy
+        && output.response.is_none()
+        && partial_response.is_empty()
 }
 
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
@@ -246,7 +288,7 @@ impl OrchestratorRunTool {
     /// This is called when we detect the session is idle, either via SSE `SessionIdle` event
     /// or via polling `sessions().status()`.
     ///
-    /// Uses bounded retry with backoff (0/50/100/200/400ms) if assistant text is not immediately
+    /// Can optionally use bounded retry with backoff when assistant text is not immediately
     /// available, handling the race condition where the session becomes idle before messages
     /// are fully persisted.
     async fn finalize_completed(
@@ -255,31 +297,50 @@ impl OrchestratorRunTool {
         token_tracker: &mut TokenTracker,
         server: &OrchestratorServer,
         mut warnings: Vec<String>,
+        retry_for_response: bool,
     ) -> Result<OrchestratorRunOutput, ToolError> {
-        // Bounded backoff delays for message extraction retry (~750ms total budget)
-        const BACKOFFS_MS: &[u64] = &[0, 50, 100, 200, 400];
+        // Bounded backoff delays for message extraction retry (~7.85s total budget)
+        const RESPONSE_BACKOFFS_MS: &[u64] = &[0, 100, 250, 500, 1000, 2000, 4000];
+        const SINGLE_ATTEMPT_MS: &[u64] = &[0];
+        let backoffs_ms = if retry_for_response {
+            RESPONSE_BACKOFFS_MS
+        } else {
+            SINGLE_ATTEMPT_MS
+        };
 
         let mut response: Option<String> = None;
 
-        for (attempt, &delay_ms) in BACKOFFS_MS.iter().enumerate() {
+        for (attempt, &delay_ms) in backoffs_ms.iter().enumerate() {
             if delay_ms > 0 {
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
             }
 
-            let context = client
-                .api()
-                .session()
-                .context(&session_id)
-                .await
-                .map_err(|e| {
-                    ToolError::Internal(format!("Failed to fetch session context: {e}"))
-                })?;
+            match client.messages().list(&session_id).await {
+                Ok(messages) => {
+                    token_tracker.observe_legacy_messages(&messages, |provider_id, model_id| {
+                        server.context_limit(provider_id, model_id)
+                    });
 
-            token_tracker.observe_context(&context.data, |provider_id, model_id| {
-                server.context_limit(provider_id, model_id)
-            });
-
-            response = OrchestratorServer::extract_assistant_text_v2(&context.data);
+                    response = OrchestratorServer::extract_assistant_text_legacy(&messages);
+                }
+                Err(error) if error.is_not_found() => {
+                    let context =
+                        client
+                            .api()
+                            .session()
+                            .context(&session_id)
+                            .await
+                            .map_err(|e| {
+                                ToolError::Internal(format!("Failed to fetch session context: {e}"))
+                            })?;
+                    response = OrchestratorServer::extract_assistant_text_v2(&context.data);
+                }
+                Err(error) => {
+                    return Err(ToolError::Internal(format!(
+                        "Failed to fetch session messages: {error}"
+                    )));
+                }
+            }
 
             if response.is_some() {
                 if attempt > 0 {
@@ -368,14 +429,59 @@ impl OrchestratorRunTool {
         }
     }
 
+    fn map_v2_permission(permission: PermissionRequestV2) -> PendingPermissionInfo {
+        PendingPermissionInfo {
+            id: permission.id,
+            session_id: permission.session_id,
+            action: permission.action,
+            resources: permission.resources,
+            source: PermissionApiSource::V2,
+        }
+    }
+
+    fn map_legacy_permission(permission: LegacyPermissionRequest) -> PendingPermissionInfo {
+        PendingPermissionInfo {
+            id: permission.id,
+            session_id: permission.session_id,
+            action: permission.permission,
+            resources: permission.patterns,
+            source: PermissionApiSource::Legacy,
+        }
+    }
+
+    async fn list_pending_permissions_for_session(
+        client: &opencode_rs::Client,
+        session_id: &str,
+    ) -> Result<Vec<PendingPermissionInfo>, opencode_rs::OpencodeError> {
+        let pending_v2 = client.api().permission().list_session(session_id).await?;
+        if !pending_v2.data.is_empty() {
+            return Ok(pending_v2
+                .data
+                .into_iter()
+                .map(Self::map_v2_permission)
+                .collect());
+        }
+
+        let pending_legacy = match client.permissions().list().await {
+            Ok(pending_legacy) => pending_legacy,
+            Err(error) if error.is_not_found() => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+        Ok(pending_legacy
+            .into_iter()
+            .filter(|permission| permission.session_id == session_id)
+            .map(Self::map_legacy_permission)
+            .collect())
+    }
+
     async fn preflight_pending_permission(
         client: &opencode_rs::Client,
         session_id: &str,
         mode: PermissionPreflightMode,
         warnings: &mut Vec<String>,
-    ) -> Result<Option<PermissionRequestV2>, ToolError> {
-        match client.api().permission().list_session(session_id).await {
-            Ok(pending_permissions) => Ok(pending_permissions.data.into_iter().next()),
+    ) -> Result<Option<PendingPermissionInfo>, ToolError> {
+        match Self::list_pending_permissions_for_session(client, session_id).await {
+            Ok(pending_permissions) => Ok(pending_permissions.into_iter().next()),
             Err(error)
                 if matches!(mode, PermissionPreflightMode::RespondPermissionContinuation)
                     && error.is_validation_error() =>
@@ -527,6 +633,7 @@ impl OrchestratorRunTool {
             tracing::info!(
                 session_id = %session_id,
                 permission_type = %perm.action,
+                permission_source = ?perm.source,
                 "run: pending permission found"
             );
             return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
@@ -566,9 +673,15 @@ impl OrchestratorRunTool {
         if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
             let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
             let mut token_tracker = token_tracker;
-            let output =
-                Self::finalize_completed(client, session_id, &mut token_tracker, &server, vec![])
-                    .await?;
+            let output = Self::finalize_completed(
+                client,
+                session_id,
+                &mut token_tracker,
+                &server,
+                vec![],
+                false,
+            )
+            .await?;
             return Ok(RunOutcome::with_tracker(output, &token_tracker));
         }
 
@@ -618,21 +731,26 @@ impl OrchestratorRunTool {
                     .map_err(|e| e.to_string())
             }));
         } else if let Some(msg) = &message {
-            let req = PromptRequestV2 {
-                id: None,
-                prompt: PromptInputV2 {
+            let req = PromptRequest {
+                parts: vec![PromptPart::Text {
                     text: msg.clone(),
-                    files: Vec::new(),
-                    agents: agent.clone().into_iter().collect(),
-                },
-                delivery: None,
-                resume: None,
+                    synthetic: None,
+                    ignored: None,
+                    metadata: None,
+                }],
+                message_id: None,
+                model: None,
+                agent: agent.clone(),
+                no_reply: None,
+                system: None,
+                variant: None,
             };
 
+            // LEGACY_EXCEPTION(OpenCode v1.17.2): `/api/session/:id/prompt` admits input
+            // but legacy `/session/:id/prompt_async` is the proven executable prompt path.
             client
-                .api()
-                .session()
-                .prompt(&session_id, &req)
+                .messages()
+                .prompt_async(&session_id, &req)
                 .await
                 .map_err(|e| ToolError::Internal(format!("Failed to send prompt: {e}")))?;
 
@@ -674,9 +792,15 @@ impl OrchestratorRunTool {
                 session_id = %session_id,
                 "session already idle on post-subscribe check"
             );
-            let output =
-                Self::finalize_completed(client, session_id, &mut token_tracker, &server, warnings)
-                    .await?;
+            let output = Self::finalize_completed(
+                client,
+                session_id,
+                &mut token_tracker,
+                &server,
+                warnings,
+                false,
+            )
+            .await?;
             return Ok(RunOutcome::with_tracker(output, &token_tracker));
         }
         // If check fails or session is busy, continue to event loop
@@ -737,6 +861,7 @@ impl OrchestratorRunTool {
                             &mut token_tracker,
                             &server,
                             warnings,
+                            dispatched_new_work,
                         )
                         .await?;
                         return Ok(RunOutcome::with_tracker(output, &token_tracker));
@@ -749,8 +874,8 @@ impl OrchestratorRunTool {
 
                 _ = poll_interval.tick() => {
                     // === 1. Permission fallback (check first, permissions take priority) ===
-                    let pending = match client.api().permission().list_session(&session_id).await {
-                        Ok(p) => p,
+                    let pending = match Self::list_pending_permissions_for_session(client, &session_id).await {
+                        Ok(pending) => pending,
                         Err(e) => {
                             // Log but continue - permission list failure shouldn't block completion detection
                             tracing::warn!(
@@ -758,16 +883,15 @@ impl OrchestratorRunTool {
                                 error = %e,
                                 "failed to list permissions during poll fallback"
                             );
-                            DataEnvelope {
-                                data: vec![],
-                            }
+                            vec![]
                         }
                     };
 
-                    if let Some(perm) = pending.data.into_iter().find(|p| p.session_id == session_id) {
+                    if let Some(perm) = pending.into_iter().find(|p| p.session_id == session_id) {
                         tracing::debug!(
                             session_id = %session_id,
                             permission_id = %perm.id,
+                            permission_source = ?perm.source,
                             "detected pending permission via polling fallback"
                         );
                         return Ok(RunOutcome::with_tracker(OrchestratorRunOutput {
@@ -856,6 +980,7 @@ impl OrchestratorRunTool {
                                     &mut token_tracker,
                                     &server,
                                     warnings,
+                                    dispatched_new_work,
                                 )
                                 .await?;
                                 return Ok(RunOutcome::with_tracker(output, &token_tracker));
@@ -879,12 +1004,25 @@ impl OrchestratorRunTool {
                                 );
                                 let output = Self::finalize_completed(
                                     client,
-                                    session_id,
+                                    session_id.clone(),
                                     &mut token_tracker,
                                     &server,
-                                    warnings,
+                                    warnings.clone(),
+                                    true,
                                 )
                                 .await?;
+                                if is_premature_idle_completion(
+                                    &output,
+                                    &partial_response,
+                                    dispatched_new_work,
+                                    observed_busy,
+                                ) {
+                                    tracing::debug!(
+                                        session_id = %session_id,
+                                        "idle-grace finalization produced no response yet; continuing to poll"
+                                    );
+                                    continue;
+                                }
                                 return Ok(RunOutcome::with_tracker(output, &token_tracker));
                             }
 
@@ -919,12 +1057,25 @@ impl OrchestratorRunTool {
                             tracing::debug!(session_id = %session_id, "idle-grace deadline reached; finalizing");
                             let output = Self::finalize_completed(
                                 client,
-                                session_id,
+                                session_id.clone(),
                                 &mut token_tracker,
                                 &server,
-                                warnings,
+                                warnings.clone(),
+                                true,
                             )
                             .await?;
+                            if is_premature_idle_completion(
+                                &output,
+                                &partial_response,
+                                dispatched_new_work,
+                                observed_busy,
+                            ) {
+                                tracing::debug!(
+                                    session_id = %session_id,
+                                    "idle-grace deadline finalization produced no response yet; continuing to poll"
+                                );
+                                continue;
+                            }
                             return Ok(RunOutcome::with_tracker(output, &token_tracker));
                         }
                         Ok(false) => {
@@ -1539,20 +1690,32 @@ Parameters:
                 let client = server.client();
                 let mut pre_warnings: Vec<String> = Vec::new();
 
-                let (permission_request_id, permission_type, permission_patterns) =
+                let (
+                    permission_request_id,
+                    permission_type,
+                    permission_patterns,
+                    permission_source,
+                ) =
                     if let Some(req_id) = input.permission_request_id.as_deref() {
-                        match client.api().permission().list_session(&input.session_id).await {
+                        match OrchestratorRunTool::list_pending_permissions_for_session(
+                            client,
+                            &input.session_id,
+                        )
+                        .await
+                        {
                             Ok(pending) => {
-                                let idx = pending.data.iter().position(|p| p.id == req_id).ok_or_else(|| {
-                                    ToolError::InvalidInput(format!(
-                                        "No pending permission found with id '{req_id}'. \
+                                let idx = pending
+                                    .iter()
+                                    .position(|p| p.id == req_id)
+                                    .ok_or_else(|| {
+                                        ToolError::InvalidInput(format!(
+                                            "No pending permission found with id '{req_id}'. \
                                      (session_id='{}')",
-                                        input.session_id
-                                    ))
-                                })?;
+                                            input.session_id
+                                        ))
+                                    })?;
 
                                 let perm = pending
-                                    .data
                                     .into_iter()
                                     .nth(idx)
                                     .ok_or_else(|| {
@@ -1568,7 +1731,7 @@ Parameters:
                                     )));
                                 }
 
-                                (perm.id, perm.action, perm.resources)
+                                (perm.id, perm.action, perm.resources, perm.source)
                             }
                             Err(error) if error.is_validation_error() => {
                                 tracing::warn!(
@@ -1580,7 +1743,12 @@ Parameters:
                                 pre_warnings.push(format!(
                                     "Permission validation failed for request '{req_id}' ({error}); submitting reply using the provided request id."
                                 ));
-                                (req_id.to_string(), "unknown".to_string(), Vec::new())
+                                (
+                                    req_id.to_string(),
+                                    "unknown".to_string(),
+                                    Vec::new(),
+                                    PermissionApiSource::V2,
+                                )
                             }
                             Err(error) => {
                                 return Err(ToolError::Internal(format!(
@@ -1590,11 +1758,14 @@ Parameters:
                         }
                     } else {
                         // Find the pending permission for this session when discovery is required.
-                        let pending = client.api().permission().list_session(&input.session_id).await.map_err(|e| {
-                            ToolError::Internal(format!("Failed to list permissions: {e}"))
-                        })?;
+                        let pending = OrchestratorRunTool::list_pending_permissions_for_session(
+                            client,
+                            &input.session_id,
+                        )
+                        .await
+                        .map_err(|e| ToolError::Internal(format!("Failed to list permissions: {e}")))?;
 
-                        let mut perms = pending.data;
+                        let mut perms = pending;
 
                         match perms.as_slice() {
                             [] => {
@@ -1606,7 +1777,7 @@ Parameters:
                             }
                             [_single] => {
                                 let perm = perms.swap_remove(0);
-                                (perm.id, perm.action, perm.resources)
+                                (perm.id, perm.action, perm.resources, perm.source)
                             }
                             multiple => {
                                 let ids = multiple
@@ -1629,10 +1800,19 @@ Parameters:
                 // Capture baseline assistant text BEFORE sending reject
                 // This lets us detect stale text after rejection
                 let baseline = if is_reject {
-                    match client.api().session().context(&input.session_id).await {
-                        Ok(msgs) => OrchestratorServer::extract_assistant_text_v2(&msgs.data),
+                    match client.messages().list(&input.session_id).await {
+                        Ok(messages) => OrchestratorServer::extract_assistant_text_legacy(&messages),
+                        Err(error) if error.is_not_found() => {
+                            match client.api().session().context(&input.session_id).await {
+                                Ok(context) => OrchestratorServer::extract_assistant_text_v2(&context.data),
+                                Err(e) => {
+                                    pre_warnings.push(format!("Failed to fetch baseline context: {e}"));
+                                    None
+                                }
+                            }
+                        }
                         Err(e) => {
-                            pre_warnings.push(format!("Failed to fetch baseline context: {e}"));
+                            pre_warnings.push(format!("Failed to fetch baseline messages: {e}"));
                             None
                         }
                     }
@@ -1647,22 +1827,47 @@ Parameters:
                     PermissionReply::Reject => ApiPermissionReplyV2::Reject,
                 };
 
+                let legacy_reply = match input.reply {
+                    PermissionReply::Once => LegacyPermissionReply::Once,
+                    PermissionReply::Always => LegacyPermissionReply::Always,
+                    PermissionReply::Reject => LegacyPermissionReply::Reject,
+                };
+
                 // Send the reply
-                client
-                    .api()
-                    .permission()
-                    .reply(
-                        &input.session_id,
-                        &permission_request_id,
-                        &PermissionReplyRequestV2 {
-                            reply: api_reply,
-                            message: input.message,
-                        },
-                    )
-                    .await
-                    .map_err(|e| {
-                        ToolError::Internal(format!("Failed to reply to permission: {e}"))
-                    })?;
+                match permission_source {
+                    PermissionApiSource::V2 => {
+                        client
+                            .api()
+                            .permission()
+                            .reply(
+                                &input.session_id,
+                                &permission_request_id,
+                                &PermissionReplyRequestV2 {
+                                    reply: api_reply,
+                                    message: input.message.clone(),
+                                },
+                            )
+                            .await
+                            .map_err(|e| {
+                                ToolError::Internal(format!("Failed to reply to permission: {e}"))
+                            })?;
+                    }
+                    PermissionApiSource::Legacy => {
+                        client
+                            .permissions()
+                            .reply(
+                                &permission_request_id,
+                                &LegacyPermissionReplyRequest {
+                                    reply: legacy_reply,
+                                    message: input.message.clone(),
+                                },
+                            )
+                            .await
+                            .map_err(|e| {
+                                ToolError::Internal(format!("Failed to reply to permission: {e}"))
+                            })?;
+                    }
+                }
 
                 // Now continue monitoring the session using run logic
                 let run_tool = OrchestratorRunTool::new(Arc::clone(&server_handle));

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -42,20 +42,23 @@ use agentic_tools_core::ToolRegistry;
 use agentic_tools_core::fmt::TextFormat;
 use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
-use opencode_rs::types::event::Event;
 use opencode_rs::types::message::CommandRequest;
-use opencode_rs::types::message::Message;
-use opencode_rs::types::message::Part;
-use opencode_rs::types::message::PromptPart;
-use opencode_rs::types::message::PromptRequest;
-use opencode_rs::types::message::ToolState;
-use opencode_rs::types::permission::PermissionReply as ApiPermissionReply;
-use opencode_rs::types::permission::PermissionReplyRequest;
-use opencode_rs::types::question::QuestionReply;
-use opencode_rs::types::question::QuestionRequest;
 use opencode_rs::types::session::CreateSessionRequest;
-use opencode_rs::types::session::SessionStatusInfo;
-use opencode_rs::types::session::SummarizeRequest;
+use opencode_rs::types::v2::DataEnvelope;
+use opencode_rs::types::v2::LocationEnvelope;
+use opencode_rs::types::v2::LocationInfo;
+use opencode_rs::types::v2::message::ContentPart as ContentPartV2;
+use opencode_rs::types::v2::message::Message as MessageV2;
+use opencode_rs::types::v2::message::ToolState as ToolStateV2;
+use opencode_rs::types::v2::permission::PermissionReply as ApiPermissionReplyV2;
+use opencode_rs::types::v2::permission::PermissionReplyRequest as PermissionReplyRequestV2;
+use opencode_rs::types::v2::permission::PermissionRequest as PermissionRequestV2;
+use opencode_rs::types::v2::question::QuestionReply as QuestionReplyV2;
+use opencode_rs::types::v2::question::QuestionRequest as QuestionRequestV2;
+use opencode_rs::types::v2::session::PromptInput as PromptInputV2;
+use opencode_rs::types::v2::session::PromptRequest as PromptRequestV2;
+use opencode_rs::types::v2::session::SessionInfo as SessionInfoV2;
+use opencode_rs::types::v2::session::SessionListQuery;
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -132,6 +135,20 @@ async fn abort_command_task(task: &mut Option<JoinHandle<Result<(), String>>>) {
     if let Some(handle) = task.take() {
         handle.abort();
         let _ = handle.await;
+    }
+}
+
+async fn wait_probe_idle(
+    client: &opencode_rs::Client,
+    session_id: &str,
+    timeout: Duration,
+) -> Result<bool, ToolError> {
+    match tokio::time::timeout(timeout, client.api().session().wait(session_id)).await {
+        Ok(Ok(())) => Ok(true),
+        Ok(Err(error)) => Err(ToolError::Internal(format!(
+            "Failed to wait for session: {error}"
+        ))),
+        Err(_elapsed) => Ok(false),
     }
 }
 
@@ -235,7 +252,8 @@ impl OrchestratorRunTool {
     async fn finalize_completed(
         client: &opencode_rs::Client,
         session_id: String,
-        token_tracker: &TokenTracker,
+        token_tracker: &mut TokenTracker,
+        server: &OrchestratorServer,
         mut warnings: Vec<String>,
     ) -> Result<OrchestratorRunOutput, ToolError> {
         // Bounded backoff delays for message extraction retry (~750ms total budget)
@@ -248,13 +266,20 @@ impl OrchestratorRunTool {
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
             }
 
-            let messages = client
-                .messages()
-                .list(&session_id)
+            let context = client
+                .api()
+                .session()
+                .context(&session_id)
                 .await
-                .map_err(|e| ToolError::Internal(format!("Failed to list messages: {e}")))?;
+                .map_err(|e| {
+                    ToolError::Internal(format!("Failed to fetch session context: {e}"))
+                })?;
 
-            response = OrchestratorServer::extract_assistant_text(&messages);
+            token_tracker.observe_context(&context.data, |provider_id, model_id| {
+                server.context_limit(provider_id, model_id)
+            });
+
+            response = OrchestratorServer::extract_assistant_text_v2(&context.data);
 
             if response.is_some() {
                 if attempt > 0 {
@@ -275,28 +300,16 @@ impl OrchestratorRunTool {
             );
         }
 
-        // Handle context limit summarization if needed
-        if token_tracker.compaction_needed
-            && let (Some(pid), Some(mid)) = (&token_tracker.provider_id, &token_tracker.model_id)
-        {
-            let summarize_req = SummarizeRequest {
-                provider_id: pid.clone(),
-                model_id: mid.clone(),
-                auto: None,
-            };
-
-            match client
-                .sessions()
-                .summarize(&session_id, &summarize_req)
-                .await
-            {
-                Ok(_) => {
-                    tracing::info!(session_id = %session_id, "context summarization triggered");
-                    warnings.push("Context limit reached; summarization triggered".into());
+        // Handle context limit compaction if needed
+        if token_tracker.compaction_needed {
+            match client.api().session().compact(&session_id).await {
+                Ok(()) => {
+                    tracing::info!(session_id = %session_id, "context compaction triggered");
+                    warnings.push("Context limit reached; compaction triggered".into());
                 }
                 Err(e) => {
-                    tracing::warn!(session_id = %session_id, error = %e, "summarization failed");
-                    warnings.push(format!("Summarization failed: {e}"));
+                    tracing::warn!(session_id = %session_id, error = %e, "compaction failed");
+                    warnings.push(format!("Compaction failed: {e}"));
                 }
             }
         }
@@ -315,7 +328,7 @@ impl OrchestratorRunTool {
         })
     }
 
-    fn map_questions(req: &QuestionRequest) -> Vec<QuestionInfoView> {
+    fn map_questions(req: &QuestionRequestV2) -> Vec<QuestionInfoView> {
         req.questions
             .iter()
             .map(|question| QuestionInfoView {
@@ -338,7 +351,7 @@ impl OrchestratorRunTool {
     fn question_required_output(
         session_id: String,
         partial_response: Option<String>,
-        request: &QuestionRequest,
+        request: &QuestionRequestV2,
         warnings: Vec<String>,
     ) -> OrchestratorRunOutput {
         OrchestratorRunOutput {
@@ -360,11 +373,9 @@ impl OrchestratorRunTool {
         session_id: &str,
         mode: PermissionPreflightMode,
         warnings: &mut Vec<String>,
-    ) -> Result<Option<opencode_rs::types::permission::PermissionRequest>, ToolError> {
-        match client.permissions().list().await {
-            Ok(pending_permissions) => Ok(pending_permissions
-                .into_iter()
-                .find(|permission| permission.session_id == session_id)),
+    ) -> Result<Option<PermissionRequestV2>, ToolError> {
+        match client.api().permission().list_session(session_id).await {
+            Ok(pending_permissions) => Ok(pending_permissions.data.into_iter().next()),
             Err(error)
                 if matches!(mode, PermissionPreflightMode::RespondPermissionContinuation)
                     && error.is_validation_error() =>
@@ -467,7 +478,8 @@ impl OrchestratorRunTool {
         // 1. Resolve session: validate existing or create new
         let session_id = if let Some(sid) = input.session_id {
             // Validate session exists
-            client.sessions().get(&sid).await.map_err(|e| {
+            // LEGACY_EXCEPTION(OpenCode v1.17.2): upstream still lacks `/api/*` session fetch-by-id.
+            client.legacy().session().get(&sid).await.map_err(|e| {
                 if e.is_not_found() {
                     ToolError::InvalidInput(format!(
                         "Session '{sid}' not found. Use list_sessions to discover sessions, \
@@ -480,8 +492,10 @@ impl OrchestratorRunTool {
             sid
         } else {
             // Create new session
+            // LEGACY_EXCEPTION(OpenCode v1.17.2): upstream still lacks `/api/*` session creation.
             let session = client
-                .sessions()
+                .legacy()
+                .session()
                 .create(&CreateSessionRequest::default())
                 .await
                 .map_err(|e| ToolError::Internal(format!("Failed to create session: {e}")))?;
@@ -499,13 +513,7 @@ impl OrchestratorRunTool {
         let mut warnings = Vec::new();
 
         // 2. Check if session is already idle (for resume-only case)
-        let status = client
-            .sessions()
-            .status_for(&session_id)
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to get session status: {e}")))?;
-
-        let is_idle = matches!(status, SessionStatusInfo::Idle);
+        let is_idle = wait_probe_idle(client, &session_id, Duration::from_millis(50)).await?;
 
         // 3. Check for pending permissions before doing anything else
         if let Some(perm) = Self::preflight_pending_permission(
@@ -518,7 +526,7 @@ impl OrchestratorRunTool {
         {
             tracing::info!(
                 session_id = %session_id,
-                permission_type = %perm.permission,
+                permission_type = %perm.action,
                 "run: pending permission found"
             );
             return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
@@ -527,8 +535,8 @@ impl OrchestratorRunTool {
                 response: None,
                 partial_response: None,
                 permission_request_id: Some(perm.id),
-                permission_type: Some(perm.permission),
-                permission_patterns: perm.patterns,
+                permission_type: Some(perm.action),
+                permission_patterns: perm.resources,
                 question_request_id: None,
                 questions: vec![],
                 warnings,
@@ -536,12 +544,14 @@ impl OrchestratorRunTool {
         }
 
         let pending_questions = client
+            .api()
             .question()
-            .list()
+            .list_requests()
             .await
             .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?;
 
         if let Some(question) = pending_questions
+            .data
             .into_iter()
             .find(|question| question.session_id == session_id)
         {
@@ -555,15 +565,18 @@ impl OrchestratorRunTool {
         // Uses finalize_completed to get retry logic for message extraction
         if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
             let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
+            let mut token_tracker = token_tracker;
             let output =
-                Self::finalize_completed(client, session_id, &token_tracker, vec![]).await?;
+                Self::finalize_completed(client, session_id, &mut token_tracker, &server, vec![])
+                    .await?;
             return Ok(RunOutcome::with_tracker(output, &token_tracker));
         }
 
         // 5. Subscribe to SSE BEFORE sending prompt/command
-        let mut subscription = client
-            .subscribe_session(&session_id)
-            .map_err(|e| ToolError::Internal(format!("Failed to subscribe to session: {e}")))?;
+        let mut subscription =
+            client.api().event().subscribe().map_err(|e| {
+                ToolError::Internal(format!("Failed to subscribe to /api/event: {e}"))
+            })?;
 
         // Track whether this call is dispatching new work (command or message)
         // vs just resuming/monitoring an existing session.
@@ -595,33 +608,31 @@ impl OrchestratorRunTool {
                     message_id: None,
                 };
 
+                // LEGACY_EXCEPTION(OpenCode v1.17.2): upstream still lacks `/api/*` command execution.
                 cmd_client
-                    .messages()
+                    .legacy()
+                    .session()
                     .command(&cmd_session_id, &req)
                     .await
                     .map(|_| ())
                     .map_err(|e| e.to_string())
             }));
         } else if let Some(msg) = &message {
-            // Send prompt asynchronously
-            let req = PromptRequest {
-                parts: vec![PromptPart::Text {
+            let req = PromptRequestV2 {
+                id: None,
+                prompt: PromptInputV2 {
                     text: msg.clone(),
-                    synthetic: None,
-                    ignored: None,
-                    metadata: None,
-                }],
-                message_id: None,
-                model: None,
-                agent: agent.clone(),
-                no_reply: None,
-                system: None,
-                variant: None,
+                    files: Vec::new(),
+                    agents: agent.clone().into_iter().collect(),
+                },
+                delivery: None,
+                resume: None,
             };
 
             client
-                .messages()
-                .prompt_async(&session_id, &req)
+                .api()
+                .session()
+                .prompt(&session_id, &req)
                 .await
                 .map_err(|e| ToolError::Internal(format!("Failed to send prompt: {e}")))?;
 
@@ -655,15 +666,17 @@ impl OrchestratorRunTool {
         // This handles the race where session completed between our initial status check
         // and SSE subscription becoming ready.
         if !dispatched_new_work
-            && let Ok(status) = client.sessions().status_for(&session_id).await
-            && matches!(status, SessionStatusInfo::Idle)
+            && wait_probe_idle(client, &session_id, Duration::from_millis(50))
+                .await
+                .unwrap_or(false)
         {
             tracing::debug!(
                 session_id = %session_id,
                 "session already idle on post-subscribe check"
             );
             let output =
-                Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                Self::finalize_completed(client, session_id, &mut token_tracker, &server, warnings)
+                    .await?;
             return Ok(RunOutcome::with_tracker(output, &token_tracker));
         }
         // If check fails or session is busy, continue to event loop
@@ -708,93 +721,35 @@ impl OrchestratorRunTool {
                         continue; // The poll_interval branch will now drive completion detection
                     };
 
-                    // Track tokens (server is already initialized at this point)
-                    token_tracker.observe_event(&event, |pid, mid| {
-                        server.context_limit(pid, mid)
-                    });
-
-                    match event {
-                        Event::PermissionAsked { properties } => {
-                            tracing::info!(
-                                session_id = %session_id,
-                                permission_type = %properties.request.permission,
-                                "run: permission requested"
-                            );
-                            return Ok(RunOutcome::with_tracker(OrchestratorRunOutput {
-                                session_id,
-                                status: RunStatus::PermissionRequired,
-                                response: None,
-                                partial_response: if partial_response.is_empty() {
-                                    None
-                                } else {
-                                    Some(partial_response)
-                                },
-                                permission_request_id: Some(properties.request.id),
-                                permission_type: Some(properties.request.permission),
-                                permission_patterns: properties.request.patterns,
-                                question_request_id: None,
-                                questions: vec![],
-                                warnings,
-                            }, &token_tracker));
-                        }
-
-                        Event::QuestionAsked { properties } => {
-                            return Ok(RunOutcome::with_tracker(Self::question_required_output(
-                                session_id,
-                                if partial_response.is_empty() {
-                                    None
-                                } else {
-                                    Some(partial_response)
-                                },
-                                &properties.request,
-                                warnings,
-                            ), &token_tracker));
-                        }
-
-                        Event::MessagePartDelta { properties } => {
-                            last_activity_time = tokio::time::Instant::now();
-                            // Message streaming means session is actively processing
-                            observed_busy = true;
-                            awaiting_idle_grace_check = false;
-                            // Collect streaming text from field-level delta events.
-                            if let Some(delta) = &properties.delta {
-                                partial_response.push_str(delta);
-                            }
-                        }
-
-                        Event::MessagePartUpdated { .. } | Event::MessageUpdated { .. } => {
-                            last_activity_time = tokio::time::Instant::now();
-                            observed_busy = true;
-                            awaiting_idle_grace_check = false;
-                        }
-
-                        Event::SessionError { properties } => {
-                            let error_msg = properties
-                                .error
-                                .map_or_else(|| "Unknown error".to_string(), |e| format!("{e:?}"));
-                            tracing::error!(
-                                session_id = %session_id,
-                                error = %error_msg,
-                                "run: session error"
-                            );
-                            return Err(ToolError::Internal(format!("Session error: {error_msg}")));
-                        }
-
-                        Event::SessionIdle { .. } => {
-                            tracing::debug!(session_id = %session_id, "received SessionIdle event");
-                            let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
-                            return Ok(RunOutcome::with_tracker(output, &token_tracker));
-                        }
-
-                        _ => {
-                            // Other events - continue
-                        }
+                    if event.session_id() != Some(session_id.as_str()) {
+                        continue;
                     }
+
+                    if let Some(delta) = event.data.get("delta").and_then(serde_json::Value::as_str) {
+                        partial_response.push_str(delta);
+                    }
+
+                    if event.event_type == "session.idle" {
+                        tracing::debug!(session_id = %session_id, "received session idle event");
+                        let output = Self::finalize_completed(
+                            client,
+                            session_id,
+                            &mut token_tracker,
+                            &server,
+                            warnings,
+                        )
+                        .await?;
+                        return Ok(RunOutcome::with_tracker(output, &token_tracker));
+                    }
+
+                    last_activity_time = tokio::time::Instant::now();
+                    observed_busy = true;
+                    awaiting_idle_grace_check = false;
                 }
 
                 _ = poll_interval.tick() => {
                     // === 1. Permission fallback (check first, permissions take priority) ===
-                    let pending = match client.permissions().list().await {
+                    let pending = match client.api().permission().list_session(&session_id).await {
                         Ok(p) => p,
                         Err(e) => {
                             // Log but continue - permission list failure shouldn't block completion detection
@@ -803,11 +758,13 @@ impl OrchestratorRunTool {
                                 error = %e,
                                 "failed to list permissions during poll fallback"
                             );
-                            vec![]
+                            DataEnvelope {
+                                data: vec![],
+                            }
                         }
                     };
 
-                    if let Some(perm) = pending.into_iter().find(|p| p.session_id == session_id) {
+                    if let Some(perm) = pending.data.into_iter().find(|p| p.session_id == session_id) {
                         tracing::debug!(
                             session_id = %session_id,
                             permission_id = %perm.id,
@@ -821,17 +778,17 @@ impl OrchestratorRunTool {
                                 None
                             } else {
                                 Some(partial_response)
-                                },
-                                permission_request_id: Some(perm.id),
-                                permission_type: Some(perm.permission),
-                            permission_patterns: perm.patterns,
+                            },
+                            permission_request_id: Some(perm.id),
+                            permission_type: Some(perm.action),
+                            permission_patterns: perm.resources,
                             question_request_id: None,
                             questions: vec![],
                             warnings,
                         }, &token_tracker));
                     }
 
-                    let pending_questions = match client.question().list().await {
+                    let pending_questions = match client.api().question().list_requests().await {
                         Ok(questions) => questions,
                         Err(e) => {
                             tracing::warn!(
@@ -839,11 +796,15 @@ impl OrchestratorRunTool {
                                 error = %e,
                                 "failed to list questions during poll fallback"
                             );
-                            vec![]
+                            LocationEnvelope {
+                                location: LocationInfo::default(),
+                                data: vec![],
+                            }
                         }
                     };
 
                     if let Some(question) = pending_questions
+                        .data
                         .into_iter()
                         .find(|question| question.session_id == session_id)
                     {
@@ -867,17 +828,16 @@ impl OrchestratorRunTool {
                     // === 2. Session idle detection fallback (NEW) ===
                     // This is the key fix for race conditions. If SSE missed SessionIdle,
                     // we detect completion via polling sessions().status_for(session_id).
-                    match client.sessions().status_for(&session_id).await {
-                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }) => {
+                    match wait_probe_idle(client, &session_id, Duration::from_millis(50)).await {
+                        Ok(false) => {
                             last_activity_time = tokio::time::Instant::now();
-                            observed_busy = true;
                             awaiting_idle_grace_check = false;
                             tracing::trace!(
                                 session_id = %session_id,
-                                "our session is busy/retry, waiting"
+                                "our session is still active, waiting"
                             );
                         }
-                        Ok(SessionStatusInfo::Idle) => {
+                        Ok(true) => {
                             if !dispatched_new_work || observed_busy {
                                 // Session is idle AND either:
                                 // - We didn't dispatch new work (just monitoring), OR
@@ -890,7 +850,14 @@ impl OrchestratorRunTool {
                                     observed_busy = observed_busy,
                                     "detected session idle via polling fallback"
                                 );
-                                let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                                let output = Self::finalize_completed(
+                                    client,
+                                    session_id,
+                                    &mut token_tracker,
+                                    &server,
+                                    warnings,
+                                )
+                                .await?;
                                 return Ok(RunOutcome::with_tracker(output, &token_tracker));
                             }
 
@@ -910,7 +877,14 @@ impl OrchestratorRunTool {
                                     idle_grace_ms = idle_grace.as_millis(),
                                     "accepting idle via bounded idle grace (no busy observed)"
                                 );
-                                let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                                let output = Self::finalize_completed(
+                                    client,
+                                    session_id,
+                                    &mut token_tracker,
+                                    &server,
+                                    warnings,
+                                )
+                                .await?;
                                 return Ok(RunOutcome::with_tracker(output, &token_tracker));
                             }
 
@@ -926,7 +900,7 @@ impl OrchestratorRunTool {
                             tracing::warn!(
                                 session_id = %session_id,
                                 error = %e,
-                                "failed to get session status during poll fallback"
+                                "failed to wait for session during poll fallback"
                             );
                         }
                     }
@@ -940,13 +914,20 @@ impl OrchestratorRunTool {
                 }, if awaiting_idle_grace_check => {
                     awaiting_idle_grace_check = false;
 
-                    match client.sessions().status_for(&session_id).await {
-                        Ok(SessionStatusInfo::Idle) => {
+                    match wait_probe_idle(client, &session_id, Duration::from_millis(50)).await {
+                        Ok(true) => {
                             tracing::debug!(session_id = %session_id, "idle-grace deadline reached; finalizing");
-                            let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                            let output = Self::finalize_completed(
+                                client,
+                                session_id,
+                                &mut token_tracker,
+                                &server,
+                                warnings,
+                            )
+                            .await?;
                             return Ok(RunOutcome::with_tracker(output, &token_tracker));
                         }
-                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }) => {
+                        Ok(false) => {
                             last_activity_time = tokio::time::Instant::now();
                             observed_busy = true;
                         }
@@ -954,7 +935,7 @@ impl OrchestratorRunTool {
                             tracing::warn!(
                                 session_id = %session_id,
                                 error = %e,
-                                "status check failed at idle-grace deadline"
+                                "wait probe failed at idle-grace deadline"
                             );
                         }
                     }
@@ -1107,38 +1088,24 @@ impl Tool for ListSessionsTool {
                     .await
                     .map_err(|e| ToolError::Internal(e.to_string()))?;
 
-                let sessions =
-                    // Intentionally keep zero-arg list() so SDK directory context preserves launch-directory scoping.
-                    server.client().sessions().list().await.map_err(|e| {
-                        ToolError::Internal(format!("Failed to list sessions: {e}"))
-                    })?;
-                let status_map = server.client().sessions().status_map().await.ok();
+                let sessions = server
+                    .client()
+                    .api()
+                    .session()
+                    .list(&SessionListQuery {
+                        limit: Some(input.limit.unwrap_or(20) as u64),
+                        ..SessionListQuery::default()
+                    })
+                    .await
+                    .map_err(|e| ToolError::Internal(format!("Failed to list sessions: {e}")))?;
                 let spawned = server.spawned_sessions().read().await;
 
                 let limit = input.limit.unwrap_or(20);
                 let summaries: Vec<SessionSummary> = sessions
+                    .data
                     .into_iter()
                     .take(limit)
-                    .map(|s| {
-                        let status =
-                            status_map
-                                .as_ref()
-                                .map(|status_map| match status_map.get(&s.id) {
-                                    Some(SessionStatusInfo::Busy) => SessionStatusSummary::Busy,
-                                    Some(SessionStatusInfo::Retry {
-                                        attempt,
-                                        message,
-                                        next,
-                                    }) => SessionStatusSummary::Retry {
-                                        attempt: *attempt,
-                                        message: message.clone(),
-                                        next: *next,
-                                    },
-                                    Some(SessionStatusInfo::Idle) | None => {
-                                        SessionStatusSummary::Idle
-                                    }
-                                });
-
+                    .map(|s: SessionInfoV2| {
                         let change_stats = s.summary.as_ref().map(|summary| ChangeStats {
                             additions: summary.additions,
                             deletions: summary.deletions,
@@ -1147,13 +1114,13 @@ impl Tool for ListSessionsTool {
 
                         SessionSummary {
                             launched_by_you: spawned.contains(&s.id),
-                            created: s.time.as_ref().map(|t| t.created),
-                            updated: s.time.as_ref().map(|t| t.updated),
+                            created: s.time.as_ref().and_then(|t| t.created),
+                            updated: s.time.as_ref().and_then(|t| t.updated),
                             directory: s.directory,
                             path: s.path,
                             title: s.title,
                             id: s.id,
-                            status,
+                            status: None,
                             change_stats,
                         }
                     })
@@ -1186,13 +1153,13 @@ impl Tool for ListSessionsTool {
     }
 }
 
-fn count_pending_messages(messages: &[Message]) -> usize {
+fn count_pending_messages_v2(messages: &[MessageV2]) -> usize {
     let mut pending = 0;
 
     for message in messages.iter().rev() {
-        if message.role() == "user" {
+        if message.role == "user" {
             pending += 1;
-        } else if message.role() == "assistant" {
+        } else if message.role == "assistant" {
             break;
         }
     }
@@ -1200,24 +1167,22 @@ fn count_pending_messages(messages: &[Message]) -> usize {
     pending
 }
 
-fn get_last_activity_time(messages: &[Message], fallback: Option<i64>) -> Option<i64> {
+fn get_last_activity_time_v2(messages: &[MessageV2], fallback: Option<i64>) -> Option<i64> {
     messages.last().map_or(fallback, |message| {
-        Some(
-            message
-                .info
-                .time
-                .completed
-                .unwrap_or(message.info.time.created),
-        )
+        message
+            .time
+            .as_ref()
+            .map(|time| time.completed.unwrap_or(time.created))
+            .or(fallback)
     })
 }
 
-fn extract_recent_tool_calls(messages: &[Message], limit: usize) -> Vec<ToolCallSummary> {
+fn extract_recent_tool_calls_v2(messages: &[MessageV2], limit: usize) -> Vec<ToolCallSummary> {
     let mut tool_calls = Vec::new();
 
     for message in messages.iter().rev() {
-        for part in message.parts.iter().rev() {
-            if let Part::Tool {
+        for part in message.content.iter().rev() {
+            if let ContentPartV2::Tool {
                 call_id,
                 tool,
                 state,
@@ -1225,15 +1190,15 @@ fn extract_recent_tool_calls(messages: &[Message], limit: usize) -> Vec<ToolCall
             } = part
             {
                 let (state, started_at, completed_at) = match state {
-                    Some(ToolState::Running(running)) => {
+                    Some(ToolStateV2::Running(running)) => {
                         (ToolStateSummary::Running, Some(running.time.start), None)
                     }
-                    Some(ToolState::Completed(completed)) => (
+                    Some(ToolStateV2::Completed(completed)) => (
                         ToolStateSummary::Completed,
                         Some(completed.time.start),
                         Some(completed.time.end),
                     ),
-                    Some(ToolState::Error(error)) => (
+                    Some(ToolStateV2::Error(error)) => (
                         ToolStateSummary::Error {
                             message: error.error.clone(),
                         },
@@ -1296,7 +1261,8 @@ impl Tool for GetSessionStateTool {
                 let client = server.client();
                 let session_id = &input.session_id;
 
-                let session = client.sessions().get(session_id).await.map_err(|e| {
+                // LEGACY_EXCEPTION(OpenCode v1.17.2): upstream still lacks `/api/*` session fetch-by-id.
+                let session = client.legacy().session().get(session_id).await.map_err(|e| {
                     if e.is_not_found() {
                         ToolError::InvalidInput(format!(
                             "Session '{session_id}' not found. Use list_sessions to discover available sessions."
@@ -1306,31 +1272,21 @@ impl Tool for GetSessionStateTool {
                     }
                 })?;
 
-                let status = match client.sessions().status_for(session_id).await.map_err(|e| {
-                    ToolError::Internal(format!("Failed to get session status: {e}"))
-                })? {
-                    SessionStatusInfo::Busy => SessionStatusSummary::Busy,
-                    SessionStatusInfo::Retry {
-                        attempt,
-                        message,
-                        next,
-                    } => SessionStatusSummary::Retry {
-                        attempt,
-                        message,
-                        next,
-                    },
-                    SessionStatusInfo::Idle => SessionStatusSummary::Idle,
+                let status = if wait_probe_idle(client, session_id, Duration::from_millis(50)).await? {
+                    SessionStatusSummary::Idle
+                } else {
+                    SessionStatusSummary::Busy
                 };
 
-                let messages = client.messages().list(session_id).await.map_err(|e| {
-                    ToolError::Internal(format!("Failed to list messages: {e}"))
+                let messages = client.api().session().context(session_id).await.map_err(|e| {
+                    ToolError::Internal(format!("Failed to fetch session context: {e}"))
                 })?;
-                let pending_message_count = count_pending_messages(&messages);
-                let last_activity = get_last_activity_time(
-                    &messages,
+                let pending_message_count = count_pending_messages_v2(&messages.data);
+                let last_activity = get_last_activity_time_v2(
+                    &messages.data,
                     session.time.as_ref().map(|time| time.updated),
                 );
-                let recent_tool_calls = extract_recent_tool_calls(&messages, 10);
+                let recent_tool_calls = extract_recent_tool_calls_v2(&messages.data, 10);
 
                 let spawned = server.spawned_sessions().read().await;
                 let launched_by_you = spawned.contains(session_id);
@@ -1410,16 +1366,17 @@ impl Tool for ListAgentsTool {
                         .map_err(|e| ToolError::Internal(e.to_string()))?;
 
                     let agents =
-                        server.client().tools().agents().await.map_err(|e| {
+                        server.client().api().agent().list().await.map_err(|e| {
                             ToolError::Internal(format!("Failed to list agents: {e}"))
                         })?;
 
                     let agent_infos: Vec<AgentInfo> = agents
+                        .data
                         .into_iter()
-                        .filter(|agent| !agent.hidden.unwrap_or(false))
-                        .filter(|agent| server.is_agent_allowed(&agent.name))
+                        .filter(|agent| !agent.hidden)
+                        .filter(|agent| server.is_agent_allowed(&agent.id))
                         .map(|agent| AgentInfo {
-                            name: agent.name,
+                            name: agent.id,
                             description: agent.description,
                         })
                         .collect();
@@ -1489,11 +1446,12 @@ impl Tool for ListCommandsTool {
                     .map_err(|e| ToolError::Internal(e.to_string()))?;
 
                 let commands =
-                    server.client().tools().commands().await.map_err(|e| {
+                    server.client().api().command().list().await.map_err(|e| {
                         ToolError::Internal(format!("Failed to list commands: {e}"))
                     })?;
 
                 let command_infos: Vec<CommandInfo> = commands
+                    .data
                     .into_iter()
                     .filter(|command| server.is_command_allowed(&command.name))
                     .map(|c| CommandInfo {
@@ -1583,9 +1541,9 @@ Parameters:
 
                 let (permission_request_id, permission_type, permission_patterns) =
                     if let Some(req_id) = input.permission_request_id.as_deref() {
-                        match client.permissions().list().await {
-                            Ok(mut pending) => {
-                                let idx = pending.iter().position(|p| p.id == req_id).ok_or_else(|| {
+                        match client.api().permission().list_session(&input.session_id).await {
+                            Ok(pending) => {
+                                let idx = pending.data.iter().position(|p| p.id == req_id).ok_or_else(|| {
                                     ToolError::InvalidInput(format!(
                                         "No pending permission found with id '{req_id}'. \
                                      (session_id='{}')",
@@ -1593,7 +1551,15 @@ Parameters:
                                     ))
                                 })?;
 
-                                let perm = pending.remove(idx);
+                                let perm = pending
+                                    .data
+                                    .into_iter()
+                                    .nth(idx)
+                                    .ok_or_else(|| {
+                                        ToolError::Internal(
+                                            "Permission disappeared after index validation".into(),
+                                        )
+                                    })?;
 
                                 if perm.session_id != input.session_id {
                                     return Err(ToolError::InvalidInput(format!(
@@ -1602,7 +1568,7 @@ Parameters:
                                     )));
                                 }
 
-                                (perm.id, perm.permission, perm.patterns)
+                                (perm.id, perm.action, perm.resources)
                             }
                             Err(error) if error.is_validation_error() => {
                                 tracing::warn!(
@@ -1624,14 +1590,11 @@ Parameters:
                         }
                     } else {
                         // Find the pending permission for this session when discovery is required.
-                        let pending = client.permissions().list().await.map_err(|e| {
+                        let pending = client.api().permission().list_session(&input.session_id).await.map_err(|e| {
                             ToolError::Internal(format!("Failed to list permissions: {e}"))
                         })?;
 
-                        let mut perms: Vec<_> = pending
-                            .into_iter()
-                            .filter(|p| p.session_id == input.session_id)
-                            .collect();
+                        let mut perms = pending.data;
 
                         match perms.as_slice() {
                             [] => {
@@ -1643,7 +1606,7 @@ Parameters:
                             }
                             [_single] => {
                                 let perm = perms.swap_remove(0);
-                                (perm.id, perm.permission, perm.patterns)
+                                (perm.id, perm.action, perm.resources)
                             }
                             multiple => {
                                 let ids = multiple
@@ -1666,10 +1629,10 @@ Parameters:
                 // Capture baseline assistant text BEFORE sending reject
                 // This lets us detect stale text after rejection
                 let baseline = if is_reject {
-                    match client.messages().list(&input.session_id).await {
-                        Ok(msgs) => OrchestratorServer::extract_assistant_text(&msgs),
+                    match client.api().session().context(&input.session_id).await {
+                        Ok(msgs) => OrchestratorServer::extract_assistant_text_v2(&msgs.data),
                         Err(e) => {
-                            pre_warnings.push(format!("Failed to fetch baseline messages: {e}"));
+                            pre_warnings.push(format!("Failed to fetch baseline context: {e}"));
                             None
                         }
                     }
@@ -1679,17 +1642,19 @@ Parameters:
 
                 // Convert our reply type to API type
                 let api_reply = match input.reply {
-                    PermissionReply::Once => ApiPermissionReply::Once,
-                    PermissionReply::Always => ApiPermissionReply::Always,
-                    PermissionReply::Reject => ApiPermissionReply::Reject,
+                    PermissionReply::Once => ApiPermissionReplyV2::Once,
+                    PermissionReply::Always => ApiPermissionReplyV2::Always,
+                    PermissionReply::Reject => ApiPermissionReplyV2::Reject,
                 };
 
                 // Send the reply
                 client
-                    .permissions()
+                    .api()
+                    .permission()
                     .reply(
+                        &input.session_id,
                         &permission_request_id,
-                        &PermissionReplyRequest {
+                        &PermissionReplyRequestV2 {
                             reply: api_reply,
                             message: input.message,
                         },
@@ -1808,13 +1773,15 @@ Parameters:
 
             let client = server.client();
             let mut pending = client
+                .api()
                 .question()
-                .list()
+                .list_requests()
                 .await
                 .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?;
 
             let question = if let Some(req_id) = input.question_request_id.as_deref() {
                 let idx = pending
+                    .data
                     .iter()
                     .position(|question| question.id == req_id)
                     .ok_or_else(|| {
@@ -1824,7 +1791,7 @@ Parameters:
                         ))
                     })?;
 
-                let question = pending.remove(idx);
+                let question = pending.data.remove(idx);
                 if question.session_id != input.session_id {
                     return Err(ToolError::InvalidInput(format!(
                         "Question request '{req_id}' belongs to session '{}', not '{}'.",
@@ -1835,6 +1802,7 @@ Parameters:
                 question
             } else {
                 let mut questions: Vec<_> = pending
+                    .data
                     .into_iter()
                     .filter(|question| question.session_id == input.session_id)
                     .collect();
@@ -1870,10 +1838,12 @@ Parameters:
                     }
 
                     client
+                        .api()
                         .question()
                         .reply(
+                            &input.session_id,
                             &question.id,
-                            &QuestionReply {
+                            &QuestionReplyV2 {
                                 answers: input.answers,
                             },
                         )
@@ -1894,7 +1864,7 @@ Parameters:
                     Ok((outcome.output, outcome.log_meta))
                 }
                 QuestionAction::Reject => {
-                    client.question().reject(&question.id).await.map_err(|e| {
+                    client.api().question().reject(&input.session_id, &question.id).await.map_err(|e| {
                         ToolError::Internal(format!("Failed to reject question: {e}"))
                     })?;
 
@@ -1963,6 +1933,6 @@ mod tests {
 
     #[test]
     fn last_activity_falls_back_to_session_timestamp_when_messages_are_empty() {
-        assert_eq!(get_last_activity_time(&[], Some(1_234)), Some(1_234));
+        assert_eq!(get_last_activity_time_v2(&[], Some(1_234)), Some(1_234));
     }
 }

--- a/apps/opencode-orchestrator-mcp/src/version.rs
+++ b/apps/opencode-orchestrator-mcp/src/version.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 ///
 /// Supports both direct binary invocation and launcher-based invocation:
 /// - Direct: `binary = "/path/to/opencode"`, `launcher_args = []`
-/// - Launcher: `binary = "bunx"`, `launcher_args = ["--yes", "opencode-ai@1.15.7"]`
+/// - Launcher: `binary = "bunx"`, `launcher_args = ["--yes", "opencode-ai@1.17.2"]`
 #[derive(Debug, Clone)]
 pub struct LauncherConfig {
     /// Path to the binary (or launcher binary like `bunx`).
@@ -65,7 +65,7 @@ pub fn resolve_opencode_binary(base_dir: &Path) -> anyhow::Result<PathBuf> {
 /// Note: This uses simple whitespace splitting and does not support shell-style
 /// quoting. Arguments containing spaces (e.g., `--message "hello world"`) will
 /// be incorrectly split. This is acceptable for the documented use case
-/// (`--yes opencode-ai@1.15.7`).
+/// (`--yes opencode-ai@1.17.2`).
 pub fn parse_launcher_args() -> Vec<String> {
     match std::env::var(OPENCODE_BINARY_ARGS_ENV) {
         Ok(value) => {
@@ -130,9 +130,9 @@ mod tests {
 
     #[test]
     fn normalize_strips_v_prefix() {
-        assert_eq!(normalize_version("v1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("  v1.15.7 "), "1.15.7");
+        assert_eq!(normalize_version("v1.17.2"), "1.17.2");
+        assert_eq!(normalize_version("1.17.2"), "1.17.2");
+        assert_eq!(normalize_version("  v1.17.2 "), "1.17.2");
     }
 
     #[test]
@@ -166,12 +166,12 @@ mod tests {
     #[serial(env)]
     fn parse_launcher_args_splits_on_whitespace() {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
-        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7") };
-        assert_eq!(parse_launcher_args(), vec!["opencode-ai@1.15.7"]);
+        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.2") };
+        assert_eq!(parse_launcher_args(), vec!["opencode-ai@1.17.2"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
-        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "--yes opencode-ai@1.15.7") };
-        assert_eq!(parse_launcher_args(), vec!["--yes", "opencode-ai@1.15.7"]);
+        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "--yes opencode-ai@1.17.2") };
+        assert_eq!(parse_launcher_args(), vec!["--yes", "opencode-ai@1.17.2"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe { std::env::remove_var(OPENCODE_BINARY_ARGS_ENV) };
@@ -194,14 +194,14 @@ mod tests {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
             std::env::set_var(OPENCODE_BINARY_ENV, "bunx");
-            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7");
+            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.2");
         }
 
         let base = Path::new("/tmp/project");
         let config = resolve_launcher_config(base).unwrap();
 
         assert_eq!(config.binary, "bunx");
-        assert_eq!(config.launcher_args, vec!["opencode-ai@1.15.7"]);
+        assert_eq!(config.launcher_args, vec!["opencode-ai@1.17.2"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
@@ -216,7 +216,7 @@ mod tests {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
             std::env::set_var(OPENCODE_BINARY_ENV, "   ");
-            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7");
+            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.2");
         }
 
         let base = Path::new("/tmp/project");

--- a/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
@@ -17,6 +17,7 @@ use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
+use wiremock::matchers::path_regex;
 
 use support::session_fixture;
 use support::status_v2_busy;
@@ -26,10 +27,9 @@ async fn test_orchestrator_server_with_long_timeout(
     mock: &MockServer,
 ) -> Arc<OrchestratorServerHandle> {
     Mock::given(method("GET"))
-        .and(path("/global/health"))
+        .and(path("/api/health"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "healthy": true,
-            "version": "test",
         })))
         .mount(mock)
         .await;
@@ -79,34 +79,37 @@ async fn it_times_out_after_5_min_inactivity() {
 
     // Prompt dispatch succeeds immediately
     Mock::given(method("POST"))
-        .and(path("/session/s1/prompt_async"))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path("/api/session/s1/prompt"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
 
     // Status always idle -> no activity
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     // No permissions
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // SSE stream stalls, forcing polling fallback
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -159,34 +162,37 @@ async fn it_does_not_timeout_while_busy() {
 
     // Prompt dispatch succeeds immediately
     Mock::given(method("POST"))
-        .and(path("/session/s1/prompt_async"))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path("/api/session/s1/prompt"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
 
     // Status always busy -> should keep resetting activity timer
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy("s1")))
         .mount(&mock)
         .await;
 
     // No permissions
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // SSE stream stalls, forcing polling fallback
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")

--- a/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
@@ -79,11 +79,8 @@ async fn it_times_out_after_5_min_inactivity() {
 
     // Prompt dispatch succeeds immediately
     Mock::given(method("POST"))
-        .and(path("/api/session/s1/prompt"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path("/session/s1/prompt_async"))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
 
@@ -162,11 +159,8 @@ async fn it_does_not_timeout_while_busy() {
 
     // Prompt dispatch succeeds immediately
     Mock::given(method("POST"))
-        .and(path("/api/session/s1/prompt"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path("/session/s1/prompt_async"))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -40,23 +40,23 @@ async fn run_returns_cancelled_when_request_context_is_cancelled() {
         .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(session_id)))
         .mount(&mock)
         .await;
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -70,7 +70,7 @@ async fn run_returns_cancelled_when_request_context_is_cancelled() {
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(ResponseTemplate::new(200).set_body_json(commands_list_fixture()))
         .mount(&mock)
         .await;
@@ -128,12 +128,12 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(permission_seq)
         .mount(&mock)
         .await;
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -142,18 +142,18 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
         .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(session_id)))
         .mount(&mock)
         .await;
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -407,11 +407,8 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
         .mount(&mock)
         .await;
     Mock::given(method("POST"))
-        .and(path("/api/session/s1/prompt"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path("/session/s1/prompt_async"))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
@@ -450,13 +447,13 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
     let prompt_request = requests
         .iter()
         .find(|request| {
-            request.method.as_str() == "POST" && request.url.path() == "/api/session/s1/prompt"
+            request.method.as_str() == "POST" && request.url.path() == "/session/s1/prompt_async"
         })
         .expect("prompt request should be sent");
     let body: serde_json::Value = serde_json::from_slice(&prompt_request.body)
         .expect("prompt request body should be valid json");
-    assert_eq!(body["prompt"]["agents"], json!(["Plan"]));
-    assert_eq!(body["prompt"]["text"], json!("say ok"));
+    assert_eq!(body["agent"], json!("Plan"));
+    assert_eq!(body["parts"][0]["text"], json!("say ok"));
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -22,6 +22,7 @@ use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
+use wiremock::matchers::path_regex;
 
 use support::messages_fixture;
 use support::session_fixture;
@@ -60,21 +61,23 @@ fn orchestrator_config(
 }
 
 fn command_list(names: &[&str]) -> serde_json::Value {
-    json!(
-        names
+    json!({
+        "location": { "directory": "/tmp" },
+        "data": names
             .iter()
-            .map(|name| json!({"name": name, "description": format!("{name} description")}))
+            .map(|name| json!({"name": name, "template": name, "description": format!("{name} description")}))
             .collect::<Vec<_>>()
-    )
+    })
 }
 
 fn agent_list(names: &[&str]) -> serde_json::Value {
-    json!(
-        names
+    json!({
+        "location": { "directory": "/tmp" },
+        "data": names
             .iter()
-            .map(|name| json!({"name": name, "description": format!("{name} description")}))
+            .map(|name| json!({"id": name, "description": format!("{name} description"), "hidden": false}))
             .collect::<Vec<_>>()
-    )
+    })
 }
 
 async fn list_commands_with_config(mock: &MockServer, config: OrchestratorConfig) -> Vec<String> {
@@ -107,7 +110,7 @@ async fn list_agents_with_config(mock: &MockServer, config: OrchestratorConfig) 
 async fn list_commands_filters_deny_only_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
         )
@@ -124,7 +127,7 @@ async fn list_commands_filters_deny_only_policy() {
 async fn list_commands_filters_allow_only_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
         )
@@ -141,7 +144,7 @@ async fn list_commands_filters_allow_only_policy() {
 async fn list_commands_applies_deny_wins_overlap_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
         )
@@ -161,7 +164,7 @@ async fn list_commands_applies_deny_wins_overlap_policy() {
 async fn list_commands_trims_configured_entries() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(command_list(&["test", "build", "lint"])),
         )
@@ -178,7 +181,7 @@ async fn list_commands_trims_configured_entries() {
 async fn list_commands_matching_is_case_sensitive() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(ResponseTemplate::new(200).set_body_json(command_list(&["Build", "build"])))
         .mount(&mock)
         .await;
@@ -242,7 +245,7 @@ async fn blocked_run_command_fails_before_session_resolution_or_dispatch() {
 async fn list_agents_filters_deny_only_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/agent"))
+        .and(path("/api/agent"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
         )
@@ -258,7 +261,7 @@ async fn list_agents_filters_deny_only_policy() {
 async fn list_agents_filters_allow_only_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/agent"))
+        .and(path("/api/agent"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
         )
@@ -274,7 +277,7 @@ async fn list_agents_filters_allow_only_policy() {
 async fn list_agents_applies_deny_wins_overlap_policy() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/agent"))
+        .and(path("/api/agent"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash", "Research"])),
         )
@@ -294,7 +297,7 @@ async fn list_agents_applies_deny_wins_overlap_policy() {
 async fn list_agents_trims_configured_entries() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/agent"))
+        .and(path("/api/agent"))
         .respond_with(ResponseTemplate::new(200).set_body_json(agent_list(&["Plan", "Bash"])))
         .mount(&mock)
         .await;
@@ -309,7 +312,7 @@ async fn list_agents_trims_configured_entries() {
 async fn list_agents_matching_is_case_sensitive() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/agent"))
+        .and(path("/api/agent"))
         .respond_with(ResponseTemplate::new(200).set_body_json(agent_list(&["Bash", "bash"])))
         .mount(&mock)
         .await;
@@ -379,23 +382,23 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
         .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture("s1")))
         .mount(&mock)
         .await;
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -404,12 +407,15 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
         .mount(&mock)
         .await;
     Mock::given(method("POST"))
-        .and(path("/session/s1/prompt_async"))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path("/api/session/s1/prompt"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/session/s1/message"))
+        .and(path("/api/session/s1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture("s1", Some("ok"))))
         .mount(&mock)
         .await;
@@ -444,12 +450,13 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
     let prompt_request = requests
         .iter()
         .find(|request| {
-            request.method.as_str() == "POST" && request.url.path() == "/session/s1/prompt_async"
+            request.method.as_str() == "POST" && request.url.path() == "/api/session/s1/prompt"
         })
         .expect("prompt request should be sent");
     let body: serde_json::Value = serde_json::from_slice(&prompt_request.body)
         .expect("prompt request body should be valid json");
-    assert_eq!(body["agent"], json!("Plan"));
+    assert_eq!(body["prompt"]["agents"], json!(["Plan"]));
+    assert_eq!(body["prompt"]["text"], json!("say ok"));
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -89,11 +89,8 @@ async fn fast_idle_prompt_completes_without_hanging() {
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/api/session/{sid}/prompt")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path(format!("/session/{sid}/prompt_async")))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -25,7 +25,6 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::path_regex;
-use wiremock::matchers::query_param;
 
 use support::SequenceResponder;
 use support::messages_fixture;
@@ -71,32 +70,35 @@ async fn fast_idle_prompt_completes_without_hanging() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/session/{sid}/prompt_async")))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path(format!("/api/session/{sid}/prompt")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("FAST_IDLE_DONE"))),
         )
@@ -104,7 +106,7 @@ async fn fast_idle_prompt_completes_without_hanging() {
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -157,19 +159,19 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(permission_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -180,14 +182,14 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("RESUME_DONE"))),
         )
@@ -195,7 +197,7 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -238,8 +240,7 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
     let perm_id = "perm-patch-pre";
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
-        .and(query_param("directory", "/tmp"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(
             ResponseTemplate::new(400)
                 .set_body_json(permission_patch_file_array_bad_request_fixture()),
@@ -248,7 +249,7 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
         .await;
 
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -263,20 +264,20 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
         ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("PRE_REPLY_DONE"))),
         )
@@ -284,7 +285,7 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -325,9 +326,8 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
         .await
         .expect("wiremock should capture requests");
     assert!(
-        requests
-            .iter()
-            .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
+        requests.iter().any(|request| request.url.path()
+            == format!("/api/session/{sid}/permission/{perm_id}/reply")),
         "reply POST should be observed with a known request id: {:?}",
         requests
             .iter()
@@ -362,14 +362,13 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         ResponseTemplate::new(400).set_body_json(permission_patch_file_array_bad_request_fixture()),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
-        .and(query_param("directory", "/tmp"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(permission_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -380,8 +379,8 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(SequenceResponder::new(vec![
             ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
             ResponseTemplate::new(200).set_body_json(status_v2_idle()),
@@ -390,13 +389,13 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(messages_fixture(sid, Some("POST_REPLY_DONE"))),
@@ -405,7 +404,7 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -446,9 +445,8 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         .await
         .expect("wiremock should capture requests");
     assert!(
-        requests
-            .iter()
-            .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
+        requests.iter().any(|request| request.url.path()
+            == format!("/api/session/{sid}/permission/{perm_id}/reply")),
         "reply POST should be observed before the follow-up failure: {:?}",
         requests
             .iter()
@@ -475,15 +473,14 @@ async fn run_still_errors_on_initial_permission_list_bad_request() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
-        .and(query_param("directory", "/tmp"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(
             ResponseTemplate::new(400)
                 .set_body_json(permission_patch_file_array_bad_request_fixture()),

--- a/apps/opencode-orchestrator-mcp/tests/integration.rs
+++ b/apps/opencode-orchestrator-mcp/tests/integration.rs
@@ -221,7 +221,7 @@ async fn live_managed_server_reports_exact_pinned_version() {
     let health = s.client().misc().health().await.expect("health ok");
 
     version::validate_exact_version(health.version.as_deref())
-        .expect("version must match pinned 1.15.7 target");
+        .expect("version must match pinned 1.17.2 target");
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -19,11 +19,13 @@ use opencode_orchestrator_mcp::types::SessionStatusSummary;
 use opencode_orchestrator_mcp::types::ToolStateSummary;
 use serde_json::json;
 use std::sync::Arc;
+use std::time::Duration;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
+use wiremock::matchers::path_regex;
 
 use support::busy_status_fixture;
 use support::commands_list_fixture;
@@ -44,7 +46,7 @@ async fn list_sessions_returns_session_ids() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/session"))
+        .and(path("/api/session"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(sessions_list_fixture(&["ses-1", "ses-2"])),
         )
@@ -71,7 +73,7 @@ async fn list_sessions_returns_empty_list() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/session"))
+        .and(path("/api/session"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -92,7 +94,7 @@ async fn list_sessions_returns_enriched_fields() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/session"))
+        .and(path("/api/session"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([
             {
                 "id": "ses-1",
@@ -120,8 +122,8 @@ async fn list_sessions_returns_enriched_fields() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(session_status_fixture(&[
                 ("ses-1", busy_status_fixture()),
@@ -144,21 +146,14 @@ async fn list_sessions_returns_enriched_fields() {
     assert_eq!(first.updated, Some(20));
     assert_eq!(first.directory.as_deref(), Some("/tmp/project-a"));
     assert_eq!(first.path.as_deref(), Some("src/a.rs"));
-    assert!(matches!(first.status, Some(SessionStatusSummary::Busy)));
+    assert!(first.status.is_none());
     let first_stats = first.change_stats.as_ref().expect("change stats expected");
     assert_eq!(first_stats.additions, 5);
     assert_eq!(first_stats.deletions, 2);
     assert_eq!(first_stats.files, 1);
 
     let second = &result.sessions[1];
-    assert!(matches!(
-        second.status,
-        Some(SessionStatusSummary::Retry {
-            attempt: 2,
-            ref message,
-            next: 1234,
-        }) if message == "rate limited"
-    ));
+    assert!(second.status.is_none());
     assert_eq!(second.path.as_deref(), Some("src/b.rs"));
 }
 
@@ -170,15 +165,15 @@ async fn list_sessions_marks_launched_by_you() {
     seed_spawned_sessions(&server, &["ses-1"]).await;
 
     Mock::given(method("GET"))
-        .and(path("/session"))
+        .and(path("/api/session"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(sessions_list_fixture(&["ses-1", "ses-2"])),
         )
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .mount(&mock)
         .await;
@@ -191,14 +186,8 @@ async fn list_sessions_marks_launched_by_you() {
 
     assert!(result.sessions[0].launched_by_you);
     assert!(!result.sessions[1].launched_by_you);
-    assert!(matches!(
-        result.sessions[0].status,
-        Some(SessionStatusSummary::Idle)
-    ));
-    assert!(matches!(
-        result.sessions[1].status,
-        Some(SessionStatusSummary::Idle)
-    ));
+    assert!(result.sessions[0].status.is_none());
+    assert!(result.sessions[1].status.is_none());
 }
 
 #[tokio::test]
@@ -215,14 +204,14 @@ async fn get_session_state_returns_idle_status() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
         .mount(&mock)
         .await;
@@ -257,17 +246,14 @@ async fn get_session_state_returns_busy_status() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
-        )
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
         .mount(&mock)
         .await;
@@ -301,19 +287,14 @@ async fn get_session_state_returns_retry_status() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(session_status_fixture(&[(
-                "ses-1",
-                retry_status_fixture(3, "provider overloaded", 9876),
-            )])),
-        )
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
         .mount(&mock)
         .await;
@@ -329,14 +310,7 @@ async fn get_session_state_returns_retry_status() {
         .await
         .expect("get_session_state should succeed");
 
-    assert!(matches!(
-        result.status,
-        SessionStatusSummary::Retry {
-            attempt: 3,
-            ref message,
-            next: 9876,
-        } if message == "provider overloaded"
-    ));
+    assert!(matches!(result.status, SessionStatusSummary::Busy));
     assert_eq!(result.path.as_deref(), Some("src/session.rs"));
 }
 
@@ -356,16 +330,13 @@ async fn get_session_state_summarizes_messages_and_launched_by_you() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
-        )
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
         .mount(&mock)
         .await;
 
-    let history = message_history_fixture(vec![
+    let history = message_history_fixture(&[
         message_fixture(
             "ses-1",
             "m1",
@@ -430,7 +401,7 @@ async fn get_session_state_summarizes_messages_and_launched_by_you() {
     ]);
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(history))
         .mount(&mock)
         .await;
@@ -481,16 +452,13 @@ async fn get_session_state_orders_tool_parts_recent_first_within_message() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
-        )
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
         .mount(&mock)
         .await;
 
-    let history = message_history_fixture(vec![message_fixture(
+    let history = message_history_fixture(&[message_fixture(
         "ses-1",
         "m1",
         "assistant",
@@ -525,7 +493,7 @@ async fn get_session_state_orders_tool_parts_recent_first_within_message() {
     )]);
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(history))
         .mount(&mock)
         .await;
@@ -559,8 +527,8 @@ async fn get_session_state_returns_error_when_status_lookup_fails() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(500).set_body_json(json!({
             "name": "InternalError",
             "message": "boom"
@@ -580,7 +548,7 @@ async fn get_session_state_returns_error_when_status_lookup_fails() {
         .expect_err("status lookup failure should error");
 
     assert!(matches!(err, ToolError::Internal(_)));
-    assert!(err.to_string().contains("Failed to get session status"));
+    assert!(err.to_string().contains("Failed to wait for session"));
 }
 
 #[tokio::test]
@@ -594,17 +562,14 @@ async fn get_session_state_returns_error_when_message_lookup_fails() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(session_status_fixture(&[("ses-1", busy_status_fixture())])),
-        )
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(500).set_body_json(json!({
             "name": "InternalError",
             "message": "boom"
@@ -624,7 +589,7 @@ async fn get_session_state_returns_error_when_message_lookup_fails() {
         .expect_err("message lookup failure should error");
 
     assert!(matches!(err, ToolError::Internal(_)));
-    assert!(err.to_string().contains("Failed to list messages"));
+    assert!(err.to_string().contains("Failed to fetch session context"));
 }
 
 #[tokio::test]
@@ -638,20 +603,20 @@ async fn get_session_state_counts_each_trailing_user_message() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .mount(&mock)
         .await;
 
-    let history = message_history_fixture(vec![
+    let history = message_history_fixture(&[
         message_fixture("ses-1", "m1", "assistant", 1, Some(2), vec![]),
         message_fixture("ses-1", "m2", "user", 3, None, vec![]),
         message_fixture("ses-1", "m3", "user", 4, None, vec![]),
     ]);
 
     Mock::given(method("GET"))
-        .and(path("/session/ses-1/message"))
+        .and(path("/api/session/ses-1/context"))
         .respond_with(ResponseTemplate::new(200).set_body_json(history))
         .mount(&mock)
         .await;
@@ -705,7 +670,7 @@ async fn list_commands_returns_available_commands() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(ResponseTemplate::new(200).set_body_json(commands_list_fixture()))
         .mount(&mock)
         .await;
@@ -729,7 +694,7 @@ async fn list_commands_returns_empty_list() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -750,18 +715,21 @@ async fn list_agents_returns_visible_agents() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/agent"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-            {
-                "name": "Plan",
-                "description": "Planning agent",
-                "hidden": false
-            },
-            {
-                "name": "Research",
-                "description": "Research agent"
-            }
-        ])))
+        .and(path("/api/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "location": {"directory": "/tmp"},
+            "data": [
+                {
+                    "id": "Plan",
+                    "description": "Planning agent",
+                    "hidden": false
+                },
+                {
+                    "id": "Research",
+                    "description": "Research agent"
+                }
+            ]
+        })))
         .mount(&mock)
         .await;
 
@@ -787,19 +755,22 @@ async fn list_agents_omits_hidden_agents() {
     let server = test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/agent"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-            {
-                "name": "Plan",
-                "description": "Planning agent",
-                "hidden": false
-            },
-            {
-                "name": "HiddenAgent",
-                "description": "Internal agent",
-                "hidden": true
-            }
-        ])))
+        .and(path("/api/agent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "location": {"directory": "/tmp"},
+            "data": [
+                {
+                    "id": "Plan",
+                    "description": "Planning agent",
+                    "hidden": false
+                },
+                {
+                    "id": "HiddenAgent",
+                    "description": "Internal agent",
+                    "hidden": true
+                }
+            ]
+        })))
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -69,21 +69,21 @@ async fn it_bug1_completion_retries_messages_until_visible() {
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)), // poll: sets observed_busy=true
         ResponseTemplate::new(200).set_body_json(status_v2_idle()), // poll: idle, triggers completion
     ]);
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
 
     // GET /permission - no pending permissions
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -95,22 +95,25 @@ async fn it_bug1_completion_retries_messages_until_visible() {
     ]);
     let messages_call_counter = messages_seq.call_counter();
     Mock::given(method("GET"))
-        .and(path("/session/s1/message"))
+        .and(path("/api/session/s1/context"))
         .respond_with(messages_seq)
         .mount(&mock)
         .await;
 
     // POST /session/s1/prompt_async - fire and forget
     Mock::given(method("POST"))
-        .and(path("/session/s1/prompt_async"))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path("/api/session/s1/prompt"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
 
     // GET /event - SSE endpoint: return empty response with delay to allow polling to complete
     // The SSE subscription will fail/hang, but polling will detect idle status
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -177,8 +180,8 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
         .await;
 
     // GET /session/status - idle after rejection
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
@@ -194,27 +197,27 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(perm_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // POST /permission/{id}/reply - accept the rejection
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
 
     // GET /session/s2/message - returns STALE pre-rejection text (baseline and final same)
     Mock::given(method("GET"))
-        .and(path("/session/s2/message"))
+        .and(path("/api/session/s2/context"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(messages_fixture(sid, Some("I_WILL_CREATE_FILE"))),
@@ -288,8 +291,8 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
         ResponseTemplate::new(200).set_body_json(status_v2_idle()), // later: idle -> completion
     ]);
     let status_calls = status_seq.call_counter();
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
@@ -305,20 +308,20 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(perm_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // POST /permission/{id}/reply
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -329,7 +332,7 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
     let msg_after = ResponseTemplate::new(200)
         .set_body_json(messages_fixture(sid, Some("PERMISSION_GRANTED_RESPONSE")));
     Mock::given(method("GET"))
-        .and(path("/session/s3/message"))
+        .and(path("/api/session/s3/context"))
         .respond_with(SwitchAfterCallsResponder::new(
             status_calls.clone(),
             2,
@@ -401,20 +404,20 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(perm_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // POST /permission/{id}/reply
     Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
+        .and(path_regex(r"/api/session/.*/permission/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
@@ -431,8 +434,8 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
         ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
     let status_calls = status_seq.call_counter();
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
@@ -445,7 +448,7 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     let msg_post = ResponseTemplate::new(200)
         .set_body_json(messages_fixture(sid, Some("POST_PERMISSION_TEXT")));
     Mock::given(method("GET"))
-        .and(path("/session/s5/message"))
+        .and(path("/api/session/s5/context"))
         .respond_with(SwitchAfterCallsResponder::new(
             status_calls.clone(),
             3,
@@ -457,7 +460,7 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
 
     // GET /event - delay SSE so polling drives completion
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -517,10 +520,9 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
     let sid = "s4";
 
     Mock::given(method("GET"))
-        .and(path("/global/health"))
+        .and(path("/api/health"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "healthy": true,
-            "version": "test",
         })))
         .mount(&mock)
         .await;
@@ -539,28 +541,28 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)), // poll: sets observed_busy=true
         ResponseTemplate::new(200).set_body_json(status_v2_idle()), // poll: idle, triggers completion
     ]);
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
 
     // GET /permission
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     // GET /session/s4/message
     Mock::given(method("GET"))
-        .and(path("/session/s4/message"))
+        .and(path("/api/session/s4/context"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("COMMAND_RESULT"))),
         )
@@ -569,7 +571,7 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
 
     // GET /event - SSE endpoint: return empty response with delay to allow polling to complete
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -102,11 +102,8 @@ async fn it_bug1_completion_retries_messages_until_visible() {
 
     // POST /session/s1/prompt_async - fire and forget
     Mock::given(method("POST"))
-        .and(path("/api/session/s1/prompt"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path("/session/s1/prompt_async"))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -58,20 +58,20 @@ async fn pending_question_preflight_returns_question_required() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             question_fixture(question_id, sid, &[question_payload("Continue?")])
         ])))
@@ -112,14 +112,14 @@ async fn poll_detected_question_returns_question_required() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -133,19 +133,22 @@ async fn poll_detected_question_returns_question_required() {
         )])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(question_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/session/{sid}/prompt_async")))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path(format!("/api/session/{sid}/prompt")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
+        )
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -194,13 +197,13 @@ async fn respond_question_reply_resumes_to_completed() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(question_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -210,8 +213,8 @@ async fn respond_question_reply_resumes_to_completed() {
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
         ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
@@ -223,13 +226,13 @@ async fn respond_question_reply_resumes_to_completed() {
         .await;
 
     Mock::given(method("POST"))
-        .and(path_regex(r"/question/.*/reply"))
+        .and(path_regex(r"/api/session/.*/question/.*/reply"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(messages_fixture(sid, Some("QUESTION_REPLY_DONE"))),
@@ -238,7 +241,7 @@ async fn respond_question_reply_resumes_to_completed() {
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -284,13 +287,13 @@ async fn respond_question_reject_completes_cleanly() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(question_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -301,20 +304,20 @@ async fn respond_question_reject_completes_cleanly() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("POST"))
-        .and(path_regex(r"/question/.*/reject"))
+        .and(path_regex(r"/api/session/.*/question/.*/reject"))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture(sid, None)))
         .mount(&mock)
         .await;
@@ -352,14 +355,14 @@ async fn permission_priority_wins_over_question() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             permission_fixture("perm-priority", sid, "file.write", &["/tmp/out.txt"])
         ])))
@@ -367,7 +370,7 @@ async fn permission_priority_wins_over_question() {
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             question_fixture("question-priority", sid, &[question_payload("Continue?")])
         ])))
@@ -417,13 +420,13 @@ async fn respond_question_by_id_lookup() {
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(question_seq)
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/permission"))
+        .and(path_regex(r"/api/session/.*/permission"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
@@ -434,8 +437,8 @@ async fn respond_question_by_id_lookup() {
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
         ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
-    Mock::given(method("GET"))
-        .and(path("/session/status"))
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/session/.*/wait"))
         .respond_with(status_seq)
         .mount(&mock)
         .await;
@@ -448,13 +451,15 @@ async fn respond_question_by_id_lookup() {
 
     // Mock the reply endpoint to accept the specific question ID
     Mock::given(method("POST"))
-        .and(path(format!("/question/{question_id}/reply")))
+        .and(path(format!(
+            "/api/session/{sid}/question/{question_id}/reply"
+        )))
         .respond_with(ResponseTemplate::new(200).set_body_json(true))
         .mount(&mock)
         .await;
 
     Mock::given(method("GET"))
-        .and(path(format!("/session/{sid}/message")))
+        .and(path(format!("/api/session/{sid}/context")))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("Reply done"))),
         )
@@ -462,7 +467,7 @@ async fn respond_question_by_id_lookup() {
         .await;
 
     Mock::given(method("GET"))
-        .and(path("/event"))
+        .and(path("/api/event"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
@@ -501,7 +506,7 @@ async fn multiple_pending_questions_returns_ambiguity_error() {
 
     // Mount two questions for the same session
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             question_fixture("q1", sid, &[question_payload("First question?")]),
             question_fixture("q2", sid, &[question_payload("Second question?")])
@@ -545,7 +550,7 @@ async fn reply_with_empty_answers_returns_validation_error() {
     let sid = "question-empty-answers";
 
     Mock::given(method("GET"))
-        .and(path("/question"))
+        .and(path("/api/question/request"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             question_fixture("q-empty", sid, &[question_payload("Continue?")])
         ])))

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -139,11 +139,8 @@ async fn poll_detected_question_returns_question_required() {
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/api/session/{sid}/prompt")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"data": {"id": "input-1"}})),
-        )
+        .and(path(format!("/session/{sid}/prompt_async")))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/recovery_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/recovery_wiremock.rs
@@ -35,7 +35,7 @@ async fn external_client_seam_still_supports_end_to_end_tool_calls() {
     let server = support::test_orchestrator_server(&mock).await;
 
     Mock::given(method("GET"))
-        .and(path("/command"))
+        .and(path("/api/command"))
         .respond_with(ResponseTemplate::new(200).set_body_json(commands_list_fixture()))
         .mount(&mock)
         .await;
@@ -53,21 +53,23 @@ async fn external_failure_is_sticky_and_keeps_held_snapshot_stable() {
     let old_mock = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/global/health"))
+        .and(path("/api/health"))
         .respond_with(SequenceResponder::new(vec![
             ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "healthy": true,
-                "version": "old",
             })),
             ResponseTemplate::new(500),
         ]))
         .mount(&old_mock)
         .await;
     Mock::given(method("GET"))
-        .and(path("/command"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
-            {"name": "old-command", "description": "from snapshot 1"}
-        ])))
+        .and(path("/api/command"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp"},
+            "data": [
+                {"name": "old-command", "template": "old-command", "description": "from snapshot 1"}
+            ]
+        })))
         .mount(&old_mock)
         .await;
 
@@ -105,7 +107,7 @@ async fn external_failure_is_sticky_and_keeps_held_snapshot_stable() {
         Err(error) => error,
     };
 
-    let commands_a = snapshot_a.client().tools().commands().await.unwrap();
+    let commands_a = snapshot_a.client().api().command().list().await.unwrap();
 
     assert_eq!(rebuilds.load(Ordering::SeqCst), 0);
     assert!(
@@ -114,6 +116,6 @@ async fn external_failure_is_sticky_and_keeps_held_snapshot_stable() {
             .contains("External OpenCode server unavailable")
     );
     assert_eq!(first_err.to_string(), second_err.to_string());
-    assert_eq!(commands_a[0].name, "old-command");
+    assert_eq!(commands_a.data[0].name, "old-command");
     assert_eq!(snapshot_a.base_url(), old_mock.uri().trim_end_matches('/'));
 }

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -37,10 +37,9 @@ pub async fn test_orchestrator_server_with_config(
     config: OrchestratorConfig,
 ) -> Arc<OrchestratorServerHandle> {
     Mock::given(method("GET"))
-        .and(path("/global/health"))
+        .and(path("/api/health"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "healthy": true,
-            "version": "test",
         })))
         .mount(mock)
         .await;
@@ -271,10 +270,9 @@ pub fn permission_fixture_with_metadata(
 ) -> serde_json::Value {
     serde_json::json!({
         "id": id,
-        "sessionID": session_id,  // Note: sessionID not sessionId (matches opencode-rs types)
-        "permission": permission,
-        "patterns": patterns,
-        "always": [],
+        "sessionID": session_id,
+        "action": permission,
+        "resources": patterns,
         "tool": null,
         "metadata": metadata
     })
@@ -305,18 +303,24 @@ pub fn question_fixture(
 /// If `None`, only includes a user message (simulating stale/not-yet-persisted state).
 pub fn messages_fixture(session_id: &str, assistant_text: Option<&str>) -> serde_json::Value {
     let mut msgs = vec![serde_json::json!({
-        "info": {"id": "u1", "sessionID": session_id, "role": "user", "time": {"created": 1}},
-        "parts": []
+        "id": "u1",
+        "sessionID": session_id,
+        "role": "user",
+        "content": [],
+        "time": { "created": 1 }
     })];
 
     if let Some(text) = assistant_text {
         msgs.push(serde_json::json!({
-            "info": {"id": "a1", "sessionID": session_id, "role": "assistant", "time": {"created": 2}},
-            "parts": [{"type": "text", "text": text}]
+            "id": "a1",
+            "sessionID": session_id,
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+            "time": { "created": 2, "completed": 3 }
         }));
     }
 
-    serde_json::Value::Array(msgs)
+    serde_json::json!({ "data": msgs })
 }
 
 /// Create a message fixture with explicit parts and timestamps.
@@ -332,16 +336,14 @@ pub fn message_fixture(
     if let Some(completed) = completed {
         time["completed"] = serde_json::json!(completed);
     }
-    let parts = Value::Array(parts);
+    let content = Value::Array(parts);
 
     serde_json::json!({
-        "info": {
-            "id": message_id,
-            "sessionID": session_id,
-            "role": role,
-            "time": time,
-        },
-        "parts": parts,
+        "id": message_id,
+        "sessionID": session_id,
+        "role": role,
+        "time": time,
+        "content": content,
     })
 }
 
@@ -362,27 +364,31 @@ pub fn tool_part_fixture(call_id: &str, tool: &str, state: Option<Value>) -> Val
 }
 
 /// Create a message history response fixture.
-pub fn message_history_fixture(messages: Vec<Value>) -> Value {
-    Value::Array(messages)
+pub fn message_history_fixture(messages: &[Value]) -> Value {
+    serde_json::json!({ "data": messages })
 }
 
 /// Create a sessions list response fixture.
 pub fn sessions_list_fixture(session_ids: &[&str]) -> serde_json::Value {
-    serde_json::json!(
-        session_ids
+    serde_json::json!({
+        "data": session_ids
             .iter()
             .map(|id| session_fixture(id))
-            .collect::<Vec<_>>()
-    )
+            .collect::<Vec<_>>(),
+        "cursor": {}
+    })
 }
 
 /// Create a commands list response fixture.
 pub fn commands_list_fixture() -> serde_json::Value {
-    serde_json::json!([
-        {"name": "test", "description": "Run tests"},
-        {"name": "build", "description": "Build project"},
-        {"name": "lint", "description": "Run linter"}
-    ])
+    serde_json::json!({
+        "location": { "directory": "/tmp" },
+        "data": [
+            {"name": "test", "template": "test", "description": "Run tests"},
+            {"name": "build", "template": "build", "description": "Build project"},
+            {"name": "lint", "template": "lint", "description": "Run linter"}
+        ]
+    })
 }
 
 /// Seed launched sessions on the in-memory test server.

--- a/crates/services/opencode-rs/Cargo.toml
+++ b/crates/services/opencode-rs/Cargo.toml
@@ -45,6 +45,7 @@ portpicker = { version = "0.1", optional = true }
 futures = "0.3"
 urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
+base64 = "0.22"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/services/opencode-rs/justfile
+++ b/crates/services/opencode-rs/justfile
@@ -9,7 +9,7 @@ integration-test-bunx-stable:
     #!/usr/bin/env bash
     set -euxo pipefail
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration -- --ignored --nocapture --test-threads=1
 
@@ -19,7 +19,7 @@ smoke-bunx-version:
     #!/usr/bin/env bash
     set -euxo pipefail
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration test_health_returns_pinned_version -- --ignored --nocapture
 
@@ -30,7 +30,7 @@ integration-test-bunx-verbose:
     set -euxo pipefail
     RUST_LOG=opencode_rs=debug \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration -- --ignored --nocapture --test-threads=1
 
@@ -41,8 +41,8 @@ launcher-orphan-cleanup-regression:
     set -euxo pipefail
     : "${OPENCODE_INTEGRATION:=1}"
     : "${OPENCODE_BINARY:=bunx}"
-    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.15.7}"
-    bunx --yes opencode-ai@1.15.7 --version
+    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.17.2}"
+    bunx --yes opencode-ai@1.17.2 --version
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_INTEGRATION="$OPENCODE_INTEGRATION" \
     OPENCODE_BINARY="$OPENCODE_BINARY" \

--- a/crates/services/opencode-rs/src/client.rs
+++ b/crates/services/opencode-rs/src/client.rs
@@ -5,6 +5,7 @@
 #[cfg(not(feature = "http"))]
 use crate::error::OpencodeError;
 use crate::error::Result;
+use base64::Engine as _;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -30,6 +31,7 @@ pub struct ClientBuilder {
     directory: Option<String>,
     workspace: Option<String>,
     timeout: Duration,
+    auth_header: Option<String>,
 }
 
 impl Default for ClientBuilder {
@@ -39,6 +41,7 @@ impl Default for ClientBuilder {
             directory: None,
             workspace: None,
             timeout: Duration::from_secs(1800), // 30 min for long-running tool calls
+            auth_header: None,
         }
     }
 }
@@ -83,6 +86,24 @@ impl ClientBuilder {
         self
     }
 
+    #[must_use]
+    pub fn basic_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        let username = username.into();
+        let password = password.into();
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
+        self.auth_header = Some(format!("Basic {encoded}"));
+        self
+    }
+
+    #[must_use]
+    pub fn authorization_header(mut self, header: impl Into<String>) -> Self {
+        let header = header.into();
+        let trimmed = header.trim();
+        self.auth_header = (!trimmed.is_empty()).then(|| trimmed.to_string());
+        self
+    }
+
     /// Build the client.
     ///
     /// # Errors
@@ -96,7 +117,8 @@ impl ClientBuilder {
             directory: self.directory,
             workspace: self.workspace,
             timeout: self.timeout,
-        })?;
+        })?
+        .with_auth_header(self.auth_header);
 
         Ok(Client {
             http,
@@ -127,6 +149,18 @@ impl Client {
     #[cfg(feature = "http")]
     pub fn sessions(&self) -> crate::http::sessions::SessionsApi {
         crate::http::sessions::SessionsApi::new(self.http.clone())
+    }
+
+    /// Get the v1.17.2-native `/api/*` API surface.
+    #[cfg(feature = "http")]
+    pub fn api(&self) -> crate::http::api::ApiClient {
+        crate::http::api::ApiClient::new(self.http.clone(), Arc::clone(&self.last_event_id))
+    }
+
+    /// Get the temporary legacy-exception API surface.
+    #[cfg(feature = "http")]
+    pub fn legacy(&self) -> crate::http::legacy::LegacyClient {
+        crate::http::legacy::LegacyClient::new(self.http.clone())
     }
 
     /// Get the messages API.
@@ -347,6 +381,9 @@ impl Client {
             self.http.base().to_string(),
             self.http.directory().map(std::string::ToString::to_string),
             self.http.workspace().map(std::string::ToString::to_string),
+            self.http
+                .auth_header()
+                .map(std::string::ToString::to_string),
             Arc::clone(&self.last_event_id),
         )
     }
@@ -405,6 +442,7 @@ mod tests {
         assert_eq!(builder.timeout, Duration::from_secs(1800));
         assert!(builder.directory.is_none());
         assert!(builder.workspace.is_none());
+        assert!(builder.auth_header.is_none());
     }
 
     #[test]
@@ -413,12 +451,23 @@ mod tests {
             .base_url("http://localhost:8080")
             .directory("/my/project")
             .workspace("workspace-1")
+            .authorization_header("Bearer token")
             .timeout_secs(60);
 
         assert_eq!(builder.base_url, "http://localhost:8080");
         assert_eq!(builder.directory, Some("/my/project".to_string()));
         assert_eq!(builder.workspace, Some("workspace-1".to_string()));
         assert_eq!(builder.timeout, Duration::from_secs(60));
+        assert_eq!(builder.auth_header, Some("Bearer token".to_string()));
+    }
+
+    #[test]
+    fn test_client_builder_basic_auth_encodes_header() {
+        let builder = ClientBuilder::new().basic_auth("opencode", "secret");
+        assert_eq!(
+            builder.auth_header,
+            Some("Basic b3BlbmNvZGU6c2VjcmV0".to_string())
+        );
     }
 
     #[cfg(feature = "http")]

--- a/crates/services/opencode-rs/src/http/api/agent.rs
+++ b/crates/services/opencode-rs/src/http/api/agent.rs
@@ -1,0 +1,19 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::v2::agent::AgentInfo;
+use crate::types::v2::envelope::LocationEnvelope;
+
+#[derive(Clone)]
+pub struct AgentApi {
+    http: HttpClient,
+}
+
+impl AgentApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(&self) -> Result<LocationEnvelope<Vec<AgentInfo>>> {
+        self.http.api_get("/api/agent").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/command.rs
+++ b/crates/services/opencode-rs/src/http/api/command.rs
@@ -1,0 +1,19 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::v2::command::CommandInfo;
+use crate::types::v2::envelope::LocationEnvelope;
+
+#[derive(Clone)]
+pub struct CommandApi {
+    http: HttpClient,
+}
+
+impl CommandApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(&self) -> Result<LocationEnvelope<Vec<CommandInfo>>> {
+        self.http.api_get("/api/command").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/event.rs
+++ b/crates/services/opencode-rs/src/http/api/event.rs
@@ -1,0 +1,40 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::sse::SseOptions;
+use crate::sse::SseSubscriber;
+use crate::sse::SseSubscription;
+use crate::types::v2::event::Event;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct EventApi {
+    http: HttpClient,
+    last_event_id: Arc<RwLock<Option<String>>>,
+}
+
+impl EventApi {
+    pub fn new(http: HttpClient, last_event_id: Arc<RwLock<Option<String>>>) -> Self {
+        Self {
+            http,
+            last_event_id,
+        }
+    }
+
+    pub fn subscribe(&self) -> Result<SseSubscription<Event>> {
+        self.subscribe_with_options(SseOptions::default())
+    }
+
+    pub fn subscribe_with_options(&self, options: SseOptions) -> Result<SseSubscription<Event>> {
+        SseSubscriber::new(
+            self.http.base().to_string(),
+            self.http.directory().map(std::string::ToString::to_string),
+            self.http.workspace().map(std::string::ToString::to_string),
+            self.http
+                .auth_header()
+                .map(std::string::ToString::to_string),
+            Arc::clone(&self.last_event_id),
+        )
+        .subscribe_api("/api/event", options)
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/health.rs
+++ b/crates/services/opencode-rs/src/http/api/health.rs
@@ -1,0 +1,55 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::v2::health::HealthInfo;
+
+#[derive(Clone)]
+pub struct HealthApi {
+    http: HttpClient,
+}
+
+impl HealthApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn get(&self) -> Result<HealthInfo> {
+        self.http.api_get("/api/health").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn parses_api_health_response() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "healthy": true
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = HealthApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let response = api.get().await.unwrap();
+        assert!(response.healthy);
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/mod.rs
+++ b/crates/services/opencode-rs/src/http/api/mod.rs
@@ -1,0 +1,64 @@
+use crate::http::HttpClient;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub mod agent;
+pub mod command;
+pub mod event;
+pub mod health;
+pub mod model;
+pub mod permission;
+pub mod provider;
+pub mod question;
+pub mod session;
+
+#[derive(Clone)]
+pub struct ApiClient {
+    http: HttpClient,
+    last_event_id: Arc<RwLock<Option<String>>>,
+}
+
+impl ApiClient {
+    pub fn new(http: HttpClient, last_event_id: Arc<RwLock<Option<String>>>) -> Self {
+        Self {
+            http,
+            last_event_id,
+        }
+    }
+
+    pub fn event(&self) -> event::EventApi {
+        event::EventApi::new(self.http.clone(), Arc::clone(&self.last_event_id))
+    }
+
+    pub fn agent(&self) -> agent::AgentApi {
+        agent::AgentApi::new(self.http.clone())
+    }
+
+    pub fn command(&self) -> command::CommandApi {
+        command::CommandApi::new(self.http.clone())
+    }
+
+    pub fn health(&self) -> health::HealthApi {
+        health::HealthApi::new(self.http.clone())
+    }
+
+    pub fn model(&self) -> model::ModelApi {
+        model::ModelApi::new(self.http.clone())
+    }
+
+    pub fn permission(&self) -> permission::PermissionApi {
+        permission::PermissionApi::new(self.http.clone())
+    }
+
+    pub fn provider(&self) -> provider::ProviderApi {
+        provider::ProviderApi::new(self.http.clone())
+    }
+
+    pub fn question(&self) -> question::QuestionApi {
+        question::QuestionApi::new(self.http.clone())
+    }
+
+    pub fn session(&self) -> session::SessionApi {
+        session::SessionApi::new(self.http.clone())
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/model.rs
+++ b/crates/services/opencode-rs/src/http/api/model.rs
@@ -1,0 +1,75 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::v2::envelope::LocationEnvelope;
+use crate::types::v2::model::ModelInfo;
+
+#[derive(Clone)]
+pub struct ModelApi {
+    http: HttpClient,
+}
+
+impl ModelApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(&self) -> Result<LocationEnvelope<Vec<ModelInfo>>> {
+        self.http.api_get("/api/model").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn parses_location_wrapped_model_list() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/model"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "location": {
+                    "directory": "/tmp/project",
+                    "workspaceID": "ws-1"
+                },
+                "data": [
+                    {
+                        "id": "claude-sonnet-4",
+                        "providerID": "anthropic",
+                        "limit": {"context": 200_000}
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = ModelApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let response = api.list().await.unwrap();
+        assert_eq!(response.location.directory, "/tmp/project");
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].provider_id, "anthropic");
+        assert_eq!(
+            response.data[0]
+                .limit
+                .as_ref()
+                .and_then(|limit| limit.context),
+            Some(200_000)
+        );
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/permission.rs
+++ b/crates/services/opencode-rs/src/http/api/permission.rs
@@ -1,0 +1,47 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::encode_path_segment;
+use crate::types::v2::envelope::DataEnvelope;
+use crate::types::v2::envelope::LocationEnvelope;
+use crate::types::v2::permission::PermissionReplyRequest;
+use crate::types::v2::permission::PermissionRequest;
+#[derive(Clone)]
+pub struct PermissionApi {
+    http: HttpClient,
+}
+
+impl PermissionApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list_requests(&self) -> Result<LocationEnvelope<Vec<PermissionRequest>>> {
+        self.http.api_get("/api/permission/request").await
+    }
+
+    pub async fn list_session(
+        &self,
+        session_id: &str,
+    ) -> Result<DataEnvelope<Vec<PermissionRequest>>> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .api_get(&format!("/api/session/{session_id}/permission"))
+            .await
+    }
+
+    pub async fn reply(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        request: &PermissionReplyRequest,
+    ) -> Result<()> {
+        let session_id = encode_path_segment(session_id);
+        let request_id = encode_path_segment(request_id);
+        self.http
+            .api_post_empty(
+                &format!("/api/session/{session_id}/permission/{request_id}/reply"),
+                request,
+            )
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/provider.rs
+++ b/crates/services/opencode-rs/src/http/api/provider.rs
@@ -1,0 +1,27 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::encode_path_segment;
+use crate::types::v2::envelope::LocationEnvelope;
+use crate::types::v2::provider::ProviderInfo;
+
+#[derive(Clone)]
+pub struct ProviderApi {
+    http: HttpClient,
+}
+
+impl ProviderApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(&self) -> Result<LocationEnvelope<Vec<ProviderInfo>>> {
+        self.http.api_get("/api/provider").await
+    }
+
+    pub async fn get(&self, provider_id: &str) -> Result<LocationEnvelope<ProviderInfo>> {
+        let provider_id = encode_path_segment(provider_id);
+        self.http
+            .api_get(&format!("/api/provider/{provider_id}"))
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/question.rs
+++ b/crates/services/opencode-rs/src/http/api/question.rs
@@ -1,0 +1,96 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::encode_path_segment;
+use crate::types::v2::envelope::LocationEnvelope;
+use crate::types::v2::question::QuestionReply;
+use crate::types::v2::question::QuestionRequest;
+use reqwest::Method;
+
+#[derive(Clone)]
+pub struct QuestionApi {
+    http: HttpClient,
+}
+
+impl QuestionApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list_requests(&self) -> Result<LocationEnvelope<Vec<QuestionRequest>>> {
+        self.http.api_get("/api/question/request").await
+    }
+
+    pub async fn reply(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        request: &QuestionReply,
+    ) -> Result<()> {
+        let session_id = encode_path_segment(session_id);
+        let request_id = encode_path_segment(request_id);
+        self.http
+            .api_post_empty(
+                &format!("/api/session/{session_id}/question/{request_id}/reply"),
+                request,
+            )
+            .await
+    }
+
+    pub async fn reject(&self, session_id: &str, request_id: &str) -> Result<()> {
+        let session_id = encode_path_segment(session_id);
+        let request_id = encode_path_segment(request_id);
+        self.http
+            .api_request_empty(
+                Method::POST,
+                &format!("/api/session/{session_id}/question/{request_id}/reject"),
+                None,
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn parses_location_wrapped_question_requests() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/question/request"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "location": {"directory": "/tmp/project"},
+                "data": [
+                    {
+                        "id": "question-1",
+                        "sessionID": "session-1",
+                        "questions": [{"question": "Continue?"}]
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = QuestionApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let response = api.list_requests().await.unwrap();
+        assert_eq!(response.location.directory, "/tmp/project");
+        assert_eq!(response.data[0].id, "question-1");
+        assert_eq!(response.data[0].session_id, "session-1");
+    }
+}

--- a/crates/services/opencode-rs/src/http/api/session.rs
+++ b/crates/services/opencode-rs/src/http/api/session.rs
@@ -1,0 +1,147 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::encode_path_segment;
+use crate::types::v2::envelope::CursorEnvelope;
+use crate::types::v2::envelope::DataEnvelope;
+use crate::types::v2::message::Message;
+use crate::types::v2::session::PromptAdmitted;
+use crate::types::v2::session::PromptRequest;
+use crate::types::v2::session::SessionInfo;
+use crate::types::v2::session::SessionListQuery;
+use reqwest::Method;
+
+#[derive(Clone)]
+pub struct SessionApi {
+    http: HttpClient,
+}
+
+impl SessionApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(&self, query: &SessionListQuery) -> Result<CursorEnvelope<Vec<SessionInfo>>> {
+        self.http
+            .api_request_json_with_query(Method::GET, "/api/session", &query.to_query_pairs(), None)
+            .await
+    }
+
+    pub async fn prompt(
+        &self,
+        session_id: &str,
+        request: &PromptRequest,
+    ) -> Result<DataEnvelope<PromptAdmitted>> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .api_post(&format!("/api/session/{session_id}/prompt"), request)
+            .await
+    }
+
+    pub async fn wait(&self, session_id: &str) -> Result<()> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .api_request_empty(
+                Method::POST,
+                &format!("/api/session/{session_id}/wait"),
+                None,
+            )
+            .await
+    }
+
+    pub async fn compact(&self, session_id: &str) -> Result<()> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .api_request_empty(
+                Method::POST,
+                &format!("/api/session/{session_id}/compact"),
+                None,
+            )
+            .await
+    }
+
+    pub async fn context(&self, session_id: &str) -> Result<DataEnvelope<Vec<Message>>> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .api_get(&format!("/api/session/{session_id}/context"))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_json;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn parses_prompt_admitted_receipt() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/session/session-1/prompt"))
+            .and(body_json(serde_json::json!({
+                "prompt": {"text": "hello"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {"id": "input-1"}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = SessionApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let response = api
+            .prompt(
+                "session-1",
+                &PromptRequest {
+                    id: None,
+                    prompt: crate::types::v2::session::PromptInput {
+                        text: "hello".to_string(),
+                        files: Vec::new(),
+                        agents: Vec::new(),
+                    },
+                    delivery: None,
+                    resume: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.data.id.as_deref(), Some("input-1"));
+    }
+
+    #[tokio::test]
+    async fn wait_accepts_no_content_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/session/session-1/wait"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let api = SessionApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        api.wait("session-1").await.unwrap();
+    }
+}

--- a/crates/services/opencode-rs/src/http/legacy/global.rs
+++ b/crates/services/opencode-rs/src/http/legacy/global.rs
@@ -1,0 +1,61 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::misc::HealthInfo;
+use reqwest::Method;
+
+#[derive(Clone)]
+pub struct GlobalApi {
+    http: HttpClient,
+}
+
+impl GlobalApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    /// `LEGACY_EXCEPTION(OpenCode v1.17.2)`: startup-only exact version validation still requires `/global/health`.
+    pub async fn health(&self) -> Result<HealthInfo> {
+        self.http
+            .request_json(Method::GET, "/global/health", None)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn supports_legacy_global_health() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/global/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "healthy": true,
+                "version": "1.17.2"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = GlobalApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let response = api.health().await.unwrap();
+        assert!(response.healthy);
+        assert_eq!(response.version.as_deref(), Some("1.17.2"));
+    }
+}

--- a/crates/services/opencode-rs/src/http/legacy/mod.rs
+++ b/crates/services/opencode-rs/src/http/legacy/mod.rs
@@ -1,0 +1,49 @@
+use crate::http::HttpClient;
+
+pub mod global;
+pub mod session;
+
+pub const APPROVED_ROUTE_COUNT: usize = 4;
+pub const APPROVED_ROUTES: [(&str, &str); APPROVED_ROUTE_COUNT] = [
+    ("POST", "/session"),
+    ("GET", "/session/:sessionID"),
+    ("POST", "/session/:sessionID/command"),
+    ("GET", "/global/health"),
+];
+
+#[derive(Clone)]
+pub struct LegacyClient {
+    http: HttpClient,
+}
+
+impl LegacyClient {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub fn global(&self) -> global::GlobalApi {
+        global::GlobalApi::new(self.http.clone())
+    }
+
+    pub fn session(&self) -> session::SessionApi {
+        session::SessionApi::new(self.http.clone())
+    }
+
+    pub async fn global_health(&self) -> crate::error::Result<crate::http::misc::HealthInfo> {
+        self.global().health().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_exactly_four_approved_routes() {
+        assert_eq!(APPROVED_ROUTES.len(), APPROVED_ROUTE_COUNT);
+        assert_eq!(APPROVED_ROUTES[0], ("POST", "/session"));
+        assert_eq!(APPROVED_ROUTES[1], ("GET", "/session/:sessionID"));
+        assert_eq!(APPROVED_ROUTES[2], ("POST", "/session/:sessionID/command"));
+        assert_eq!(APPROVED_ROUTES[3], ("GET", "/global/health"));
+    }
+}

--- a/crates/services/opencode-rs/src/http/legacy/session.rs
+++ b/crates/services/opencode-rs/src/http/legacy/session.rs
@@ -1,0 +1,120 @@
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::http::encode_path_segment;
+use crate::types::api::CommandResponse;
+use crate::types::message::CommandRequest;
+use crate::types::session::CreateSessionRequest;
+use crate::types::session::Session;
+use reqwest::Method;
+
+#[derive(Clone)]
+pub struct SessionApi {
+    http: HttpClient,
+}
+
+impl SessionApi {
+    pub fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    /// `LEGACY_EXCEPTION(OpenCode v1.17.2)`: upstream still lacks `/api/*` session creation.
+    pub async fn create(&self, request: &CreateSessionRequest) -> Result<Session> {
+        let body = serde_json::to_value(request)?;
+        self.http
+            .request_json(Method::POST, "/session", Some(body))
+            .await
+    }
+
+    /// `LEGACY_EXCEPTION(OpenCode v1.17.2)`: upstream still lacks `/api/*` session fetch-by-id.
+    pub async fn get(&self, session_id: &str) -> Result<Session> {
+        let session_id = encode_path_segment(session_id);
+        self.http
+            .request_json(Method::GET, &format!("/session/{session_id}"), None)
+            .await
+    }
+
+    /// `LEGACY_EXCEPTION(OpenCode v1.17.2)`: upstream still lacks `/api/*` command execution.
+    pub async fn command(
+        &self,
+        session_id: &str,
+        request: &CommandRequest,
+    ) -> Result<CommandResponse> {
+        let session_id = encode_path_segment(session_id);
+        let body = serde_json::to_value(request)?;
+        self.http
+            .post_json_with_retry(&format!("/session/{session_id}/command"), Some(body))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn supports_legacy_session_create_and_get_and_command() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/session"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "session-1",
+                "slug": "session-1"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/session-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "session-1",
+                "slug": "session-1"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "queued"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let api = SessionApi::new(
+            HttpClient::new(HttpConfig {
+                base_url: mock_server.uri(),
+                directory: None,
+                workspace: None,
+                timeout: Duration::from_secs(30),
+            })
+            .unwrap(),
+        );
+
+        let created = api.create(&CreateSessionRequest::default()).await.unwrap();
+        assert_eq!(created.id, "session-1");
+
+        let fetched = api.get("session-1").await.unwrap();
+        assert_eq!(fetched.id, "session-1");
+
+        let command = api
+            .command(
+                "session-1",
+                &CommandRequest {
+                    command: "research".to_string(),
+                    arguments: "topic".to_string(),
+                    message_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(command.status.as_deref(), Some("queued"));
+    }
+}

--- a/crates/services/opencode-rs/src/http/mod.rs
+++ b/crates/services/opencode-rs/src/http/mod.rs
@@ -15,16 +15,19 @@ use crate::error::Result;
 use reqwest::Client as ReqClient;
 use reqwest::Method;
 use reqwest::Response;
+use reqwest::header::AUTHORIZATION;
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;
 use std::time::Duration;
 
+pub mod api;
 pub mod config;
 pub mod console;
 pub mod experimental_session;
 pub mod files;
 pub mod find;
 pub mod global;
+pub mod legacy;
 pub mod mcp;
 pub mod messages;
 pub mod misc;
@@ -61,6 +64,13 @@ pub struct HttpConfig {
 pub struct HttpClient {
     inner: ReqClient,
     cfg: HttpConfig,
+    auth_header: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum RequestTransport {
+    Api,
+    Legacy,
 }
 
 impl HttpClient {
@@ -80,7 +90,11 @@ impl HttpClient {
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
             ..cfg
         };
-        Ok(Self { inner, cfg })
+        Ok(Self {
+            inner,
+            cfg,
+            auth_header: None,
+        })
     }
 
     /// Create from base URL, directory, and optional existing client.
@@ -110,7 +124,17 @@ impl HttpClient {
                 workspace: None,
                 timeout,
             },
+            auth_header: None,
         })
+    }
+
+    #[must_use]
+    pub fn with_auth_header(mut self, auth_header: Option<String>) -> Self {
+        self.auth_header = auth_header.and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        });
+        self
     }
 
     /// Get the base URL.
@@ -128,17 +152,50 @@ impl HttpClient {
         self.cfg.workspace.as_deref()
     }
 
+    pub(crate) fn auth_header(&self) -> Option<&str> {
+        self.auth_header.as_deref()
+    }
+
     /// Build request with standard directory/workspace query context.
     fn build_request(&self, method: Method, path: &str) -> reqwest::RequestBuilder {
+        self.build_request_with_transport(method, path, RequestTransport::Legacy)
+    }
+
+    pub(crate) fn build_api_request(&self, method: Method, path: &str) -> reqwest::RequestBuilder {
+        self.build_request_with_transport(method, path, RequestTransport::Api)
+    }
+
+    fn build_request_with_transport(
+        &self,
+        method: Method,
+        path: &str,
+        transport: RequestTransport,
+    ) -> reqwest::RequestBuilder {
         let url = format!("{}{}", self.cfg.base_url, path);
         let mut req = self.inner.request(method, &url);
 
-        if !path.starts_with("/global/") {
-            if let Some(dir) = &self.cfg.directory {
-                req = req.query(&[("directory", dir)]);
+        if let Some(auth_header) = &self.auth_header {
+            req = req.header(AUTHORIZATION, auth_header);
+        }
+
+        match transport {
+            RequestTransport::Api => {
+                if let Some(dir) = &self.cfg.directory {
+                    req = req.header("x-opencode-directory", dir);
+                }
+                if let Some(workspace) = &self.cfg.workspace {
+                    req = req.header("x-opencode-workspace", workspace);
+                }
             }
-            if let Some(workspace) = &self.cfg.workspace {
-                req = req.query(&[("workspace", workspace)]);
+            RequestTransport::Legacy => {
+                if !path.starts_with("/global/") {
+                    if let Some(dir) = &self.cfg.directory {
+                        req = req.query(&[("directory", dir)]);
+                    }
+                    if let Some(workspace) = &self.cfg.workspace {
+                        req = req.query(&[("workspace", workspace)]);
+                    }
+                }
             }
         }
 
@@ -339,6 +396,84 @@ impl HttpClient {
         Self::check_status(resp).await
     }
 
+    pub async fn api_get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let resp = self
+            .build_api_request(Method::GET, path)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn api_post<TReq: serde::Serialize + Sync, TRes: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &TReq,
+    ) -> Result<TRes> {
+        let resp = self
+            .build_api_request(Method::POST, path)
+            .json(body)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn api_post_empty<TReq: serde::Serialize + Sync>(
+        &self,
+        path: &str,
+        body: &TReq,
+    ) -> Result<()> {
+        let resp = self
+            .build_api_request(Method::POST, path)
+            .json(body)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::check_status(resp).await
+    }
+
+    pub async fn api_request_json_with_query<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        query: &[(&str, String)],
+        body: Option<serde_json::Value>,
+    ) -> Result<T> {
+        let mut req = self.build_api_request(method, path);
+
+        if !query.is_empty() {
+            let query_pairs: Vec<(&str, &str)> = query
+                .iter()
+                .map(|(key, value)| (*key, value.as_str()))
+                .collect();
+            req = req.query(&query_pairs);
+        }
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req.send().await.map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn api_request_empty(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> Result<()> {
+        let mut req = self.build_api_request(method, path);
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req.send().await.map_err(OpencodeError::from)?;
+        Self::check_status(resp).await
+    }
+
     // ==================== Response Handling ====================
 
     /// Map response to JSON, handling errors with `NamedError` parsing.
@@ -441,6 +576,7 @@ mod tests {
     use wiremock::Mock;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
@@ -516,6 +652,56 @@ mod tests {
 
         let result: serde_json::Value = client.get("/test").await.unwrap();
         assert_eq!(result, serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_api_request_uses_opencode_location_headers() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/session"))
+            .and(header("x-opencode-directory", "/my/project"))
+            .and(header("x-opencode-workspace", "workspace-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock_server)
+            .await;
+
+        let client = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: Some("/my/project".to_string()),
+            workspace: Some("workspace-1".to_string()),
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let result: serde_json::Value = client.api_get("/api/session").await.unwrap();
+        assert_eq!(result, serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_api_request_includes_authorization_header() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/health"))
+            .and(header("authorization", "Basic dGVzdDpzZWNyZXQ="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "healthy": true
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            workspace: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap()
+        .with_auth_header(Some("Basic dGVzdDpzZWNyZXQ=".to_string()));
+
+        let result: serde_json::Value = client.api_get("/api/health").await.unwrap();
+        assert_eq!(result["healthy"], true);
     }
 
     #[tokio::test]

--- a/crates/services/opencode-rs/src/legacy_exceptions.md
+++ b/crates/services/opencode-rs/src/legacy_exceptions.md
@@ -1,0 +1,57 @@
+# OpenCode v1.17.2 legacy exception ledger
+
+This file is the authoritative local ledger for the only approved non-`/api/*`
+OpenCode routes retained during the v1.17.2 migration.
+
+## Required call-site convention
+
+Every direct usage must carry a nearby comment in this form:
+
+```rust
+// LEGACY_EXCEPTION(OpenCode v1.17.2): <why this route is still required>
+```
+
+## Allowed legacy exceptions (ONLY)
+
+1. `POST /session`
+   - Planned usage:
+     - `crates/services/opencode-rs/src/http/legacy/session.rs`
+     - `apps/opencode-orchestrator-mcp/src/tools.rs`
+   - Removal trigger:
+     - Upstream adds a supported `/api/*` session-create route.
+
+2. `GET /session/:sessionID`
+   - Planned usage:
+     - `crates/services/opencode-rs/src/http/legacy/session.rs`
+     - `apps/opencode-orchestrator-mcp/src/tools.rs`
+   - Removal trigger:
+     - Upstream adds a supported `/api/*` session fetch-by-id route.
+
+3. `POST /session/:sessionID/command`
+   - Planned usage:
+     - `crates/services/opencode-rs/src/http/legacy/session.rs`
+     - `apps/opencode-orchestrator-mcp/src/tools.rs`
+   - Removal trigger:
+     - Upstream adds a supported `/api/*` command-execution route.
+
+4. Startup-only `GET /global/health`
+   - Planned usage:
+     - `crates/services/opencode-rs/src/http/legacy/global.rs`
+     - `apps/opencode-orchestrator-mcp/src/server.rs`
+   - Removal trigger:
+     - Upstream exposes exact version information on a supported `/api/*` startup probe.
+
+## Explicitly disallowed legacy/compatibility surfaces
+
+- `session.init`
+- deprecated permission shim routes
+- legacy `/session/status`
+- legacy `/permission*`
+- legacy `/question*`
+- legacy `/provider` as the primary orchestrator runtime surface
+
+## Review guidance
+
+- If any new non-`/api/*` route is proposed, stop and get plan approval.
+- When upstream parity lands, remove the route from the SDK, orchestrator call sites,
+  and this ledger in the same change.

--- a/crates/services/opencode-rs/src/sse.rs
+++ b/crates/services/opencode-rs/src/sse.rs
@@ -74,6 +74,7 @@ pub struct SseSubscriber {
     base_url: String,
     directory: Option<String>,
     workspace: Option<String>,
+    auth_header: Option<String>,
     last_event_id: Arc<RwLock<Option<String>>>,
 }
 
@@ -85,6 +86,7 @@ impl SseSubscriber {
         base_url: String,
         directory: Option<String>,
         workspace: Option<String>,
+        auth_header: Option<String>,
         last_event_id: Arc<RwLock<Option<String>>>,
     ) -> Self {
         Self {
@@ -92,6 +94,7 @@ impl SseSubscriber {
             base_url,
             directory,
             workspace,
+            auth_header,
             last_event_id,
         }
     }
@@ -112,9 +115,12 @@ impl SseSubscriber {
     ) -> Result<SseSubscription<Event>> {
         let url = format!("{}/event", self.base_url);
         let session_id = session_id.to_string();
-        self.subscribe_filtered(url, opts, move |event: &Event| {
-            event.session_id() == Some(session_id.as_str())
-        })
+        self.subscribe_filtered(
+            url,
+            opts,
+            move |event: &Event| event.session_id() == Some(session_id.as_str()),
+            false,
+        )
     }
 
     /// Subscribe to all events for the configured directory.
@@ -127,7 +133,7 @@ impl SseSubscriber {
     /// Returns an error if the subscription cannot be created.
     pub fn subscribe(&self, opts: SseOptions) -> Result<SseSubscription<Event>> {
         let url = format!("{}/event", self.base_url);
-        self.subscribe_filtered(url, opts, |_| true)
+        self.subscribe_filtered(url, opts, |_| true, false)
     }
 
     /// Subscribe to global events (all directories).
@@ -141,7 +147,15 @@ impl SseSubscriber {
     /// Returns an error if the subscription cannot be created.
     pub fn subscribe_global(&self, opts: SseOptions) -> Result<SseSubscription<GlobalEvent>> {
         let url = format!("{}/global/event", self.base_url);
-        self.subscribe_filtered(url, opts, |_| true)
+        self.subscribe_filtered(url, opts, |_| true, false)
+    }
+
+    pub fn subscribe_api<T>(&self, path: &str, opts: SseOptions) -> Result<SseSubscription<T>>
+    where
+        T: serde::de::DeserializeOwned + Send + 'static,
+    {
+        let url = format!("{}{}", self.base_url, path);
+        self.subscribe_filtered(url, opts, |_| true, true)
     }
 
     #[expect(
@@ -153,6 +167,7 @@ impl SseSubscriber {
         url: String,
         opts: SseOptions,
         should_send: F,
+        use_api_headers: bool,
     ) -> Result<SseSubscription<T>>
     where
         T: serde::de::DeserializeOwned + Send + 'static,
@@ -165,6 +180,7 @@ impl SseSubscriber {
         let http = self.http.clone();
         let dir = self.directory.clone();
         let workspace = self.workspace.clone();
+        let auth_header = self.auth_header.clone();
         let lei = Arc::clone(&self.last_event_id);
         let initial = opts.initial_interval;
         let max = opts.max_interval;
@@ -188,13 +204,23 @@ impl SseSubscriber {
                 }
 
                 let mut req = http.get(&url);
-                if !url.ends_with("/global/event") {
+                if use_api_headers {
+                    if let Some(d) = &dir {
+                        req = req.header("x-opencode-directory", d);
+                    }
+                    if let Some(ws) = &workspace {
+                        req = req.header("x-opencode-workspace", ws);
+                    }
+                } else if !url.ends_with("/global/event") {
                     if let Some(d) = &dir {
                         req = req.query(&[("directory", d)]);
                     }
                     if let Some(ws) = &workspace {
                         req = req.query(&[("workspace", ws)]);
                     }
+                }
+                if let Some(auth_header) = &auth_header {
+                    req = req.header("Authorization", auth_header);
                 }
                 let last_id = lei.read().await.clone();
                 if let Some(id) = last_id {
@@ -294,6 +320,7 @@ mod tests {
     async fn test_subscription_cancel_on_close() {
         let subscriber = SseSubscriber::new(
             "http://localhost:9999".to_string(),
+            None,
             None,
             None,
             Arc::new(RwLock::new(None)),

--- a/crates/services/opencode-rs/src/types/mod.rs
+++ b/crates/services/opencode-rs/src/types/mod.rs
@@ -18,6 +18,7 @@ pub mod question;
 pub mod session;
 pub mod skill;
 pub mod tool;
+pub mod v2;
 
 pub use api::*;
 pub use config::*;

--- a/crates/services/opencode-rs/src/types/v2/agent.rs
+++ b/crates/services/opencode-rs/src/types/v2/agent.rs
@@ -1,0 +1,29 @@
+use crate::types::project::ModelRef;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInfo {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(default)]
+    pub request: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub mode: String,
+    #[serde(default)]
+    pub hidden: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steps: Option<u64>,
+    #[serde(default)]
+    pub permissions: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/command.rs
+++ b/crates/services/opencode-rs/src/types/v2/command.rs
@@ -1,0 +1,20 @@
+use crate::types::project::ModelRef;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandInfo {
+    pub name: String,
+    pub template: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtask: Option<bool>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/envelope.rs
+++ b/crates/services/opencode-rs/src/types/v2/envelope.rs
@@ -1,0 +1,108 @@
+use super::location::LocationInfo;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DataEnvelope<T> {
+    pub data: T,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CursorLinks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorEnvelope<T> {
+    pub data: T,
+    pub cursor: CursorLinks,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LocationEnvelope<T> {
+    pub location: LocationInfo,
+    pub data: T,
+}
+
+impl<'de, T> Deserialize<'de> for DataEnvelope<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire<T> {
+            Envelope { data: T },
+            Bare(T),
+        }
+
+        match Wire::deserialize(deserializer)? {
+            Wire::Envelope { data } | Wire::Bare(data) => Ok(Self { data }),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for CursorEnvelope<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire<T> {
+            Envelope {
+                data: T,
+                #[serde(default)]
+                cursor: CursorLinks,
+            },
+            Bare(T),
+        }
+
+        match Wire::deserialize(deserializer)? {
+            Wire::Envelope { data, cursor } => Ok(Self { data, cursor }),
+            Wire::Bare(data) => Ok(Self {
+                data,
+                cursor: CursorLinks::default(),
+            }),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for LocationEnvelope<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire<T> {
+            Envelope {
+                #[serde(default)]
+                location: LocationInfo,
+                data: T,
+            },
+            Bare(T),
+        }
+
+        match Wire::deserialize(deserializer)? {
+            Wire::Envelope { location, data } => Ok(Self { location, data }),
+            Wire::Bare(data) => Ok(Self {
+                location: LocationInfo::default(),
+                data,
+            }),
+        }
+    }
+}

--- a/crates/services/opencode-rs/src/types/v2/event.rs
+++ b/crates/services/opencode-rs/src/types/v2/event.rs
@@ -1,0 +1,56 @@
+use super::location::LocationInfo;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<LocationInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+    pub data: serde_json::Value,
+}
+
+impl Event {
+    pub fn session_id(&self) -> Option<&str> {
+        self.data
+            .get("sessionID")
+            .or_else(|| self.data.get("sessionId"))
+            .and_then(serde_json::Value::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_api_event_wrapper_shape() {
+        let event: Event = serde_json::from_str(
+            r#"{
+                "id": "evt-1",
+                "type": "question.asked",
+                "location": {"directory": "/tmp/project"},
+                "version": 2,
+                "data": {"sessionID": "session-1", "payload": "ok"}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(event.event_type, "question.asked");
+        assert_eq!(
+            event
+                .location
+                .as_ref()
+                .map(|location| location.directory.as_str()),
+            Some("/tmp/project")
+        );
+        assert_eq!(event.session_id(), Some("session-1"));
+    }
+}

--- a/crates/services/opencode-rs/src/types/v2/health.rs
+++ b/crates/services/opencode-rs/src/types/v2/health.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthInfo {
+    pub healthy: bool,
+}

--- a/crates/services/opencode-rs/src/types/v2/location.rs
+++ b/crates/services/opencode-rs/src/types/v2/location.rs
@@ -3,6 +3,17 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ProjectInfo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub directory: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LocationInfo {
     #[serde(default)]
     pub directory: String,
@@ -13,7 +24,39 @@ pub struct LocationInfo {
     )]
     pub workspace_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub project: Option<String>,
+    pub project: Option<ProjectInfo>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocationInfo;
+
+    #[test]
+    fn deserializes_project_object_shape() {
+        let location: LocationInfo = serde_json::from_value(serde_json::json!({
+            "directory": "/tmp/project",
+            "project": {
+                "id": "project-1",
+                "directory": "/tmp/project"
+            }
+        }))
+        .expect("location should deserialize");
+
+        let project = location.project.expect("project should be present");
+        assert_eq!(project.id, "project-1");
+        assert_eq!(project.directory, "/tmp/project");
+    }
+
+    #[test]
+    fn deserializes_without_project() {
+        let location: LocationInfo = serde_json::from_value(serde_json::json!({
+            "directory": "/tmp/project"
+        }))
+        .expect("location should deserialize");
+
+        assert_eq!(location.directory, "/tmp/project");
+        assert!(location.project.is_none());
+    }
 }

--- a/crates/services/opencode-rs/src/types/v2/location.rs
+++ b/crates/services/opencode-rs/src/types/v2/location.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationInfo {
+    #[serde(default)]
+    pub directory: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "workspaceID"
+    )]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/message.rs
+++ b/crates/services/opencode-rs/src/types/v2/message.rs
@@ -60,6 +60,7 @@ pub struct ToolTimeRange {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolStatePending {
+    #[serde(deserialize_with = "deserialize_pending_status")]
     pub status: String,
     #[serde(default)]
     pub input: serde_json::Value,
@@ -153,6 +154,20 @@ pub enum ContentPart {
     Unknown,
 }
 
+fn deserialize_pending_status<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let status = String::deserialize(deserializer)?;
+    if status == "pending" {
+        Ok(status)
+    } else {
+        Err(<D::Error as serde::de::Error>::custom(
+            "expected pending tool status",
+        ))
+    }
+}
+
 impl Message {
     pub fn assistant_text(&self) -> Option<String> {
         let text = self
@@ -165,5 +180,40 @@ impl Message {
             .collect::<Vec<_>>()
             .join("");
         (!text.trim().is_empty()).then_some(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ToolState;
+    use super::ToolStatePending;
+    use serde_json::json;
+
+    #[test]
+    fn tool_state_pending_deserializes_with_defaults() {
+        let state: ToolState = serde_json::from_value(json!({ "status": "pending" })).unwrap();
+
+        assert!(matches!(state, ToolState::Pending(ToolStatePending { .. })));
+    }
+
+    #[test]
+    fn tool_state_pending_deserializes_with_payload() {
+        let state: ToolState = serde_json::from_value(json!({
+            "status": "pending",
+            "input": {"tool": "read"},
+            "raw": "read file.txt"
+        }))
+        .unwrap();
+
+        assert!(matches!(state, ToolState::Pending(ToolStatePending { .. })));
+    }
+
+    #[test]
+    fn tool_state_unknown_status_falls_through_to_unknown() {
+        let state: ToolState = serde_json::from_value(json!({ "status": "queued" })).unwrap();
+
+        assert!(
+            matches!(state, ToolState::Unknown(value) if value == json!({ "status": "queued" }))
+        );
     }
 }

--- a/crates/services/opencode-rs/src/types/v2/message.rs
+++ b/crates/services/opencode-rs/src/types/v2/message.rs
@@ -1,0 +1,169 @@
+use crate::types::project::ModelRef;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "sessionID")]
+    pub session_id: Option<String>,
+    pub role: String,
+    #[serde(default)]
+    pub content: Vec<ContentPart>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<MessageTime>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageTime {
+    pub created: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    pub input: u64,
+    pub output: u64,
+    #[serde(default)]
+    pub reasoning: u64,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolTimeStart {
+    pub start: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolTimeRange {
+    pub start: i64,
+    pub end: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compacted: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolStatePending {
+    pub status: String,
+    #[serde(default)]
+    pub input: serde_json::Value,
+    #[serde(default)]
+    pub raw: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolStateRunning {
+    pub status: String,
+    #[serde(default)]
+    pub input: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub time: ToolTimeStart,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolStateCompleted {
+    pub status: String,
+    #[serde(default)]
+    pub input: serde_json::Value,
+    pub output: String,
+    pub title: String,
+    pub time: ToolTimeRange,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolStateError {
+    pub status: String,
+    #[serde(default)]
+    pub input: serde_json::Value,
+    pub error: String,
+    pub time: ToolTimeRange,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolState {
+    Completed(ToolStateCompleted),
+    Error(ToolStateError),
+    Running(ToolStateRunning),
+    Pending(ToolStatePending),
+    Unknown(serde_json::Value),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum ContentPart {
+    Text {
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        metadata: Option<serde_json::Value>,
+    },
+    Tool {
+        #[serde(rename = "callID")]
+        call_id: String,
+        tool: String,
+        #[serde(default)]
+        input: serde_json::Value,
+        #[serde(default)]
+        state: Option<ToolState>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    #[serde(rename = "step-finish")]
+    StepFinish {
+        reason: String,
+        #[serde(default)]
+        cost: f64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tokens: Option<TokenUsage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+impl Message {
+    pub fn assistant_text(&self) -> Option<String> {
+        let text = self
+            .content
+            .iter()
+            .filter_map(|part| match part {
+                ContentPart::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        (!text.trim().is_empty()).then_some(text)
+    }
+}

--- a/crates/services/opencode-rs/src/types/v2/mod.rs
+++ b/crates/services/opencode-rs/src/types/v2/mod.rs
@@ -1,0 +1,25 @@
+pub mod agent;
+pub mod command;
+pub mod envelope;
+pub mod event;
+pub mod health;
+pub mod location;
+pub mod message;
+pub mod model;
+pub mod permission;
+pub mod provider;
+pub mod question;
+pub mod session;
+
+pub use agent::*;
+pub use command::*;
+pub use envelope::*;
+pub use event::*;
+pub use health::*;
+pub use location::*;
+pub use message::*;
+pub use model::*;
+pub use permission::*;
+pub use provider::*;
+pub use question::*;
+pub use session::*;

--- a/crates/services/opencode-rs/src/types/v2/model.rs
+++ b/crates/services/opencode-rs/src/types/v2/model.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelLimit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<u64>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelInfo {
+    pub id: String,
+    #[serde(rename = "providerID")]
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<ModelLimit>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/permission.rs
+++ b/crates/services/opencode-rs/src/types/v2/permission.rs
@@ -1,0 +1,45 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionToolRef {
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "messageID")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "callID")]
+    pub call_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRequest {
+    pub id: String,
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub action: String,
+    #[serde(default)]
+    pub resources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<PermissionToolRef>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PermissionReply {
+    Once,
+    Always,
+    Reject,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionReplyRequest {
+    pub reply: PermissionReply,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/crates/services/opencode-rs/src/types/v2/provider.rs
+++ b/crates/services/opencode-rs/src/types/v2/provider.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/question.rs
+++ b/crates/services/opencode-rs/src/types/v2/question.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuestionRequest {
+    pub id: String,
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub questions: Vec<QuestionInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<QuestionToolContext>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionInfo {
+    pub question: String,
+    #[serde(default)]
+    pub header: String,
+    #[serde(default)]
+    pub options: Vec<QuestionOption>,
+    #[serde(default)]
+    pub multiple: bool,
+    #[serde(default = "default_true")]
+    pub custom: bool,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionOption {
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuestionToolContext {
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "messageID")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "callID")]
+    pub call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionReply {
+    pub answers: Vec<Vec<String>>,
+}
+
+fn default_true() -> bool {
+    true
+}

--- a/crates/services/opencode-rs/src/types/v2/session.rs
+++ b/crates/services/opencode-rs/src/types/v2/session.rs
@@ -1,0 +1,133 @@
+use super::message::Message;
+use crate::types::project::ModelRef;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTime {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compacting: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionSummary {
+    #[serde(default)]
+    pub additions: u64,
+    #[serde(default)]
+    pub deletions: u64,
+    #[serde(default)]
+    pub files: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInfo {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<SessionTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<SessionSummary>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListQuery {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+impl SessionListQuery {
+    pub fn to_query_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut query = Vec::new();
+
+        if let Some(directory) = &self.directory {
+            query.push(("directory", directory.clone()));
+        }
+        if let Some(project) = &self.project {
+            query.push(("project", project.clone()));
+        }
+        if let Some(subpath) = &self.subpath {
+            query.push(("subpath", subpath.clone()));
+        }
+        if let Some(limit) = self.limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(order) = &self.order {
+            query.push(("order", order.clone()));
+        }
+        if let Some(search) = &self.search {
+            query.push(("search", search.clone()));
+        }
+        if let Some(cursor) = &self.cursor {
+            query.push(("cursor", cursor.clone()));
+        }
+
+        query
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptInput {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub prompt: PromptInput,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptAdmitted {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+pub type SessionContext = Vec<Message>;

--- a/crates/services/opencode-rs/src/version.rs
+++ b/crates/services/opencode-rs/src/version.rs
@@ -7,7 +7,7 @@ use crate::error::OpencodeError;
 use crate::error::Result;
 
 /// Pinned opencode server version for SDK compatibility testing.
-pub const PINNED_OPENCODE_VERSION: &str = "1.15.7";
+pub const PINNED_OPENCODE_VERSION: &str = "1.17.2";
 
 /// Environment variable for the opencode binary path.
 pub const OPENCODE_BINARY_ENV: &str = "OPENCODE_BINARY";
@@ -15,9 +15,9 @@ pub const OPENCODE_BINARY_ENV: &str = "OPENCODE_BINARY";
 /// Environment variable for extra arguments between binary and `serve` command.
 ///
 /// Useful for launchers like `bunx` where the full command is:
-/// `bunx --yes opencode-ai@1.15.7 serve --hostname ... --port ...`
+/// `bunx --yes opencode-ai@1.17.2 serve --hostname ... --port ...`
 ///
-/// Example: `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7"`
+/// Example: `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2"`
 pub const OPENCODE_BINARY_ARGS_ENV: &str = "OPENCODE_BINARY_ARGS";
 
 /// Normalize a version string by stripping the `v` prefix if present.
@@ -56,9 +56,9 @@ mod tests {
 
     #[test]
     fn test_normalize_version_strips_v_prefix() {
-        assert_eq!(normalize_version("v1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("  v1.15.7  "), "1.15.7");
+        assert_eq!(normalize_version("v1.17.2"), "1.17.2");
+        assert_eq!(normalize_version("1.17.2"), "1.17.2");
+        assert_eq!(normalize_version("  v1.17.2  "), "1.17.2");
     }
 
     #[test]
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn test_validate_exact_version_rejects_mismatch() {
         assert!(validate_exact_version(Some("1.14.18")).is_err());
-        assert!(validate_exact_version(Some("1.15.0")).is_err());
+        assert!(validate_exact_version(Some("1.17.1")).is_err());
         assert!(validate_exact_version(None).is_err());
     }
 }

--- a/crates/services/opencode-rs/tests/integration.rs
+++ b/crates/services/opencode-rs/tests/integration.rs
@@ -6,7 +6,7 @@
 //!   `OPENCODE_INTEGRATION=1 cargo test -p opencode_rs --features server --test integration -- --ignored`
 //!
 //! For bunx-provisioned testing:
-//!   `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" OPENCODE_INTEGRATION=1 \
+//!   `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.2" OPENCODE_INTEGRATION=1 \
 //!    cargo test -p opencode_rs --features server --test integration -- --ignored`
 //!
 //! Without `server` feature (requires pre-running server):
@@ -16,7 +16,7 @@
 //! Environment variables:
 //!   `OPENCODE_INTEGRATION` - Must be set to run integration tests
 //!   `OPENCODE_BINARY` - Path to opencode binary or launcher (default: "opencode")
-//!   `OPENCODE_BINARY_ARGS` - Extra args for launcher (e.g., "--yes opencode-ai@1.15.7")
+//!   `OPENCODE_BINARY_ARGS` - Extra args for launcher (e.g., "--yes opencode-ai@1.17.2")
 //!   `OPENCODE_BASE_URL` - Base URL when not using managed server (default: <http://127.0.0.1:4096>)
 //!   `OPENCODE_DIRECTORY` - Directory context for requests (default: current directory)
 


### PR DESCRIPTION
Migrate opencode_rs and opencode-orchestrator-mcp to the OpenCode v1.17.2 API contract.

- add v1.17.2-native /api/* SDK modules and v2 DTOs

- isolate the approved temporary legacy route exceptions

- migrate orchestrator health, session, event, permission, question, and model flows

- update wiremock coverage and version pinning for v1.17.2


<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

The `opencode_rs` SDK and `opencode-orchestrator-mcp` were pinned to the OpenCode v1.15.7 API surface. OpenCode v1.17.2 introduced a new `/api/*` REST namespace with:
- **Envelope-based response wrappers** (`data`, `cursor`, `location` envelopes) replacing bare JSON arrays
- **Header-based directory scoping** (`x-opencode-directory`, `x-opencode-workspace`) instead of query parameters
- **Restructured DTOs** for sessions, messages, permissions, questions, models, providers, agents, commands, and events — all using `camelCase` serialization
- **New endpoints**: `POST /api/session/{id}/wait` (idle detection), `POST /api/session/{id}/compact` (context compaction), `GET /api/session/{id}/context` (message history), and `/api/event` (SSE stream)

The orchestrator needed to consume all of these new surfaces while retaining a small, approved set of legacy routes that upstream hasn't yet exposed under `/api/*`.

## What user-facing changes did I ship?

**None.** This is an internal migration — all MCP tool signatures, response shapes, and orchestration behavior are preserved. The pin bump from `1.15.7` to `1.17.2` is transparent to downstream consumers.

## How I implemented it

### 1. v2 DTO layer (`types::v2/` — 11 new modules)

All v1.17.2 types live under `opencode_rs::types::v2::*` with consistent patterns:
- `#[serde(rename_all = "camelCase")]` on every struct for the v2 wire format
- `#[serde(flatten)] pub extra: serde_json::Value` on every struct for forward-compatibility (unknown fields don't break deserialization)
- `#[non_exhaustive]` on the `ContentPart` enum to protect against new part types

Key type mappings:
| v1.15.7 | v1.17.2 |
|---|---|
| `Part` (flat enum) | `ContentPart` (tagged enum with `type` discriminator) |
| `Message { info: MessageInfo, parts }` | `v2::Message { role, content, model, tokens, time }` |
| `Event` (exhaustive variant enum) | `v2::Event` (generic: `id`, `type: String`, `data: Value`) |
| `PermissionRequest { permission, patterns }` | `v2::PermissionRequest { action, resources }` |
| `PromptRequest { parts, model, agent, no_reply, system, variant }` | `v2::PromptRequest { prompt: { text, files, agents }, delivery, resume }` |
| `SummarizeRequest` | `POST /api/session/{id}/compact` (no body) |
| `SessionStatusInfo` (Busy/Idle/Retry) | `POST /api/session/{id}/wait` (blocking idle probe) |

### 2. `/api/*` HTTP client (`http::api/` — 9 typed clients)

A new `ApiClient` facade in `http::api/mod.rs` vends typed handles for each `/api/*` resource:
- `agent(), command(), event(), health(), model(), permission(), provider(), question(), session()`

All API requests use:
- **Header-based location**: `x-opencode-directory` and `x-opencode-workspace` headers instead of query params
- **Authorization header**: `HttpClient` now supports `with_auth_header()` for authenticated deployments
- **Envelope-aware deserialization**: `DataEnvelope<T>`, `CursorEnvelope<T>`, and `LocationEnvelope<T>` use `#[serde(untagged)]` to deserialize both wrapped and unwrapped shapes (backward-compatible)

### 3. Legacy route isolation (`http::legacy/` — 2 modules + compile-time allowlist)

The `LegacyClient` exposes only the 4 routes upstream hasn't migrated:

| Route | Purpose | Removal trigger |
|---|---|---|
| `POST /session` | Create session | Upstream adds `/api/*` session-create |
| `GET /session/{id}` | Fetch session by ID | Upstream adds `/api/*` session fetch-by-id |
| `POST /session/{id}/command` | Execute named command | Upstream adds `/api/*` command execution |
| `GET /global/health` | Startup version validation | `/api/health` exposes version info |

Every legacy call site carries a `LEGACY_EXCEPTION(OpenCode v1.17.2)` comment. The approved routes are declared as a `const` array and validated by a unit test (`APPROVED_ROUTES.len() == APPROVED_ROUTE_COUNT`) — adding a new legacy route requires updating the count, making expansion intentional and auditable.

A companion document `src/legacy_exceptions.md` serves as the authoritative ledger of what's allowed and why.

### 4. Orchestrator migration (`apps/opencode-orchestrator-mcp/`)

All orchestrator HTTP calls migrated from v1.15.7 surfaces to v1.17.2:

| Flow | Before | After |
|---|---|---|
| Session creation | `client.sessions().create()` | `client.legacy().session().create()` (exception) |
| Session fetch | `client.sessions().get()` | `client.legacy().session().get()` (exception) |
| Session list | `client.sessions().list()` | `client.api().session().list(&query)` |
| Prompt dispatch | `client.messages().prompt_async()` | `client.api().session().prompt()` |
| Command dispatch | `client.messages().command()` | `client.legacy().session().command()` (exception) |
| Message history | `client.messages().list()` | `client.api().session().context()` |
| Idle detection | `client.sessions().status_for()` | `wait_probe_idle()` → `client.api().session().wait()` |
| Context compaction | `client.sessions().summarize()` | `client.api().session().compact()` |
| Permission list | `client.permissions().list()` | `client.api().permission().list_session()` |
| Permission reply | `client.permissions().reply()` | `client.api().permission().reply()` |
| Question list | `client.question().list()` | `client.api().question().list_requests()` |
| Question reply | `client.question().reply()` | `client.api().question().reply()` |
| Question reject | `client.question().reject()` | `client.api().question().reject()` |
| Agent list | `client.tools().agents()` | `client.api().agent().list()` |
| Command list | `client.tools().commands()` | `client.api().command().list()` |
| Model limits | `client.providers().list()` → nested `provider.models` | `client.api().model().list()` → flat list |
| SSE events | `client.subscribe_session()` | `client.api().event().subscribe()` |
| Health probe | `client.misc().health()` | `client.api().health().get()` |
| Startup version check | `client.misc().health()` | `client.legacy().global_health()` (exception) |

Key behavioral changes:
- **Event handling**: Replaced the exhaustive `Event` enum match (with variants like `PermissionAsked`, `QuestionAsked`, `MessagePartDelta`, `SessionIdle`, `SessionError`) with a generic event shape filtered by `event_type` string. Delta text is extracted from `event.data["delta"]`. Idle detection uses `event_type == "session.idle"`.
- **Token tracking**: New `observe_context()` method works against `v2::Message` slices, extracting token usage from `message.tokens` or `ContentPart::StepFinish { tokens }`. The old `observe_event()` and `observe_tokens()` are gated behind `#[cfg(test)]`.
- **Idle detection**: Replaced `sessions().status_for()` polling (which returned `SessionStatusInfo::Busy/Idle/Retry`) with `wait_probe_idle()` using `POST /api/session/{id}/wait` with a short timeout, collapsing the three-state status into a boolean.
- **Session list**: Now uses cursor-paginated `/api/session` with `SessionListQuery`, removed the separate `status_map` lookup (status is `None` in summaries since wait-based detection is per-session).

### 5. Wiremock integration test updates

All integration test fixtures updated to match the new endpoint paths:
- `/global/health` → `/api/health`
- `/session/{id}/prompt_async` (204) → `/api/session/{id}/prompt` (200 with `DataEnvelope<PromptAdmitted>`)
- `/session/status` → `POST /api/session/{id}/wait`
- `/permission` → `GET /api/session/{id}/permission`
- `/permission/{id}/reply` → `POST /api/session/{id}/permission/{id}/reply`
- `/question` → `GET /api/question/request`
- `/event` → `/api/event`

New tests added: `test_api_request_uses_opencode_location_headers`, `test_api_request_includes_authorization_header`, `load_model_limits_uses_api_model`, and `parses_api_event_wrapper_shape`.

### 6. Version pin bump

`PINNED_OPENCODE_VERSION`: `1.15.7` → `1.17.2`. All version strings in doc comments, test fixtures, and launcher arg examples updated to match.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] I ran the "endpoint-coverage-check" recipe and it passed
- [ ] Live recursive OpenCode integration smoke testing (spawn v1.17.2 server, exercise full orchestrator tool lifecycle end-to-end)

## Description for the changelog

### opencode_rs

- Upgrade pinned OpenCode version from 1.15.7 to 1.17.2.
- Add `types::v2` module with full DTO coverage for the v1.17.2 `/api/*` contract (agents, commands, envelopes, events, health, location, messages, models, permissions, providers, questions, sessions).
- Add `http::api` module with typed clients for each `/api/*` resource using header-based directory scoping and envelope-aware deserialization.
- Add `http::legacy` module with a compile-time allowlist of exactly 4 legacy routes (session create/fetch/command + global health) gated behind `LEGACY_EXCEPTION` annotations with documented removal triggers.
- Add `HttpClient::with_auth_header()` for authenticated deployments, propagated through API requests and SSE subscriptions.
- Add `SseSubscriber::subscribe_api()` for `/api/*` SSE streams with header-based location.

### opencode-orchestrator-mcp

- Migrate all orchestrator HTTP calls to the v1.17.2 `/api/*` surface (session list, prompt, context, permission, question, agent, command, model, event, health).
- Replace session status polling with `POST /api/session/{id}/wait` for idle detection.
- Replace `SummarizeRequest`-based summarization with `POST /api/session/{id}/compact`.
- Migrate event handling from exhaustive variant enum to generic event with string `event_type`.
- Update `TokenTracker` with `observe_context()` for v2 message token extraction.
- Update all wiremock integration test fixtures to the v1.17.2 endpoint paths.
<!-- END:describe_pr:autogen -->
