### PR TITLE
feat(agentic-tools): add opt-in schema publication profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,13 @@ just endpoint-coverage-json     # JSON output for tooling
 just schema-generate    # Regenerate agentic.schema.json from Rust types
 ```
 
+## Schema Publication Invariants
+
+- Canonical schemars generation lives in `crates/agentic-tools/core/src/schema.rs` and must stay the single source of truth for cached tool schemas.
+- Do not mutate cached canonical `Arc<Schema>` values for provider compatibility work; apply compatibility lowering only to cloned/serialized publication outputs.
+- Provider-specific or transport-specific schema fixes belong at publication/rendering boundaries such as MCP `list_tools`, not inside canonical schema generation.
+- `SchemaPublicationProfile::Canonical` must remain the default unless a caller explicitly opts into a lowered publication profile.
+
 ### Vendored Codex
 
 `vendor/codex/` is a foreign vendored subtree excluded from the root workspace. Do not edit it as a first-class workspace member.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,16 @@ See `workflow.md` -> "Code Review (/review)" for:
 - Tool isolation rules for `review_*`
 - End-to-end `/review` usage
 
+## Schema Compatibility Troubleshooting
+
+When a provider rejects a tool schema:
+
+1. Prove the emitted canonical schema first using the same registry/MCP path production uses.
+2. Check whether the failure is in canonical generation or only in a publication/rendering boundary.
+3. Keep canonical schema caching unchanged; prefer lowering cloned `serde_json::Value` output at the boundary.
+4. Default new publication behavior to canonical and require explicit opt-in for compatibility profiles.
+5. Verify nullable semantics and `outputSchema` gating separately from `inputSchema` publication changes.
+
 ## Code Style Guidelines
 
 ### Workspace Lint Conformance

--- a/crates/agentic-tools/core/CLAUDE.md
+++ b/crates/agentic-tools/core/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Briefly describe the purpose of this crate and how to use it.
+`agentic-tools-core` owns canonical tool contracts: `Tool`, `ToolRegistry`, runtime formatting, and the canonical schemars-based MCP schema generator/cache in `src/schema.rs`. When changing schema behavior here, preserve the invariant that canonical generation happens once and any provider or transport compatibility lowering happens later on cloned output.
 
 ## Quick Commands
 
@@ -30,4 +30,7 @@ cargo build -p agentic-tools-core
 
 ## Notes
 
-Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.
+- `schema::mcp_schema::cached_schema_for` and `cached_output_schema_for` are canonical cache boundaries. Do not mutate the cached `Arc<Schema>` values in place.
+- `schema::publication` is the compatibility layer for publication-time lowering on serialized JSON clones. Keep it explicit and opt-in.
+- Preserve current nullable semantics from `NullFirstOptional`; publication profiles should not silently strip null branches or rewrite canonical schema structure unless explicitly designed for that purpose.
+- If a provider compatibility issue appears, prove the canonical emitted shape first, then add the narrowest boundary-layer lowering that fixes the real failing surface.

--- a/crates/agentic-tools/core/src/lib.rs
+++ b/crates/agentic-tools/core/src/lib.rs
@@ -30,6 +30,8 @@ pub use registry::ToolRegistryBuilder;
 pub use schema::FieldConstraint;
 pub use schema::SchemaEngine;
 pub use schema::SchemaTransform;
+pub use schema::publication::SchemaPublicationProfile;
+pub use schema::publication::apply_schema_publication_profile;
 pub use tool::Tool;
 pub use tool::ToolCodec;
 

--- a/crates/agentic-tools/core/src/schema.rs
+++ b/crates/agentic-tools/core/src/schema.rs
@@ -5,6 +5,9 @@ use serde_json::Value as Json;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+#[path = "schema_publication.rs"]
+pub mod publication;
+
 /// Field-level constraint to apply to a schema.
 #[derive(Clone, Debug)]
 pub enum FieldConstraint {

--- a/crates/agentic-tools/core/src/schema_publication.rs
+++ b/crates/agentic-tools/core/src/schema_publication.rs
@@ -1,0 +1,276 @@
+use serde_json::Map;
+use serde_json::Value;
+
+const DEFS_PREFIX: &str = "#/$defs/";
+const DEFINITIONS_PREFIX: &str = "#/definitions/";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum SchemaPublicationProfile {
+    #[default]
+    Canonical,
+    InlineLocalRefs,
+}
+
+pub fn apply_schema_publication_profile(profile: SchemaPublicationProfile, schema: &mut Value) {
+    match profile {
+        SchemaPublicationProfile::Canonical => {}
+        SchemaPublicationProfile::InlineLocalRefs => {
+            let snapshot = schema.clone();
+            inline_local_refs(schema, &snapshot, &mut Vec::new());
+        }
+    }
+}
+
+fn inline_local_refs(node: &mut Value, snapshot: &Value, stack: &mut Vec<String>) {
+    if let Some(ref_path) = local_ref_path(node)
+        && !stack.contains(&ref_path)
+        && let Some(mut expanded) = expand_ref(&ref_path, snapshot, stack)
+    {
+        let siblings = ref_siblings(node);
+        merge_ref_siblings(&mut expanded, siblings);
+        *node = expanded;
+        return;
+    }
+
+    match node {
+        Value::Object(object) => {
+            for value in object.values_mut() {
+                inline_local_refs(value, snapshot, stack);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                inline_local_refs(value, snapshot, stack);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn local_ref_path(node: &Value) -> Option<String> {
+    let ref_value = node.as_object()?.get("$ref")?.as_str()?;
+    if ref_value.starts_with(DEFS_PREFIX) || ref_value.starts_with(DEFINITIONS_PREFIX) {
+        Some(ref_value.to_string())
+    } else {
+        None
+    }
+}
+
+fn expand_ref(ref_path: &str, snapshot: &Value, stack: &mut Vec<String>) -> Option<Value> {
+    let pointer = ref_path.strip_prefix('#')?;
+    let target = snapshot.pointer(pointer)?;
+
+    stack.push(ref_path.to_string());
+    let mut expanded = target.clone();
+    inline_local_refs(&mut expanded, snapshot, stack);
+    stack.pop();
+
+    Some(expanded)
+}
+
+fn ref_siblings(node: &Value) -> Map<String, Value> {
+    node.as_object()
+        .into_iter()
+        .flat_map(|object| object.iter())
+        .filter(|(key, _)| key.as_str() != "$ref")
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn merge_ref_siblings(expanded: &mut Value, siblings: Map<String, Value>) {
+    if siblings.is_empty() {
+        return;
+    }
+
+    let Some(expanded_object) = expanded.as_object_mut() else {
+        return;
+    };
+
+    for (key, value) in siblings {
+        expanded_object.insert(key, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SchemaPublicationProfile;
+    use super::apply_schema_publication_profile;
+    use serde_json::Value;
+
+    fn collect_local_refs<'a>(node: &'a Value, refs: &mut Vec<&'a str>) {
+        match node {
+            Value::Object(object) => {
+                if let Some(ref_value) = object.get("$ref").and_then(Value::as_str)
+                    && (ref_value.starts_with("#/$defs/")
+                        || ref_value.starts_with("#/definitions/"))
+                {
+                    refs.push(ref_value);
+                }
+
+                for value in object.values() {
+                    collect_local_refs(value, refs);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    collect_local_refs(value, refs);
+                }
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+        }
+    }
+
+    #[test]
+    fn canonical_profile_is_a_no_op() {
+        let original = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "item": { "$ref": "#/$defs/Item" }
+            },
+            "$defs": {
+                "Item": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            }
+        });
+        let mut actual = original.clone();
+
+        apply_schema_publication_profile(SchemaPublicationProfile::Canonical, &mut actual);
+
+        assert_eq!(actual, original);
+    }
+
+    #[test]
+    fn inline_local_refs_inlines_defs_refs() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "item": { "$ref": "#/$defs/Item" }
+            },
+            "$defs": {
+                "Item": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    },
+                    "required": ["name"]
+                }
+            }
+        });
+
+        apply_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs, &mut schema);
+
+        assert_eq!(
+            schema["properties"]["item"],
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "required": ["name"]
+            })
+        );
+    }
+
+    #[test]
+    fn inline_local_refs_inlines_definitions_refs() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "item": { "$ref": "#/definitions/Item" }
+            },
+            "definitions": {
+                "Item": {
+                    "type": "string",
+                    "enum": ["a", "b"]
+                }
+            }
+        });
+
+        apply_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs, &mut schema);
+
+        assert_eq!(
+            schema["properties"]["item"],
+            serde_json::json!({
+                "type": "string",
+                "enum": ["a", "b"]
+            })
+        );
+    }
+
+    #[test]
+    fn inline_local_refs_preserves_nullable_semantics() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "maybe_item": { "$ref": "#/$defs/MaybeItem" }
+            },
+            "$defs": {
+                "MaybeItem": {
+                    "anyOf": [
+                        { "type": "null" },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": { "type": "string" }
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+
+        apply_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs, &mut schema);
+
+        assert_eq!(
+            schema["properties"]["maybe_item"]["anyOf"],
+            serde_json::json!([
+                { "type": "null" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn inline_local_refs_leaves_cyclic_local_refs_unresolved() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "node": { "$ref": "#/$defs/Node" }
+            },
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "next": { "$ref": "#/$defs/Node" }
+                    }
+                }
+            }
+        });
+
+        apply_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs, &mut schema);
+
+        let mut refs = Vec::new();
+        collect_local_refs(&schema, &mut refs);
+        assert!(
+            refs.iter().all(|ref_value| *ref_value == "#/$defs/Node"),
+            "only the cyclic local ref should remain unresolved"
+        );
+        assert_eq!(
+            schema["properties"]["node"]["type"],
+            serde_json::json!("object")
+        );
+        assert_eq!(
+            schema["properties"]["node"]["properties"]["next"]["$ref"],
+            serde_json::json!("#/$defs/Node")
+        );
+    }
+}

--- a/crates/agentic-tools/mcp/CLAUDE.md
+++ b/crates/agentic-tools/mcp/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Briefly describe the purpose of this crate and how to use it.
+`agentic-tools-mcp` wraps `ToolRegistry` with an rmcp server. `RegistryServer::list_tools()` publishes `inputSchema` for all tools and publishes `outputSchema` only in `OutputMode::Structured` when the tool output schema is object-shaped.
 
 ## Quick Commands
 
@@ -30,4 +30,7 @@ cargo build -p agentic-tools-mcp
 
 ## Notes
 
-Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.
+- MCP schema publication is explicit: `SchemaPublicationProfile::Canonical` publishes the canonical serialized input schema unchanged, while `InlineLocalRefs` lowers only published `inputSchema` JSON.
+- Do not apply input-schema publication lowering to `outputSchema` unless separately justified; structured output gating behavior must remain unchanged.
+- When debugging provider compatibility issues, compare canonical `list_tools()` output against profiled publication output before changing core schema generation.
+- Typical opt-in usage: `RegistryServer::new(registry).with_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs)`.

--- a/crates/agentic-tools/mcp/src/server.rs
+++ b/crates/agentic-tools/mcp/src/server.rs
@@ -1,8 +1,10 @@
 //! MCP server handler backed by `ToolRegistry`.
 
+use agentic_tools_core::SchemaPublicationProfile;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use agentic_tools_core::ToolRegistry;
+use agentic_tools_core::apply_schema_publication_profile;
 use agentic_tools_core::fmt::TextOptions;
 use agentic_tools_core::fmt::fallback_text_from_json;
 use rmcp::RoleServer;
@@ -61,6 +63,7 @@ pub struct RegistryServer {
     registry: Arc<ToolRegistry>,
     allowlist: Option<HashSet<String>>,
     output_mode: OutputMode,
+    schema_publication_profile: SchemaPublicationProfile,
     text_options: TextOptions,
     name: String,
     version: String,
@@ -73,6 +76,7 @@ impl RegistryServer {
             registry,
             allowlist: None,
             output_mode: OutputMode::default(),
+            schema_publication_profile: SchemaPublicationProfile::default(),
             text_options: TextOptions::default(),
             name: "agentic-tools".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -92,6 +96,13 @@ impl RegistryServer {
     #[must_use]
     pub fn with_output_mode(mut self, mode: OutputMode) -> Self {
         self.output_mode = mode;
+        self
+    }
+
+    /// Set the input schema publication profile for MCP `list_tools` output.
+    #[must_use]
+    pub fn with_schema_publication_profile(mut self, profile: SchemaPublicationProfile) -> Self {
+        self.schema_publication_profile = profile;
         self
     }
 
@@ -134,6 +145,47 @@ impl RegistryServer {
             .collect()
     }
 
+    fn listed_tools(&self) -> Vec<m::Tool> {
+        let mut tools = vec![];
+        for name in self.registry.list_names() {
+            if !self.is_allowed(&name) {
+                continue;
+            }
+
+            let Some(erased) = self.registry.get(&name) else {
+                continue;
+            };
+
+            let input_schema = erased.input_schema();
+            let mut schema_json = serde_json::to_value(&input_schema)
+                .unwrap_or_else(|_| serde_json::json!({"type": "object"}));
+            apply_schema_publication_profile(self.schema_publication_profile, &mut schema_json);
+
+            let output_schema = if matches!(self.output_mode, OutputMode::Structured) {
+                erased.output_schema().and_then(|s| {
+                    serde_json::to_value(&s)
+                        .ok()
+                        .and_then(|v| v.as_object().cloned())
+                        .map(Arc::new)
+                })
+            } else {
+                None
+            };
+
+            let input_schema = Arc::new(schema_json.as_object().cloned().unwrap_or_default());
+            let mut tool =
+                m::Tool::new(name.clone(), erased.description(), input_schema).with_title(name);
+
+            if let Some(schema) = output_schema {
+                tool = tool.with_raw_output_schema(schema);
+            }
+
+            tools.push(tool);
+        }
+
+        tools
+    }
+
     fn is_allowed(&self, name: &str) -> bool {
         self.allowlist.as_ref().is_none_or(|set| set.contains(name))
     }
@@ -164,44 +216,7 @@ impl ServerHandler for RegistryServer {
         _ctx: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<m::ListToolsResult, m::ErrorData>> + Send + '_
     {
-        async move {
-            let mut tools = vec![];
-            for name in self.registry.list_names() {
-                if !self.is_allowed(&name) {
-                    continue;
-                }
-                if let Some(erased) = self.registry.get(&name) {
-                    let input_schema = erased.input_schema();
-                    let schema_json = serde_json::to_value(&input_schema)
-                        .unwrap_or_else(|_| serde_json::json!({"type": "object"}));
-
-                    // Include output_schema only in Structured mode (MCP compliance)
-                    let output_schema = if matches!(self.output_mode, OutputMode::Structured) {
-                        erased.output_schema().and_then(|s| {
-                            serde_json::to_value(&s)
-                                .ok()
-                                .and_then(|v| v.as_object().cloned())
-                                .map(Arc::new)
-                        })
-                    } else {
-                        None
-                    };
-
-                    let input_schema =
-                        Arc::new(schema_json.as_object().cloned().unwrap_or_default());
-                    let mut tool = m::Tool::new(name.clone(), erased.description(), input_schema)
-                        .with_title(name);
-
-                    // Attach output_schema only in Structured mode
-                    if let Some(schema) = output_schema {
-                        tool = tool.with_raw_output_schema(schema);
-                    }
-
-                    tools.push(tool);
-                }
-            }
-            Ok(m::ListToolsResult::with_all_items(tools))
-        }
+        async move { Ok(m::ListToolsResult::with_all_items(self.listed_tools())) }
     }
 
     fn call_tool(
@@ -383,6 +398,7 @@ impl ServerHandler for RegistryServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentic_tools_core::SchemaPublicationProfile;
     use agentic_tools_core::Tool;
     use agentic_tools_core::ToolError;
     use agentic_tools_core::fmt::TextFormat;
@@ -401,6 +417,41 @@ mod tests {
             .await
             .unwrap();
         result.text.unwrap()
+    }
+
+    fn collect_local_refs<'a>(node: &'a serde_json::Value, refs: &mut Vec<&'a str>) {
+        match node {
+            serde_json::Value::Object(object) => {
+                if let Some(ref_value) = object.get("$ref").and_then(serde_json::Value::as_str)
+                    && (ref_value.starts_with("#/$defs/")
+                        || ref_value.starts_with("#/definitions/"))
+                {
+                    refs.push(ref_value);
+                }
+
+                for value in object.values() {
+                    collect_local_refs(value, refs);
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    collect_local_refs(value, refs);
+                }
+            }
+            serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::String(_) => {}
+        }
+    }
+
+    fn listed_tool_json(server: &RegistryServer, tool_name: &str) -> serde_json::Value {
+        server
+            .listed_tools()
+            .into_iter()
+            .map(|tool| serde_json::to_value(&tool).unwrap())
+            .find(|tool| tool["name"] == serde_json::json!(tool_name))
+            .expect("tool should be published")
     }
 
     #[test]
@@ -501,6 +552,48 @@ mod tests {
         }
     }
 
+    #[derive(
+        serde::Serialize, serde::Deserialize, schemars::JsonSchema, Clone, Debug, PartialEq,
+    )]
+    struct SchemaProfileFileMeta {
+        filename: String,
+        description: String,
+    }
+
+    #[derive(
+        serde::Serialize, serde::Deserialize, schemars::JsonSchema, Clone, Debug, PartialEq,
+    )]
+    struct SchemaProfileInput {
+        files: Vec<SchemaProfileFileMeta>,
+    }
+
+    #[derive(
+        serde::Serialize, serde::Deserialize, schemars::JsonSchema, Clone, Debug, PartialEq,
+    )]
+    struct SchemaProfileOutput {
+        files: Vec<SchemaProfileFileMeta>,
+    }
+
+    impl TextFormat for SchemaProfileOutput {}
+
+    #[derive(Clone)]
+    struct SchemaProfileTool;
+
+    impl Tool for SchemaProfileTool {
+        type Input = SchemaProfileInput;
+        type Output = SchemaProfileOutput;
+        const NAME: &'static str = "schema_profile_tool";
+        const DESCRIPTION: &'static str = "publishes schemas with local refs";
+
+        fn call(
+            &self,
+            _input: Self::Input,
+            _ctx: &ToolContext,
+        ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+            Box::pin(async move { Ok(SchemaProfileOutput { files: Vec::new() }) })
+        }
+    }
+
     #[test]
     fn test_structured_mode_output_schema_gating() {
         // Build registry with TestObjTool
@@ -594,5 +687,70 @@ mod tests {
 
         // Default should be Text mode
         assert!(matches!(server.output_mode(), OutputMode::Text));
+    }
+
+    #[test]
+    fn test_canonical_schema_publication_preserves_local_refs_in_input_schema() {
+        let registry = Arc::new(
+            ToolRegistry::builder()
+                .register::<SchemaProfileTool, ()>(SchemaProfileTool)
+                .finish(),
+        );
+        let server = RegistryServer::new(registry);
+
+        let tool_json = listed_tool_json(&server, SchemaProfileTool::NAME);
+
+        assert_eq!(
+            tool_json["inputSchema"]["properties"]["files"]["items"]["$ref"],
+            serde_json::json!("#/$defs/SchemaProfileFileMeta")
+        );
+    }
+
+    #[test]
+    fn test_inline_local_refs_publication_removes_input_schema_local_refs() {
+        let registry = Arc::new(
+            ToolRegistry::builder()
+                .register::<SchemaProfileTool, ()>(SchemaProfileTool)
+                .finish(),
+        );
+        let server = RegistryServer::new(registry)
+            .with_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs);
+
+        let tool_json = listed_tool_json(&server, SchemaProfileTool::NAME);
+        let input_schema = &tool_json["inputSchema"];
+        let mut refs = Vec::new();
+        collect_local_refs(input_schema, &mut refs);
+
+        assert!(
+            refs.is_empty(),
+            "inline publication should remove input refs"
+        );
+        assert_eq!(
+            input_schema["properties"]["files"]["items"]["type"],
+            serde_json::json!("object")
+        );
+    }
+
+    #[test]
+    fn test_inline_local_refs_does_not_change_output_schema_publication() {
+        let registry = Arc::new(
+            ToolRegistry::builder()
+                .register::<SchemaProfileTool, ()>(SchemaProfileTool)
+                .finish(),
+        );
+        let canonical_server =
+            RegistryServer::new(Arc::clone(&registry)).with_output_mode(OutputMode::Structured);
+        let inline_server = RegistryServer::new(registry)
+            .with_output_mode(OutputMode::Structured)
+            .with_schema_publication_profile(SchemaPublicationProfile::InlineLocalRefs);
+
+        let canonical_tool = listed_tool_json(&canonical_server, SchemaProfileTool::NAME);
+        let inline_tool = listed_tool_json(&inline_server, SchemaProfileTool::NAME);
+
+        assert_eq!(
+            canonical_tool["outputSchema"]["properties"]["files"]["items"]["$ref"],
+            serde_json::json!("#/$defs/SchemaProfileFileMeta")
+        );
+        assert_eq!(inline_tool["outputSchema"], canonical_tool["outputSchema"]);
     }
 }

--- a/crates/tools/gpt5-reasoner/src/tools.rs
+++ b/crates/tools/gpt5-reasoner/src/tools.rs
@@ -102,3 +102,63 @@ pub fn build_registry(cfg: ReasoningConfig) -> ToolRegistry {
         .register::<RequestTool, ()>(RequestTool::new(cfg))
         .finish()
 }
+
+#[cfg(test)]
+mod schema_proof_tests {
+    use super::RequestInput;
+    use agentic_tools_core::Tool;
+    use agentic_tools_core::ToolContext;
+    use agentic_tools_core::ToolError;
+    use agentic_tools_core::ToolRegistry;
+    use futures::future::BoxFuture;
+
+    #[derive(Clone)]
+    struct SchemaProbeTool;
+
+    impl Tool for SchemaProbeTool {
+        type Input = RequestInput;
+        type Output = String;
+
+        const NAME: &'static str = "schema_probe_request_input";
+        const DESCRIPTION: &'static str = "Schema-only probe tool for RequestInput";
+
+        fn call(
+            &self,
+            _input: Self::Input,
+            _ctx: &ToolContext,
+        ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+            Box::pin(async { Ok(String::new()) })
+        }
+    }
+
+    #[test]
+    fn proof_request_input_files_items_refers_to_defs_filemeta() {
+        let registry = ToolRegistry::builder()
+            .register::<SchemaProbeTool, ()>(SchemaProbeTool)
+            .finish();
+
+        let erased = registry
+            .get(SchemaProbeTool::NAME)
+            .expect("schema probe tool must be registered");
+
+        let schema = erased.input_schema();
+        let json = serde_json::to_value(&schema).expect("serialize RequestInput schema");
+
+        assert_eq!(
+            json["properties"]["files"]["items"]["$ref"],
+            serde_json::json!("#/$defs/FileMeta")
+        );
+        assert_eq!(
+            json["$defs"]["FileMeta"]["type"],
+            serde_json::json!("object")
+        );
+        assert_eq!(
+            json["$defs"]["FileMeta"]["properties"]["filename"]["type"],
+            serde_json::json!("string")
+        );
+        assert_eq!(
+            json["$defs"]["FileMeta"]["properties"]["description"]["type"],
+            serde_json::json!("string")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add an explicit schema publication profile API for canonical vs inline-local-ref output
- wire MCP inputSchema publication to optionally inline local #/ and #/definitions refs on cloned JSON
- add RequestInput/FileMeta proof coverage plus MCP publication regression tests
- document canonical-schema-first and provider-boundary-lowering guidance

## Verification
- just crate-test gpt5_reasoner
- just crate-check agentic-tools-core
- just crate-test agentic-tools-core
- just crate-check agentic-tools-mcp
- just crate-test agentic-tools-mcp
- just test

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

DeepSeek/OpenCode compatibility work still had an unresolved schema-publication failure mode: MCP `inputSchema` values could expose local `#/$defs/*` and `#/definitions/*` refs directly to downstream consumers, but the repository did not yet have an explicit publication-boundary compatibility layer for lowering those refs without changing canonical schemars generation.

This PR solves that by keeping canonical schema generation and caching unchanged while adding an opt-in publication profile for MCP `inputSchema` output only. It also closes the remaining evidence gap by proving the actual emitted `gpt5_reasoner::RequestInput.files -> #/$defs/FileMeta` shape in a checked-in regression test.

## What user-facing changes did I ship?

- MCP servers built with `RegistryServer` can now opt into `SchemaPublicationProfile::InlineLocalRefs` to publish local-ref-free `inputSchema` JSON.
- Default behavior remains canonical, so existing MCP consumers keep the current schema shape unless they opt in.
- Structured `outputSchema` publication behavior is unchanged.
- Maintainer docs now describe the canonical-schema-first rule and the publication-boundary compatibility approach.

## How I implemented it

- Added a proof-first regression test in `gpt5_reasoner` that registers a schema probe tool and asserts the real emitted `RequestInput.files.items -> #/$defs/FileMeta` path plus the referenced definition contents.
- Added a new `SchemaPublicationProfile` API in `agentic-tools-core` and re-exported it from the crate root.
- Implemented cloned-JSON publication lowering in `schema_publication.rs`, with targeted handling for local `#/$defs/*` and `#/definitions/*` refs, nullable-shape preservation, and cycle-safe behavior that leaves cyclic local refs unresolved instead of recursing forever.
- Wired `RegistryServer` to accept a `with_schema_publication_profile(...)` builder option and apply the selected profile only to published MCP `inputSchema` values.
- Left `outputSchema` publication canonical and preserved existing `OutputMode::Structured` gating semantics.
- Added MCP regression tests that prove:
  - canonical publication still exposes local refs
  - `InlineLocalRefs` removes local refs from published `inputSchema`
  - `outputSchema` remains unchanged even when the input publication profile is enabled
- Updated repo and crate maintainer docs with schema publication invariants and troubleshooting guidance.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-test gpt5_reasoner`
- [x] `just crate-check agentic-tools-core`
- [x] `just crate-test agentic-tools-core`
- [x] `just crate-check agentic-tools-mcp`
- [x] `just crate-test agentic-tools-mcp`
- [x] `just test`

## Description for the changelog

Add an opt-in MCP schema publication profile that can inline local refs for published `inputSchema` values while keeping canonical schema generation and cached schemas unchanged.
<!-- END:describe_pr:autogen -->
