### PR TITLE
Upgrade OpenCode support to 1.17.4

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
       "mcp__orchestrator__list_commands",
       "mcp__orchestrator__get_session_state",
       "mcp__orchestrator__respond_permission",
-      "mcp__orchestrator__respond_question"
+      "mcp__orchestrator__respond_question",
+      "mcp__orchestrator__list_agents"
     ],
     "deny": [
       "Bash",
@@ -38,7 +39,9 @@
       "TaskUpdate",
       "EnterPlanMode",
       "ExitPlanMode",
-      "AskUserQuestion"
+      "AskUserQuestion",
+      "Workflow",
+      "DesignSync"
     ]
   }
 }

--- a/apps/opencode-orchestrator-mcp/README.md
+++ b/apps/opencode-orchestrator-mcp/README.md
@@ -16,7 +16,7 @@ just build
 
 Integration tests are `#[ignore]` by default and require a working `opencode` binary plus local provider configuration.
 
-Use the pinned v1.15.7 bunx lane for live integration validation:
+Use the pinned v1.17.4 bunx lane for live integration validation:
 
 ```bash
 just smoke-bunx-stable-version

--- a/apps/opencode-orchestrator-mcp/justfile
+++ b/apps/opencode-orchestrator-mcp/justfile
@@ -37,19 +37,19 @@ integration-test-permissions-debug:
         permission
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Stable v1.15.7 lane (bunx launcher mode, non-interactive)
+# Stable v1.17.4 lane (bunx launcher mode, non-interactive)
 # Uses --yes to skip bunx confirmation prompts for CI/automated contexts
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Full integration tests using bunx opencode-ai@1.15.7 (requires bun installed)
+# Full integration tests using bunx opencode-ai@1.17.4 (requires bun installed)
 # Ignored by default; run manually to validate stable version compatibility
 [no-exit-message]
 integration-test-bunx-stable:
-    @echo "Running integration tests with bunx --yes opencode-ai@1.15.7..."
+    @echo "Running integration tests with bunx --yes opencode-ai@1.17.4..."
     @echo "Requires: bun installed and available in PATH"
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration -- --ignored --nocapture --test-threads=1
 
@@ -58,11 +58,11 @@ integration-test-bunx-stable:
 # Note: Explicitly disables recursion guard to allow running from within orchestrator contexts
 [no-exit-message]
 smoke-bunx-stable-version:
-    @echo "Smoke test: starting managed server via bunx --yes opencode-ai@1.15.7 and validating exact version..."
+    @echo "Smoke test: starting managed server via bunx --yes opencode-ai@1.17.4 and validating exact version..."
     @echo "Requires: bun installed and available in PATH"
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration live_managed_server_reports_exact_pinned_version -- --ignored --nocapture --test-threads=1
 
@@ -71,7 +71,7 @@ integration-test-bunx-stable-verbose:
     RUST_LOG=debug,opencode_orchestrator_mcp=trace,opencode_rs=debug \
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
     cargo test -p opencode-orchestrator-mcp --test integration -- --ignored --nocapture --test-threads=1
 
@@ -82,8 +82,8 @@ integration-test-one-bunx-stable TEST="managed_server_rebuilds_after_forced_stop
     set -euxo pipefail
     : "${OPENCODE_ORCHESTRATOR_INTEGRATION:=1}"
     : "${OPENCODE_BINARY:=bunx}"
-    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.15.7}"
-    bunx --yes opencode-ai@1.15.7 --version
+    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.17.4}"
+    bunx --yes opencode-ai@1.17.4 --version
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_BINARY="$OPENCODE_BINARY" \
     OPENCODE_BINARY_ARGS="$OPENCODE_BINARY_ARGS" \

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -868,7 +868,11 @@ impl OrchestratorRunTool {
                     // This is the key fix for race conditions. If SSE missed SessionIdle,
                     // we detect completion via polling sessions().status_for(session_id).
                     match client.sessions().status_for(&session_id).await {
-                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }) => {
+                        Ok(
+                            SessionStatusInfo::Busy
+                            | SessionStatusInfo::Retry { .. }
+                            | SessionStatusInfo::Unknown,
+                        ) => {
                             last_activity_time = tokio::time::Instant::now();
                             observed_busy = true;
                             awaiting_idle_grace_check = false;
@@ -946,7 +950,11 @@ impl OrchestratorRunTool {
                             let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
                             return Ok(RunOutcome::with_tracker(output, &token_tracker));
                         }
-                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }) => {
+                        Ok(
+                            SessionStatusInfo::Busy
+                            | SessionStatusInfo::Retry { .. }
+                            | SessionStatusInfo::Unknown,
+                        ) => {
                             last_activity_time = tokio::time::Instant::now();
                             observed_busy = true;
                         }
@@ -1124,7 +1132,9 @@ impl Tool for ListSessionsTool {
                             status_map
                                 .as_ref()
                                 .map(|status_map| match status_map.get(&s.id) {
-                                    Some(SessionStatusInfo::Busy) => SessionStatusSummary::Busy,
+                                    Some(SessionStatusInfo::Busy | SessionStatusInfo::Unknown) => {
+                                        SessionStatusSummary::Busy
+                                    }
                                     Some(SessionStatusInfo::Retry {
                                         attempt,
                                         message,
@@ -1309,7 +1319,9 @@ impl Tool for GetSessionStateTool {
                 let status = match client.sessions().status_for(session_id).await.map_err(|e| {
                     ToolError::Internal(format!("Failed to get session status: {e}"))
                 })? {
-                    SessionStatusInfo::Busy => SessionStatusSummary::Busy,
+                    SessionStatusInfo::Busy | SessionStatusInfo::Unknown => {
+                        SessionStatusSummary::Busy
+                    }
                     SessionStatusInfo::Retry {
                         attempt,
                         message,

--- a/apps/opencode-orchestrator-mcp/src/version.rs
+++ b/apps/opencode-orchestrator-mcp/src/version.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 ///
 /// Supports both direct binary invocation and launcher-based invocation:
 /// - Direct: `binary = "/path/to/opencode"`, `launcher_args = []`
-/// - Launcher: `binary = "bunx"`, `launcher_args = ["--yes", "opencode-ai@1.15.7"]`
+/// - Launcher: `binary = "bunx"`, `launcher_args = ["--yes", "opencode-ai@1.17.4"]`
 #[derive(Debug, Clone)]
 pub struct LauncherConfig {
     /// Path to the binary (or launcher binary like `bunx`).
@@ -65,7 +65,7 @@ pub fn resolve_opencode_binary(base_dir: &Path) -> anyhow::Result<PathBuf> {
 /// Note: This uses simple whitespace splitting and does not support shell-style
 /// quoting. Arguments containing spaces (e.g., `--message "hello world"`) will
 /// be incorrectly split. This is acceptable for the documented use case
-/// (`--yes opencode-ai@1.15.7`).
+/// (`--yes opencode-ai@1.17.4`).
 pub fn parse_launcher_args() -> Vec<String> {
     match std::env::var(OPENCODE_BINARY_ARGS_ENV) {
         Ok(value) => {
@@ -130,9 +130,9 @@ mod tests {
 
     #[test]
     fn normalize_strips_v_prefix() {
-        assert_eq!(normalize_version("v1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("  v1.15.7 "), "1.15.7");
+        assert_eq!(normalize_version("v1.17.4"), "1.17.4");
+        assert_eq!(normalize_version("1.17.4"), "1.17.4");
+        assert_eq!(normalize_version("  v1.17.4 "), "1.17.4");
     }
 
     #[test]
@@ -166,12 +166,12 @@ mod tests {
     #[serial(env)]
     fn parse_launcher_args_splits_on_whitespace() {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
-        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7") };
-        assert_eq!(parse_launcher_args(), vec!["opencode-ai@1.15.7"]);
+        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.4") };
+        assert_eq!(parse_launcher_args(), vec!["opencode-ai@1.17.4"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
-        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "--yes opencode-ai@1.15.7") };
-        assert_eq!(parse_launcher_args(), vec!["--yes", "opencode-ai@1.15.7"]);
+        unsafe { std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "--yes opencode-ai@1.17.4") };
+        assert_eq!(parse_launcher_args(), vec!["--yes", "opencode-ai@1.17.4"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe { std::env::remove_var(OPENCODE_BINARY_ARGS_ENV) };
@@ -194,14 +194,14 @@ mod tests {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
             std::env::set_var(OPENCODE_BINARY_ENV, "bunx");
-            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7");
+            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.4");
         }
 
         let base = Path::new("/tmp/project");
         let config = resolve_launcher_config(base).unwrap();
 
         assert_eq!(config.binary, "bunx");
-        assert_eq!(config.launcher_args, vec!["opencode-ai@1.15.7"]);
+        assert_eq!(config.launcher_args, vec!["opencode-ai@1.17.4"]);
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
@@ -216,7 +216,7 @@ mod tests {
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
         unsafe {
             std::env::set_var(OPENCODE_BINARY_ENV, "   ");
-            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.15.7");
+            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.4");
         }
 
         let base = Path::new("/tmp/project");

--- a/apps/opencode-orchestrator-mcp/tests/integration.rs
+++ b/apps/opencode-orchestrator-mcp/tests/integration.rs
@@ -77,7 +77,7 @@ fn unique_tmp_path(prefix: &str) -> std::path::PathBuf {
 const PERMISSION_CONFIG_FIXTURE: &str = "opencode.permission.config.json";
 
 // NOTE: This fixture pins a concrete model ID (currently anthropic/claude-sonnet-4-5).
-// OpenCode v1.15.7 resolves model availability dynamically at runtime. If this pin is invalid
+// OpenCode v1.17.4 resolves model availability dynamically at runtime. If this pin is invalid
 // or unavailable, the server should fail loudly (no silent fallback). If needed, update the
 // fixture model string to another concrete (non-*-latest) model ID.
 struct TempFileGuard {
@@ -221,7 +221,7 @@ async fn live_managed_server_reports_exact_pinned_version() {
     let health = s.client().misc().health().await.expect("health ok");
 
     version::validate_exact_version(health.version.as_deref())
-        .expect("version must match pinned 1.15.7 target");
+        .expect("version must match pinned 1.17.4 target");
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/list_tools_wiremock.rs
@@ -37,6 +37,7 @@ use support::session_status_fixture;
 use support::sessions_list_fixture;
 use support::test_orchestrator_server;
 use support::tool_part_fixture;
+use support::unknown_status_fixture;
 
 #[tokio::test]
 async fn list_sessions_returns_session_ids() {
@@ -202,6 +203,40 @@ async fn list_sessions_marks_launched_by_you() {
 }
 
 #[tokio::test]
+async fn list_sessions_treats_unknown_status_as_busy() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+
+    Mock::given(method("GET"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sessions_list_fixture(&["ses-1"])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(session_status_fixture(&[(
+                "ses-1",
+                unknown_status_fixture(),
+            )])),
+        )
+        .mount(&mock)
+        .await;
+
+    let tool = ListSessionsTool::new(Arc::clone(&server));
+    let result = tool
+        .call(ListSessionsInput { limit: None }, &ToolContext::default())
+        .await
+        .expect("list_sessions should succeed");
+
+    assert!(matches!(
+        result.sessions[0].status,
+        Some(SessionStatusSummary::Busy)
+    ));
+}
+
+#[tokio::test]
 async fn get_session_state_returns_idle_status() {
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
@@ -337,6 +372,52 @@ async fn get_session_state_returns_retry_status() {
             next: 9876,
         } if message == "provider overloaded"
     ));
+    assert_eq!(result.path.as_deref(), Some("src/session.rs"));
+}
+
+#[tokio::test]
+async fn get_session_state_treats_unknown_status_as_busy() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(session_fixture_with_path("ses-1", Some("src/session.rs"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(session_status_fixture(&[(
+                "ses-1",
+                unknown_status_fixture(),
+            )])),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/ses-1/message"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&mock)
+        .await;
+
+    let tool = GetSessionStateTool::new(Arc::clone(&server));
+    let result = tool
+        .call(
+            GetSessionStateInput {
+                session_id: "ses-1".into(),
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect("get_session_state should succeed");
+
+    assert!(matches!(result.status, SessionStatusSummary::Busy));
     assert_eq!(result.path.as_deref(), Some("src/session.rs"));
 }
 

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -168,7 +168,7 @@ impl Respond for SequenceResponder {
 }
 
 // ============================================================================
-// JSON Fixtures matching upstream v1.15.7 `...ID` wire casing.
+// JSON Fixtures matching upstream v1.17.4 `...ID` wire casing.
 // ============================================================================
 
 /// Create a session fixture with the given session ID.
@@ -236,6 +236,11 @@ pub fn retry_status_fixture(attempt: u64, message: &str, next: u64) -> Value {
         "message": message,
         "next": next,
     })
+}
+
+/// Create an unknown status fixture entry.
+pub fn unknown_status_fixture() -> Value {
+    serde_json::json!({ "type": "paused" })
 }
 
 /// Create a permission fixture.

--- a/crates/meta/xtask/src/endpoint_coverage.rs
+++ b/crates/meta/xtask/src/endpoint_coverage.rs
@@ -5,7 +5,50 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
+use serde::Deserialize;
 use std::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct CoverageReport {
+    comparison_mode: String,
+    live_diff_performed: bool,
+    duplicate_sdk_endpoints: Vec<String>,
+    duplicate_skip_endpoints: Vec<String>,
+    overlapping_endpoints: Vec<String>,
+    missing_endpoints: Vec<String>,
+}
+
+fn validate_report(report: &CoverageReport) -> Result<()> {
+    if !report.duplicate_sdk_endpoints.is_empty() {
+        bail!(
+            "duplicate SDK endpoints found: {}",
+            report.duplicate_sdk_endpoints.join(", ")
+        );
+    }
+
+    if !report.duplicate_skip_endpoints.is_empty() {
+        bail!(
+            "duplicate skipped endpoints found: {}",
+            report.duplicate_skip_endpoints.join(", ")
+        );
+    }
+
+    if !report.overlapping_endpoints.is_empty() {
+        bail!(
+            "endpoint(s) listed in both SDK and skip sets: {}",
+            report.overlapping_endpoints.join(", ")
+        );
+    }
+
+    if report.live_diff_performed && !report.missing_endpoints.is_empty() {
+        bail!(
+            "missing live endpoints found: {}",
+            report.missing_endpoints.join(", ")
+        );
+    }
+
+    Ok(())
+}
 
 pub fn run(json: bool, check: bool) -> Result<()> {
     println!("[endpoint-coverage] Running SDK endpoint coverage analysis...");
@@ -22,7 +65,7 @@ pub fn run(json: bool, check: bool) -> Result<()> {
         "--",
     ]);
 
-    if json {
+    if json || check {
         cmd.arg("--json");
     }
 
@@ -41,18 +84,63 @@ pub fn run(json: bool, check: bool) -> Result<()> {
         );
     }
 
-    println!("{stdout}");
+    if !check {
+        println!("{stdout}");
+    }
 
     if !stderr.is_empty() {
         eprintln!("{stderr}");
     }
 
-    // In check mode, could parse output and fail if coverage is incomplete
     if check {
-        // For now, just succeed if the tool ran
-        // Future: parse JSON output and check for missing endpoints
-        println!("[endpoint-coverage] Check mode: tool ran successfully");
+        let report: CoverageReport = serde_json::from_str(&stdout)
+            .context("Failed to parse endpoint coverage JSON output")?;
+        validate_report(&report)?;
+
+        if report.live_diff_performed {
+            println!(
+                "[endpoint-coverage] Check mode: validated {} report",
+                report.comparison_mode
+            );
+        } else {
+            println!(
+                "[endpoint-coverage] Check mode: inventory-only validation passed (no live OpenAPI diff performed)"
+            );
+        }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_report_accepts_inventory_only_without_live_missing_gate() {
+        let report = CoverageReport {
+            comparison_mode: "inventory-only".to_string(),
+            live_diff_performed: false,
+            duplicate_sdk_endpoints: vec![],
+            duplicate_skip_endpoints: vec![],
+            overlapping_endpoints: vec![],
+            missing_endpoints: vec!["GET /api/example".to_string()],
+        };
+
+        validate_report(&report).unwrap();
+    }
+
+    #[test]
+    fn validate_report_rejects_overlaps() {
+        let report = CoverageReport {
+            comparison_mode: "inventory-only".to_string(),
+            live_diff_performed: false,
+            duplicate_sdk_endpoints: vec![],
+            duplicate_skip_endpoints: vec![],
+            overlapping_endpoints: vec!["GET /api/example".to_string()],
+            missing_endpoints: vec![],
+        };
+
+        assert!(validate_report(&report).is_err());
+    }
 }

--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 pub(crate) const MISE_PATH: &str = "mise.toml";
 
-const TOOL_PINS_BLOCK: &str = "claude = \"2.1.160\"\n\"github:anomalyco/opencode\" = \"1.15.7\"";
+const TOOL_PINS_BLOCK: &str = "claude = \"2.1.175\"\n\"github:anomalyco/opencode\" = \"1.17.4\"";
 
 const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("linux-x64", "x86_64-unknown-linux-gnu"),

--- a/crates/services/opencode-rs/examples/endpoint_coverage.rs
+++ b/crates/services/opencode-rs/examples/endpoint_coverage.rs
@@ -1,14 +1,8 @@
 //! Endpoint coverage tool for opencode-rs SDK.
 //!
-//! Compares SDK endpoints against the server's OpenAPI spec to identify
-//! missing, extra, and matched endpoints.
-//!
-//! Usage:
-//!   cargo run -p opencode_rs --example endpoint_coverage --features full
-//!
-//! Or with a running server:
-//!   cargo run -p opencode_rs --example endpoint_coverage --features full -- --base-url http://localhost:4096
+//! Reports the SDK endpoint inventory and any deterministic inventory issues.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::env;
 use std::process::ExitCode;
@@ -27,11 +21,13 @@ const SDK_ENDPOINTS: &[(&str, &str)] = &[
     ("POST", "/session/{id}/share"),
     ("DELETE", "/session/{id}/share"),
     ("POST", "/session/{id}/revert"),
+    ("POST", "/session/{id}/unrevert"),
     ("POST", "/session/{id}/init"),
     ("GET", "/session/{id}/diff"),
     ("GET", "/session/{id}/todo"),
     ("PATCH", "/session/{id}"),
     ("GET", "/session/status"),
+    ("GET", "/session/{id}/children"),
     // messages.rs
     ("POST", "/session/{id}/message"),
     ("GET", "/session/{id}/message"),
@@ -129,6 +125,38 @@ const SDK_ENDPOINTS: &[(&str, &str)] = &[
     ("GET", "/skill"),
     // resource.rs
     ("GET", "/experimental/resource"),
+    // v2 core groups
+    ("GET", "/api/health"),
+    ("GET", "/api/location"),
+    ("GET", "/api/session"),
+    ("POST", "/api/session"),
+    ("GET", "/api/session/{id}"),
+    ("POST", "/api/session/{id}/prompt"),
+    ("POST", "/api/session/{id}/compact"),
+    ("POST", "/api/session/{id}/wait"),
+    ("GET", "/api/session/{id}/context"),
+    ("GET", "/api/session/{id}/message"),
+    ("GET", "/api/model"),
+    ("GET", "/api/provider"),
+    ("GET", "/api/provider/{id}"),
+    ("GET", "/api/permission/request"),
+    ("GET", "/api/session/{id}/permission"),
+    ("POST", "/api/session/{id}/permission/{requestId}/reply"),
+    ("GET", "/api/question/request"),
+    ("GET", "/api/session/{id}/question"),
+    ("POST", "/api/session/{id}/question/{requestId}/reply"),
+    ("POST", "/api/session/{id}/question/{requestId}/reject"),
+    // v2 optional additive groups
+    ("GET", "/api/connector"),
+    ("GET", "/api/connector/{id}"),
+    ("POST", "/api/connector/{id}/connect/key"),
+    ("POST", "/api/connector/{id}/connect/oauth"),
+    ("GET", "/api/connector/oauth/{attemptId}"),
+    ("POST", "/api/connector/oauth/{attemptId}/complete"),
+    ("DELETE", "/api/connector/oauth/{attemptId}"),
+    ("GET", "/api/fs/list"),
+    ("GET", "/api/fs/find"),
+    ("GET", "/api/reference"),
 ];
 
 /// Endpoints intentionally not implemented in SDK.
@@ -149,13 +177,16 @@ const SKIP_ENDPOINTS: &[(&str, &str)] = &[
     ("POST", "/tui/picker"),
     ("POST", "/tui/prompt"),
     ("POST", "/tui/auth_complete"),
+    // Explicitly deferred optional V2 coverage
+    ("GET", "/api/fs/read/{path}"),
+    ("GET", "/api/event"),
+    ("GET", "/api/permission/saved"),
+    ("DELETE", "/api/permission/saved/{id}"),
 ];
 
 fn normalize_path(path: &str) -> String {
-    // Convert OpenAPI path params like {sessionID} to {id} for comparison
     let mut normalized = path.to_string();
 
-    // Common normalizations
     normalized = normalized.replace("{sessionID}", "{id}");
     normalized = normalized.replace("{sessionId}", "{id}");
     normalized = normalized.replace("{messageID}", "{messageId}");
@@ -168,28 +199,40 @@ fn normalize_path(path: &str) -> String {
     normalized = normalized.replace("{skillID}", "{id}");
     normalized = normalized.replace("{providerID}", "{id}");
     normalized = normalized.replace("{mcpID}", "{id}");
+    normalized = normalized.replace("{requestID}", "{requestId}");
+    normalized = normalized.replace("{connectorID}", "{id}");
+    normalized = normalized.replace("{attemptID}", "{attemptId}");
+    normalized = normalized.replace('*', "{path}");
 
     normalized
+}
+
+fn duplicate_entries(entries: &[(&str, &str)]) -> Vec<String> {
+    let mut counts = BTreeMap::new();
+    for (method, path) in entries {
+        let key = format!("{} {}", method, normalize_path(path));
+        *counts.entry(key).or_insert(0usize) += 1;
+    }
+
+    counts
+        .into_iter()
+        .filter_map(|(key, count)| (count > 1).then_some(key))
+        .collect()
 }
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
 
-    // Check for --help
     if args.iter().any(|a| a == "--help" || a == "-h") {
-        println!("Usage: endpoint_coverage [--base-url URL] [--json]");
+        println!("Usage: endpoint_coverage [--json]");
         println!();
         println!("Options:");
-        println!("  --base-url URL   Server base URL (default: starts managed server)");
         println!("  --json           Output results as JSON");
         println!("  --help, -h       Show this help message");
         return ExitCode::SUCCESS;
     }
 
     let json_output = args.iter().any(|a| a == "--json");
-
-    // For now, just output the SDK endpoints list
-    // Full implementation would fetch from server and compare
 
     let sdk_set: BTreeSet<(String, String)> = SDK_ENDPOINTS
         .iter()
@@ -201,31 +244,67 @@ fn main() -> ExitCode {
         .map(|(m, p)| (m.to_string(), normalize_path(p)))
         .collect();
 
+    let duplicate_sdk_endpoints = duplicate_entries(SDK_ENDPOINTS);
+    let duplicate_skip_endpoints = duplicate_entries(SKIP_ENDPOINTS);
+    let overlapping_endpoints: Vec<String> = sdk_set
+        .intersection(&skip_set)
+        .map(|(method, path)| format!("{method} {path}"))
+        .collect();
+
     if json_output {
         let output = serde_json::json!({
+            "comparison_mode": "inventory-only",
+            "live_diff_performed": false,
             "sdk_endpoints": sdk_set.iter().map(|(m, p)| format!("{m} {p}")).collect::<Vec<_>>(),
             "skipped_endpoints": skip_set.iter().map(|(m, p)| format!("{m} {p}")).collect::<Vec<_>>(),
             "sdk_count": sdk_set.len(),
             "skipped_count": skip_set.len(),
+            "duplicate_sdk_endpoints": duplicate_sdk_endpoints,
+            "duplicate_skip_endpoints": duplicate_skip_endpoints,
+            "overlapping_endpoints": overlapping_endpoints,
+            "missing_endpoints": Vec::<String>::new(),
+            "extra_endpoints": Vec::<String>::new(),
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     } else {
         println!("=== SDK Endpoint Coverage Report ===");
         println!();
-        println!("SDK Endpoints ({}):", sdk_set.len());
+        println!("Mode: inventory-only (no live OpenAPI diff performed)");
+        println!();
+        println!("SDK Endpoints ({})", sdk_set.len());
         for (method, path) in &sdk_set {
             println!("  {method} {path}");
         }
         println!();
-        println!("Intentionally Skipped ({}):", skip_set.len());
+        println!("Intentionally Skipped ({})", skip_set.len());
         for (method, path) in &skip_set {
             println!("  {method} {path}");
         }
         println!();
-        println!("Note: Run with a live server to compare against OpenAPI spec.");
-        println!(
-            "      cargo run -p opencode_rs --example endpoint_coverage --features full -- --base-url http://localhost:4096"
-        );
+
+        if !duplicate_sdk_endpoints.is_empty() {
+            println!("Duplicate SDK endpoints:");
+            for endpoint in &duplicate_sdk_endpoints {
+                println!("  {endpoint}");
+            }
+            println!();
+        }
+        if !duplicate_skip_endpoints.is_empty() {
+            println!("Duplicate skipped endpoints:");
+            for endpoint in &duplicate_skip_endpoints {
+                println!("  {endpoint}");
+            }
+            println!();
+        }
+        if !overlapping_endpoints.is_empty() {
+            println!("Overlapping SDK/skipped endpoints:");
+            for endpoint in &overlapping_endpoints {
+                println!("  {endpoint}");
+            }
+            println!();
+        }
+
+        println!("Live OpenAPI diff is not implemented in this upgrade slice.");
     }
 
     ExitCode::SUCCESS

--- a/crates/services/opencode-rs/examples/endpoint_coverage.rs
+++ b/crates/services/opencode-rs/examples/endpoint_coverage.rs
@@ -265,7 +265,13 @@ fn main() -> ExitCode {
             "missing_endpoints": Vec::<String>::new(),
             "extra_endpoints": Vec::<String>::new(),
         });
-        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        match serde_json::to_string_pretty(&output) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("Failed to serialize JSON output: {error}");
+                return ExitCode::FAILURE;
+            }
+        }
     } else {
         println!("=== SDK Endpoint Coverage Report ===");
         println!();

--- a/crates/services/opencode-rs/justfile
+++ b/crates/services/opencode-rs/justfile
@@ -9,7 +9,7 @@ integration-test-bunx-stable:
     #!/usr/bin/env bash
     set -euxo pipefail
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration -- --ignored --nocapture --test-threads=1
 
@@ -19,7 +19,7 @@ smoke-bunx-version:
     #!/usr/bin/env bash
     set -euxo pipefail
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration test_health_returns_pinned_version -- --ignored --nocapture
 
@@ -30,7 +30,7 @@ integration-test-bunx-verbose:
     set -euxo pipefail
     RUST_LOG=opencode_rs=debug \
     OPENCODE_BINARY=bunx \
-    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" \
+    OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
     OPENCODE_INTEGRATION=1 \
     cargo test -p opencode_rs --features server --test integration -- --ignored --nocapture --test-threads=1
 
@@ -41,8 +41,8 @@ launcher-orphan-cleanup-regression:
     set -euxo pipefail
     : "${OPENCODE_INTEGRATION:=1}"
     : "${OPENCODE_BINARY:=bunx}"
-    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.15.7}"
-    bunx --yes opencode-ai@1.15.7 --version
+    : "${OPENCODE_BINARY_ARGS:=--yes opencode-ai@1.17.4}"
+    bunx --yes opencode-ai@1.17.4 --version
     OPENCODE_ORCHESTRATOR_MANAGED=0 \
     OPENCODE_INTEGRATION="$OPENCODE_INTEGRATION" \
     OPENCODE_BINARY="$OPENCODE_BINARY" \

--- a/crates/services/opencode-rs/src/client.rs
+++ b/crates/services/opencode-rs/src/client.rs
@@ -239,6 +239,12 @@ impl Client {
         crate::http::misc::MiscApi::new(self.http.clone())
     }
 
+    /// Get the parallel V2 API surface.
+    #[cfg(feature = "http")]
+    pub fn v2(&self) -> crate::http::v2::V2Client {
+        crate::http::v2::V2Client::new(self.http.clone())
+    }
+
     /// Get the question API.
     #[cfg(feature = "http")]
     pub fn question(&self) -> crate::http::question::QuestionApi {

--- a/crates/services/opencode-rs/src/http/messages.rs
+++ b/crates/services/opencode-rs/src/http/messages.rs
@@ -88,7 +88,7 @@ impl MessagesApi {
     ///
     /// Uses transport-level retry for transient network failures (connect/timeout).
     ///
-    /// Live verification against `OpenCode` 1.15.7 must confirm whether command
+    /// Live verification against `OpenCode` 1.17.4 must confirm whether command
     /// dispatch dedupes by `messageID`. Until that contract is revalidated,
     /// callers should treat this endpoint as at-least-once, not exactly-once:
     /// if the server has already started executing the command before a

--- a/crates/services/opencode-rs/src/http/mod.rs
+++ b/crates/services/opencode-rs/src/http/mod.rs
@@ -40,6 +40,7 @@ pub mod skills;
 pub mod sync;
 pub mod tools;
 pub mod tui;
+pub mod v2;
 pub mod workspaces;
 pub mod worktree;
 

--- a/crates/services/opencode-rs/src/http/sessions.rs
+++ b/crates/services/opencode-rs/src/http/sessions.rs
@@ -134,16 +134,7 @@ impl SessionsApi {
 
         let active: Vec<String> = map
             .into_iter()
-            .filter_map(|(sid, status)| {
-                if matches!(
-                    status,
-                    SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. }
-                ) {
-                    Some(sid)
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(sid, status)| status.is_busy_like().then_some(sid))
             .collect();
 
         let busy = !active.is_empty();
@@ -543,6 +534,33 @@ mod tests {
 
         assert!(status.busy);
         assert!(status.active_session_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_status_treats_unknown_as_busy() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "s1": {"type": "paused"}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            workspace: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let sessions = SessionsApi::new(http);
+        let status = sessions.status().await.unwrap();
+
+        assert!(status.busy);
+        assert_eq!(status.active_session_id.as_deref(), Some("s1"));
     }
 
     #[tokio::test]

--- a/crates/services/opencode-rs/src/http/v2/connector.rs
+++ b/crates/services/opencode-rs/src/http/v2/connector.rs
@@ -1,0 +1,78 @@
+//! V2 connector API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct ConnectorApi {
+    http: super::V2HttpClient,
+}
+
+impl ConnectorApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        self.http.get("/api/connector").await
+    }
+
+    pub async fn get(
+        &self,
+        connector_id: &str,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Option<serde_json::Value>>>
+    {
+        let cid = encode_path_segment(connector_id);
+        self.http.get(&format!("/api/connector/{cid}")).await
+    }
+
+    pub async fn connect_key(
+        &self,
+        connector_id: &str,
+        req: &serde_json::Value,
+    ) -> crate::error::Result<()> {
+        let cid = encode_path_segment(connector_id);
+        self.http
+            .post_empty(&format!("/api/connector/{cid}/connect/key"), req)
+            .await
+    }
+
+    pub async fn connect_oauth_begin(
+        &self,
+        connector_id: &str,
+        req: &serde_json::Value,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<serde_json::Value>> {
+        let cid = encode_path_segment(connector_id);
+        self.http
+            .post(&format!("/api/connector/{cid}/connect/oauth"), req)
+            .await
+    }
+
+    pub async fn oauth_status(
+        &self,
+        attempt_id: &str,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<serde_json::Value>> {
+        let aid = encode_path_segment(attempt_id);
+        self.http.get(&format!("/api/connector/oauth/{aid}")).await
+    }
+
+    pub async fn oauth_complete(
+        &self,
+        attempt_id: &str,
+        req: &serde_json::Value,
+    ) -> crate::error::Result<()> {
+        let aid = encode_path_segment(attempt_id);
+        self.http
+            .post_empty(&format!("/api/connector/oauth/{aid}/complete"), req)
+            .await
+    }
+
+    pub async fn oauth_cancel(&self, attempt_id: &str) -> crate::error::Result<()> {
+        let aid = encode_path_segment(attempt_id);
+        self.http
+            .delete_empty(&format!("/api/connector/oauth/{aid}"))
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/fs.rs
+++ b/crates/services/opencode-rs/src/http/v2/fs.rs
@@ -1,0 +1,41 @@
+//! V2 filesystem API.
+
+#[derive(Clone)]
+pub struct FsApi {
+    http: super::V2HttpClient,
+}
+
+impl FsApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+        path: Option<&str>,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        let mut query = Vec::new();
+        if let Some(path) = path {
+            query.push(("path", path.to_string()));
+        }
+        self.http.get_with_query("/api/fs/list", &query).await
+    }
+
+    pub async fn find(
+        &self,
+        query_text: &str,
+        entry_type: Option<&str>,
+        limit: Option<u64>,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        let mut query = vec![("query", query_text.to_string())];
+        if let Some(entry_type) = entry_type {
+            query.push(("type", entry_type.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        self.http.get_with_query("/api/fs/find", &query).await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/health.rs
+++ b/crates/services/opencode-rs/src/http/v2/health.rs
@@ -1,0 +1,16 @@
+//! V2 health API.
+
+#[derive(Clone)]
+pub struct HealthApi {
+    http: super::V2HttpClient,
+}
+
+impl HealthApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn get(&self) -> crate::error::Result<crate::types::v2::health::Health> {
+        self.http.get("/api/health").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/location.rs
+++ b/crates/services/opencode-rs/src/http/v2/location.rs
@@ -1,0 +1,16 @@
+//! V2 location API.
+
+#[derive(Clone)]
+pub struct LocationApi {
+    http: super::V2HttpClient,
+}
+
+impl LocationApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn get(&self) -> crate::error::Result<crate::types::v2::location::Location> {
+        self.http.get("/api/location").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/message.rs
+++ b/crates/services/opencode-rs/src/http/v2/message.rs
@@ -1,0 +1,29 @@
+//! V2 message API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct MessageApi {
+    http: super::V2HttpClient,
+}
+
+impl MessageApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+        session_id: &str,
+        cursor: Option<&str>,
+    ) -> crate::error::Result<crate::types::v2::common::CursorResponse<serde_json::Value>> {
+        let sid = encode_path_segment(session_id);
+        let mut query = Vec::new();
+        if let Some(cursor) = cursor {
+            query.push(("cursor", cursor.to_string()));
+        }
+        self.http
+            .get_with_query(&format!("/api/session/{sid}/message"), &query)
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/mod.rs
+++ b/crates/services/opencode-rs/src/http/v2/mod.rs
@@ -1,0 +1,279 @@
+//! Parallel V2 HTTP client surface for `/api/*` endpoints.
+//!
+//! Intentionally deferred in this additive layer:
+//! - `/api/fs/read/*` raw binary responses
+//! - `/api/event` SSE streaming transport
+
+use crate::error::OpencodeError;
+use crate::error::Result;
+use reqwest::Method;
+use reqwest::Response;
+use serde::de::DeserializeOwned;
+
+pub mod connector;
+pub mod fs;
+pub mod health;
+pub mod location;
+pub mod message;
+pub mod model;
+pub mod permission;
+pub mod provider;
+pub mod question;
+pub mod reference;
+pub mod session;
+
+#[derive(Clone)]
+pub struct V2Client {
+    http: V2HttpClient,
+}
+
+impl V2Client {
+    pub(crate) fn new(legacy: super::HttpClient) -> Self {
+        Self {
+            http: V2HttpClient::from_legacy(legacy),
+        }
+    }
+
+    pub fn http(&self) -> &V2HttpClient {
+        &self.http
+    }
+
+    pub fn health(&self) -> health::HealthApi {
+        health::HealthApi::new(self.http.clone())
+    }
+
+    pub fn connector(&self) -> connector::ConnectorApi {
+        connector::ConnectorApi::new(self.http.clone())
+    }
+
+    pub fn fs(&self) -> fs::FsApi {
+        fs::FsApi::new(self.http.clone())
+    }
+
+    pub fn location(&self) -> location::LocationApi {
+        location::LocationApi::new(self.http.clone())
+    }
+
+    pub fn session(&self) -> session::SessionApi {
+        session::SessionApi::new(self.http.clone())
+    }
+
+    pub fn message(&self) -> message::MessageApi {
+        message::MessageApi::new(self.http.clone())
+    }
+
+    pub fn model(&self) -> model::ModelApi {
+        model::ModelApi::new(self.http.clone())
+    }
+
+    pub fn provider(&self) -> provider::ProviderApi {
+        provider::ProviderApi::new(self.http.clone())
+    }
+
+    pub fn permission(&self) -> permission::PermissionApi {
+        permission::PermissionApi::new(self.http.clone())
+    }
+
+    pub fn question(&self) -> question::QuestionApi {
+        question::QuestionApi::new(self.http.clone())
+    }
+
+    pub fn reference(&self) -> reference::ReferenceApi {
+        reference::ReferenceApi::new(self.http.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct V2HttpClient {
+    inner: reqwest::Client,
+    base_url: String,
+    directory: Option<String>,
+    workspace: Option<String>,
+}
+
+impl V2HttpClient {
+    fn from_legacy(legacy: super::HttpClient) -> Self {
+        Self {
+            inner: legacy.inner,
+            base_url: legacy.cfg.base_url,
+            directory: legacy.cfg.directory,
+            workspace: legacy.cfg.workspace,
+        }
+    }
+
+    fn build_request(&self, method: Method, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", self.base_url, path);
+        let mut req = self.inner.request(method, &url);
+
+        if let Some(directory) = &self.directory {
+            req = req.query(&[("location[directory]", directory)]);
+        }
+
+        if let Some(workspace) = &self.workspace {
+            req = req.query(&[("location[workspace]", workspace)]);
+        }
+
+        req
+    }
+
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let resp = self
+            .build_request(Method::GET, path)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn get_with_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<T> {
+        let mut req = self.build_request(Method::GET, path);
+        if !query.is_empty() {
+            let query_pairs: Vec<(&str, &str)> = query
+                .iter()
+                .map(|(key, value)| (*key, value.as_str()))
+                .collect();
+            req = req.query(&query_pairs);
+        }
+
+        let resp = req.send().await.map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn post<TReq: serde::Serialize + Sync, TRes: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &TReq,
+    ) -> Result<TRes> {
+        let resp = self
+            .build_request(Method::POST, path)
+            .json(body)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::map_json_response(resp).await
+    }
+
+    pub async fn post_empty<TReq: serde::Serialize + Sync>(
+        &self,
+        path: &str,
+        body: &TReq,
+    ) -> Result<()> {
+        let resp = self
+            .build_request(Method::POST, path)
+            .json(body)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::check_status(resp).await
+    }
+
+    pub async fn delete_empty(&self, path: &str) -> Result<()> {
+        let resp = self
+            .build_request(Method::DELETE, path)
+            .send()
+            .await
+            .map_err(OpencodeError::from)?;
+        Self::check_status(resp).await
+    }
+
+    async fn map_json_response<T: DeserializeOwned>(resp: Response) -> Result<T> {
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(OpencodeError::from)?;
+
+        if !status.is_success() {
+            let body_text = String::from_utf8_lossy(&bytes);
+            return Err(OpencodeError::http(status.as_u16(), &body_text));
+        }
+
+        serde_json::from_slice(&bytes).map_err(OpencodeError::from)
+    }
+
+    async fn check_status(resp: Response) -> Result<()> {
+        let status = resp.status();
+
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(OpencodeError::http(status.as_u16(), &body));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpClient;
+    use crate::http::HttpConfig;
+    use std::time::Duration;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+    use wiremock::matchers::query_param;
+
+    #[tokio::test]
+    async fn v2_requests_use_location_query_without_legacy_query_keys() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/location"))
+            .and(query_param("location[directory]", "/tmp/project"))
+            .and(query_param("location[workspace]", "workspace-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock_server)
+            .await;
+
+        let legacy = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: Some("/tmp/project".to_string()),
+            workspace: Some("workspace-1".to_string()),
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let client = V2Client::new(legacy);
+        let _: serde_json::Value = client.http().get("/api/location").await.unwrap();
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let url = &requests[0].url;
+        let query = url.query().unwrap_or_default();
+        assert!(query.contains("location%5Bdirectory%5D=%2Ftmp%2Fproject"));
+        assert!(query.contains("location%5Bworkspace%5D=workspace-1"));
+        assert!(!query.contains("directory=%2Ftmp%2Fproject"));
+        assert!(!query.contains("workspace=workspace-1"));
+    }
+
+    #[tokio::test]
+    async fn v2_requests_preserve_additional_query_parameters() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/session"))
+            .and(query_param("location[directory]", "/tmp/project"))
+            .and(query_param("cursor", "next-page"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock_server)
+            .await;
+
+        let legacy = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: Some("/tmp/project".to_string()),
+            workspace: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+
+        let client = V2Client::new(legacy);
+        let _: serde_json::Value = client
+            .http()
+            .get_with_query("/api/session", &[("cursor", "next-page".to_string())])
+            .await
+            .unwrap();
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/model.rs
+++ b/crates/services/opencode-rs/src/http/v2/model.rs
@@ -1,0 +1,19 @@
+//! V2 model API.
+
+#[derive(Clone)]
+pub struct ModelApi {
+    http: super::V2HttpClient,
+}
+
+impl ModelApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        self.http.get("/api/model").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/permission.rs
+++ b/crates/services/opencode-rs/src/http/v2/permission.rs
@@ -1,0 +1,51 @@
+//! V2 permission API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct PermissionApi {
+    http: super::V2HttpClient,
+}
+
+impl PermissionApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list_requests(
+        &self,
+    ) -> crate::error::Result<
+        crate::types::v2::common::LocationResponse<
+            Vec<crate::types::v2::permission::PermissionRequest>,
+        >,
+    > {
+        self.http.get("/api/permission/request").await
+    }
+
+    pub async fn list_session_requests(
+        &self,
+        session_id: &str,
+    ) -> crate::error::Result<
+        crate::types::v2::common::DataResponse<
+            Vec<crate::types::v2::permission::PermissionRequest>,
+        >,
+    > {
+        let sid = encode_path_segment(session_id);
+        self.http
+            .get(&format!("/api/session/{sid}/permission"))
+            .await
+    }
+
+    pub async fn reply(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        req: &crate::types::v2::permission::PermissionReplyRequest,
+    ) -> crate::error::Result<()> {
+        let sid = encode_path_segment(session_id);
+        let rid = encode_path_segment(request_id);
+        self.http
+            .post_empty(&format!("/api/session/{sid}/permission/{rid}/reply"), req)
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/provider.rs
+++ b/crates/services/opencode-rs/src/http/v2/provider.rs
@@ -1,0 +1,29 @@
+//! V2 provider API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct ProviderApi {
+    http: super::V2HttpClient,
+}
+
+impl ProviderApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        self.http.get("/api/provider").await
+    }
+
+    pub async fn get(
+        &self,
+        provider_id: &str,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<serde_json::Value>> {
+        let pid = encode_path_segment(provider_id);
+        self.http.get(&format!("/api/provider/{pid}")).await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/question.rs
+++ b/crates/services/opencode-rs/src/http/v2/question.rs
@@ -1,0 +1,58 @@
+//! V2 question API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct QuestionApi {
+    http: super::V2HttpClient,
+}
+
+impl QuestionApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list_requests(
+        &self,
+    ) -> crate::error::Result<
+        crate::types::v2::common::LocationResponse<
+            Vec<crate::types::v2::question::QuestionRequest>,
+        >,
+    > {
+        self.http.get("/api/question/request").await
+    }
+
+    pub async fn list_session_requests(
+        &self,
+        session_id: &str,
+    ) -> crate::error::Result<
+        crate::types::v2::common::DataResponse<Vec<crate::types::v2::question::QuestionRequest>>,
+    > {
+        let sid = encode_path_segment(session_id);
+        self.http.get(&format!("/api/session/{sid}/question")).await
+    }
+
+    pub async fn reply(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        req: &crate::types::v2::question::QuestionReply,
+    ) -> crate::error::Result<()> {
+        let sid = encode_path_segment(session_id);
+        let rid = encode_path_segment(request_id);
+        self.http
+            .post_empty(&format!("/api/session/{sid}/question/{rid}/reply"), req)
+            .await
+    }
+
+    pub async fn reject(&self, session_id: &str, request_id: &str) -> crate::error::Result<()> {
+        let sid = encode_path_segment(session_id);
+        let rid = encode_path_segment(request_id);
+        self.http
+            .post_empty(
+                &format!("/api/session/{sid}/question/{rid}/reject"),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/reference.rs
+++ b/crates/services/opencode-rs/src/http/v2/reference.rs
@@ -1,0 +1,19 @@
+//! V2 reference API.
+
+#[derive(Clone)]
+pub struct ReferenceApi {
+    http: super::V2HttpClient,
+}
+
+impl ReferenceApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+    ) -> crate::error::Result<crate::types::v2::common::LocationResponse<Vec<serde_json::Value>>>
+    {
+        self.http.get("/api/reference").await
+    }
+}

--- a/crates/services/opencode-rs/src/http/v2/session.rs
+++ b/crates/services/opencode-rs/src/http/v2/session.rs
@@ -1,0 +1,82 @@
+//! V2 session API.
+
+use crate::http::encode_path_segment;
+
+#[derive(Clone)]
+pub struct SessionApi {
+    http: super::V2HttpClient,
+}
+
+impl SessionApi {
+    pub(crate) fn new(http: super::V2HttpClient) -> Self {
+        Self { http }
+    }
+
+    pub async fn list(
+        &self,
+        params: &crate::types::v2::session::SessionListParams,
+    ) -> crate::error::Result<
+        crate::types::v2::common::CursorResponse<crate::types::v2::session::SessionV2Info>,
+    > {
+        self.http
+            .get_with_query("/api/session", &params.to_query_pairs())
+            .await
+    }
+
+    pub async fn create(
+        &self,
+        req: &crate::types::v2::session::CreateSessionRequest,
+    ) -> crate::error::Result<
+        crate::types::v2::common::DataResponse<crate::types::v2::session::SessionV2Info>,
+    > {
+        self.http.post("/api/session", req).await
+    }
+
+    pub async fn get(
+        &self,
+        session_id: &str,
+    ) -> crate::error::Result<
+        crate::types::v2::common::DataResponse<crate::types::v2::session::SessionV2Info>,
+    > {
+        let sid = encode_path_segment(session_id);
+        self.http.get(&format!("/api/session/{sid}")).await
+    }
+
+    pub async fn prompt(
+        &self,
+        session_id: &str,
+        req: &crate::types::v2::session::SessionPromptRequest,
+    ) -> crate::error::Result<
+        crate::types::v2::common::DataResponse<crate::types::v2::session::SessionInputAdmitted>,
+    > {
+        let sid = encode_path_segment(session_id);
+        self.http
+            .post(&format!("/api/session/{sid}/prompt"), req)
+            .await
+    }
+
+    pub async fn compact(&self, session_id: &str) -> crate::error::Result<()> {
+        let sid = encode_path_segment(session_id);
+        self.http
+            .post_empty(
+                &format!("/api/session/{sid}/compact"),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    pub async fn wait(&self, session_id: &str) -> crate::error::Result<()> {
+        let sid = encode_path_segment(session_id);
+        self.http
+            .post_empty(&format!("/api/session/{sid}/wait"), &serde_json::json!({}))
+            .await
+    }
+
+    pub async fn context(
+        &self,
+        session_id: &str,
+    ) -> crate::error::Result<crate::types::v2::common::DataResponse<Vec<serde_json::Value>>> {
+        let sid = encode_path_segment(session_id);
+        self.http.get(&format!("/api/session/{sid}/context")).await
+    }
+}

--- a/crates/services/opencode-rs/src/types/mod.rs
+++ b/crates/services/opencode-rs/src/types/mod.rs
@@ -18,6 +18,7 @@ pub mod question;
 pub mod session;
 pub mod skill;
 pub mod tool;
+pub mod v2;
 
 pub use api::*;
 pub use config::*;

--- a/crates/services/opencode-rs/src/types/session.rs
+++ b/crates/services/opencode-rs/src/types/session.rs
@@ -282,6 +282,16 @@ pub enum SessionStatusInfo {
         /// Next retry timestamp.
         next: u64,
     },
+    /// Unknown upstream status variant.
+    #[serde(other)]
+    Unknown,
+}
+
+impl SessionStatusInfo {
+    /// Whether this status should be treated conservatively as busy.
+    pub fn is_busy_like(&self) -> bool {
+        matches!(self, Self::Busy | Self::Retry { .. } | Self::Unknown)
+    }
 }
 
 /// A file diff entry from the session diff endpoint.
@@ -425,6 +435,27 @@ mod tests {
         let resp: HashMap<String, SessionStatusInfo> = serde_json::from_str(json).unwrap();
 
         assert!(resp.is_empty());
+    }
+
+    #[test]
+    fn parse_unknown_status_as_unknown() {
+        let status: SessionStatusInfo = serde_json::from_str(r#"{"type":"paused"}"#).unwrap();
+        assert_eq!(status, SessionStatusInfo::Unknown);
+    }
+
+    #[test]
+    fn unknown_status_is_busy_like() {
+        assert!(SessionStatusInfo::Unknown.is_busy_like());
+        assert!(SessionStatusInfo::Busy.is_busy_like());
+        assert!(
+            SessionStatusInfo::Retry {
+                attempt: 1,
+                message: "retry".to_string(),
+                next: 123,
+            }
+            .is_busy_like()
+        );
+        assert!(!SessionStatusInfo::Idle.is_busy_like());
     }
 
     #[test]

--- a/crates/services/opencode-rs/src/types/v2/common.rs
+++ b/crates/services/opencode-rs/src/types/v2/common.rs
@@ -1,0 +1,33 @@
+//! Shared V2 response wrappers live here.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataResponse<T> {
+    pub data: T,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PageCursor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CursorResponse<T> {
+    pub data: Vec<T>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<PageCursor>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationResponse<T> {
+    pub location: crate::types::v2::location::Location,
+    pub data: T,
+}

--- a/crates/services/opencode-rs/src/types/v2/health.rs
+++ b/crates/services/opencode-rs/src/types/v2/health.rs
@@ -1,0 +1,7 @@
+//! V2 health endpoint types.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Health {
+    pub healthy: bool,
+}

--- a/crates/services/opencode-rs/src/types/v2/location.rs
+++ b/crates/services/opencode-rs/src/types/v2/location.rs
@@ -1,0 +1,27 @@
+//! V2 location types live here.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationProject {
+    pub id: String,
+    pub directory: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Location {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "workspaceID"
+    )]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<LocationProject>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/mod.rs
+++ b/crates/services/opencode-rs/src/types/v2/mod.rs
@@ -1,0 +1,8 @@
+//! V2-specific types for `/api/*` endpoints.
+
+pub mod common;
+pub mod health;
+pub mod location;
+pub mod permission;
+pub mod question;
+pub mod session;

--- a/crates/services/opencode-rs/src/types/v2/permission.rs
+++ b/crates/services/opencode-rs/src/types/v2/permission.rs
@@ -1,0 +1,36 @@
+//! V2 permission endpoint types.
+
+pub type PermissionReply = crate::types::permission::PermissionReply;
+pub type PermissionReplyRequest = crate::types::permission::PermissionReplyRequest;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionSource {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "messageID")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "callID")]
+    pub call_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRequest {
+    pub id: String,
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub action: String,
+    #[serde(default)]
+    pub resources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub save: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<PermissionSource>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/types/v2/question.rs
+++ b/crates/services/opencode-rs/src/types/v2/question.rs
@@ -1,0 +1,4 @@
+//! V2 question endpoint types.
+
+pub type QuestionReply = crate::types::question::QuestionReply;
+pub type QuestionRequest = crate::types::question::QuestionRequest;

--- a/crates/services/opencode-rs/src/types/v2/session.rs
+++ b/crates/services/opencode-rs/src/types/v2/session.rs
@@ -1,0 +1,197 @@
+//! V2 session endpoint types.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRef {
+    pub id: String,
+    #[serde(rename = "providerID")]
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationRef {
+    pub directory: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "workspaceID"
+    )]
+    pub workspace_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTime {
+    pub created: i64,
+    pub updated: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived: Option<i64>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionV2Info {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "parentID")]
+    pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "projectID")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<SessionTime>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<LocationRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionListOrder {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<SessionListOrder>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+impl SessionListParams {
+    pub(crate) fn to_query_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut query = Vec::new();
+
+        if let Some(workspace) = &self.workspace {
+            query.push(("workspace", workspace.clone()));
+        }
+        if let Some(limit) = self.limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(order) = self.order {
+            let value = match order {
+                SessionListOrder::Asc => "asc",
+                SessionListOrder::Desc => "desc",
+            };
+            query.push(("order", value.to_string()));
+        }
+        if let Some(search) = &self.search {
+            query.push(("search", search.clone()));
+        }
+        if let Some(directory) = &self.directory {
+            query.push(("directory", directory.clone()));
+        }
+        if let Some(project) = &self.project {
+            query.push(("project", project.clone()));
+        }
+        if let Some(subpath) = &self.subpath {
+            query.push(("subpath", subpath.clone()));
+        }
+        if let Some(cursor) = &self.cursor {
+            query.push(("cursor", cursor.clone()));
+        }
+
+        query
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSessionRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<LocationRef>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Prompt {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionDelivery {
+    Steer,
+    Queue,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionPromptRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub prompt: Prompt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<SessionDelivery>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume: Option<bool>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInputAdmitted {
+    pub admitted_seq: u64,
+    pub id: String,
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub prompt: Prompt,
+    pub delivery: SessionDelivery,
+    pub time_created: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promoted_seq: Option<u64>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}

--- a/crates/services/opencode-rs/src/version.rs
+++ b/crates/services/opencode-rs/src/version.rs
@@ -7,7 +7,7 @@ use crate::error::OpencodeError;
 use crate::error::Result;
 
 /// Pinned opencode server version for SDK compatibility testing.
-pub const PINNED_OPENCODE_VERSION: &str = "1.15.7";
+pub const PINNED_OPENCODE_VERSION: &str = "1.17.4";
 
 /// Environment variable for the opencode binary path.
 pub const OPENCODE_BINARY_ENV: &str = "OPENCODE_BINARY";
@@ -15,9 +15,9 @@ pub const OPENCODE_BINARY_ENV: &str = "OPENCODE_BINARY";
 /// Environment variable for extra arguments between binary and `serve` command.
 ///
 /// Useful for launchers like `bunx` where the full command is:
-/// `bunx --yes opencode-ai@1.15.7 serve --hostname ... --port ...`
+/// `bunx --yes opencode-ai@1.17.4 serve --hostname ... --port ...`
 ///
-/// Example: `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7"`
+/// Example: `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4"`
 pub const OPENCODE_BINARY_ARGS_ENV: &str = "OPENCODE_BINARY_ARGS";
 
 /// Normalize a version string by stripping the `v` prefix if present.
@@ -56,9 +56,9 @@ mod tests {
 
     #[test]
     fn test_normalize_version_strips_v_prefix() {
-        assert_eq!(normalize_version("v1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("1.15.7"), "1.15.7");
-        assert_eq!(normalize_version("  v1.15.7  "), "1.15.7");
+        assert_eq!(normalize_version("v1.17.4"), "1.17.4");
+        assert_eq!(normalize_version("1.17.4"), "1.17.4");
+        assert_eq!(normalize_version("  v1.17.4  "), "1.17.4");
     }
 
     #[test]
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn test_validate_exact_version_rejects_mismatch() {
         assert!(validate_exact_version(Some("1.14.18")).is_err());
-        assert!(validate_exact_version(Some("1.15.0")).is_err());
+        assert!(validate_exact_version(Some("1.17.3")).is_err());
         assert!(validate_exact_version(None).is_err());
     }
 }

--- a/crates/services/opencode-rs/tests/integration.rs
+++ b/crates/services/opencode-rs/tests/integration.rs
@@ -6,7 +6,7 @@
 //!   `OPENCODE_INTEGRATION=1 cargo test -p opencode_rs --features server --test integration -- --ignored`
 //!
 //! For bunx-provisioned testing:
-//!   `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.15.7" OPENCODE_INTEGRATION=1 \
+//!   `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" OPENCODE_INTEGRATION=1 \
 //!    cargo test -p opencode_rs --features server --test integration -- --ignored`
 //!
 //! Without `server` feature (requires pre-running server):
@@ -16,7 +16,7 @@
 //! Environment variables:
 //!   `OPENCODE_INTEGRATION` - Must be set to run integration tests
 //!   `OPENCODE_BINARY` - Path to opencode binary or launcher (default: "opencode")
-//!   `OPENCODE_BINARY_ARGS` - Extra args for launcher (e.g., "--yes opencode-ai@1.15.7")
+//!   `OPENCODE_BINARY_ARGS` - Extra args for launcher (e.g., "--yes opencode-ai@1.17.4")
 //!   `OPENCODE_BASE_URL` - Base URL when not using managed server (default: <http://127.0.0.1:4096>)
 //!   `OPENCODE_DIRECTORY` - Directory context for requests (default: current directory)
 
@@ -533,7 +533,7 @@ async fn test_agents_list() {
 /// Test that command dispatch reaches command lookup instead of request validation.
 #[tokio::test]
 #[ignore = "requires: opencode serve"]
-async fn test_command_dispatch_passes_request_validation_v1_15_7() {
+async fn test_command_dispatch_passes_request_validation() {
     if !should_run() {
         return;
     }
@@ -567,7 +567,7 @@ async fn test_command_dispatch_passes_request_validation_v1_15_7() {
     let err_text = err.to_string();
     assert!(
         err_text.contains("HTTP error 500") || err_text.contains("UnknownError"),
-        "expected 1.15.7 unknown-command server error shape, got: {err_text}"
+        "expected 1.17.4 unknown-command server error shape, got: {err_text}"
     );
     assert!(
         !err_text.contains("messageID"),

--- a/crates/services/opencode-rs/tests/v2.rs
+++ b/crates/services/opencode-rs/tests/v2.rs
@@ -1,4 +1,11 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![expect(
+    clippy::expect_used,
+    reason = "integration tests use concise failure handling"
+)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration tests use concise failure handling"
+)]
 
 use opencode_rs::ClientBuilder;
 use opencode_rs::types::permission::PermissionReply;
@@ -17,6 +24,14 @@ use wiremock::matchers::body_json;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::query_param;
+
+fn expect_ok<T, E: std::fmt::Debug>(result: Result<T, E>, context: &str) -> T {
+    result.expect(context)
+}
+
+fn unwrap_some<T>(value: Option<T>) -> T {
+    value.unwrap()
+}
 
 #[tokio::test]
 async fn v2_health_and_location_use_expected_shapes() {
@@ -42,12 +57,14 @@ async fn v2_health_and_location_use_expected_shapes() {
         .mount(&mock)
         .await;
 
-    let client = ClientBuilder::new()
-        .base_url(mock.uri())
-        .directory("/tmp/project")
-        .workspace("workspace-1")
-        .build()
-        .unwrap();
+    let client = expect_ok(
+        ClientBuilder::new()
+            .base_url(mock.uri())
+            .directory("/tmp/project")
+            .workspace("workspace-1")
+            .build(),
+        "wiremock test client should build",
+    );
 
     let health = client.v2().health().get().await.unwrap();
     assert!(health.healthy);
@@ -506,7 +523,7 @@ async fn v2_optional_connector_fs_and_reference_groups_cover_json_only_endpoints
     assert_eq!(connectors.data.len(), 1);
 
     let connector = client.v2().connector().get("con_1").await.unwrap();
-    assert_eq!(connector.data.unwrap()["id"], "con_1");
+    assert_eq!(unwrap_some(connector.data)["id"], "con_1");
 
     client
         .v2()

--- a/crates/services/opencode-rs/tests/v2.rs
+++ b/crates/services/opencode-rs/tests/v2.rs
@@ -1,0 +1,556 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use opencode_rs::ClientBuilder;
+use opencode_rs::types::permission::PermissionReply;
+use opencode_rs::types::v2::permission::PermissionReplyRequest;
+use opencode_rs::types::v2::question::QuestionReply;
+use opencode_rs::types::v2::session::CreateSessionRequest;
+use opencode_rs::types::v2::session::Prompt;
+use opencode_rs::types::v2::session::SessionDelivery;
+use opencode_rs::types::v2::session::SessionListOrder;
+use opencode_rs::types::v2::session::SessionListParams;
+use opencode_rs::types::v2::session::SessionPromptRequest;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_json;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::matchers::query_param;
+
+#[tokio::test]
+async fn v2_health_and_location_use_expected_shapes() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "healthy": true
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/location"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .and(query_param("location[workspace]", "workspace-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "directory": "/tmp/project",
+            "workspaceID": "workspace-1",
+            "project": {"id": "prj_1", "directory": "/tmp/project"}
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = ClientBuilder::new()
+        .base_url(mock.uri())
+        .directory("/tmp/project")
+        .workspace("workspace-1")
+        .build()
+        .unwrap();
+
+    let health = client.v2().health().get().await.unwrap();
+    assert!(health.healthy);
+
+    let location = client.v2().location().get().await.unwrap();
+    assert_eq!(location.directory.as_deref(), Some("/tmp/project"));
+    assert_eq!(location.workspace_id.as_deref(), Some("workspace-1"));
+}
+
+#[tokio::test]
+async fn v2_session_and_message_groups_deserialize_envelopes() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/session"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .and(query_param("order", "desc"))
+        .and(query_param("limit", "25"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [
+                {
+                    "id": "ses_1",
+                    "title": "Session One",
+                    "projectID": "prj_1",
+                    "location": {"directory": "/tmp/project"},
+                    "time": {"created": 1, "updated": 2}
+                }
+            ],
+            "cursor": {"next": "cursor-next"}
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/session"))
+        .and(body_json(serde_json::json!({"agent": "Plan"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "id": "ses_new",
+                "title": "",
+                "location": {"directory": "/tmp/project"}
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/session/ses_1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {"id": "ses_1", "title": "Session One", "location": {"directory": "/tmp/project"}}
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/session/ses_1/prompt"))
+        .and(body_json(serde_json::json!({
+            "prompt": {"text": "hello"},
+            "delivery": "queue"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "admittedSeq": 5,
+                "id": "msg_1",
+                "sessionID": "ses_1",
+                "prompt": {"text": "hello"},
+                "delivery": "queue",
+                "timeCreated": 123
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/session/ses_1/message"))
+        .and(query_param("cursor", "cursor-next"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{"type": "assistant", "id": "msg_1"}],
+            "cursor": {"previous": "cursor-prev"}
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = ClientBuilder::new()
+        .base_url(mock.uri())
+        .directory("/tmp/project")
+        .build()
+        .unwrap();
+
+    let sessions = client
+        .v2()
+        .session()
+        .list(&SessionListParams {
+            limit: Some(25),
+            order: Some(SessionListOrder::Desc),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(sessions.data[0].id, "ses_1");
+    assert_eq!(
+        sessions.cursor.and_then(|c| c.next).as_deref(),
+        Some("cursor-next")
+    );
+
+    let created = client
+        .v2()
+        .session()
+        .create(&CreateSessionRequest {
+            agent: Some("Plan".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(created.data.id, "ses_new");
+
+    let got = client.v2().session().get("ses_1").await.unwrap();
+    assert_eq!(got.data.title, "Session One");
+
+    let admitted = client
+        .v2()
+        .session()
+        .prompt(
+            "ses_1",
+            &SessionPromptRequest {
+                id: None,
+                prompt: Prompt {
+                    text: "hello".to_string(),
+                    ..Default::default()
+                },
+                delivery: Some(SessionDelivery::Queue),
+                resume: None,
+                extra: serde_json::Value::Null,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(admitted.data.session_id, "ses_1");
+
+    let messages = client
+        .v2()
+        .message()
+        .list("ses_1", Some("cursor-next"))
+        .await
+        .unwrap();
+    assert_eq!(messages.data.len(), 1);
+    assert_eq!(
+        messages.cursor.and_then(|c| c.previous).as_deref(),
+        Some("cursor-prev")
+    );
+}
+
+#[tokio::test]
+async fn v2_model_and_provider_groups_use_location_wrapped_responses() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/model"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"id": "claude-sonnet", "providerID": "anthropic"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/provider"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"id": "anthropic", "name": "Anthropic"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/provider/anthropic"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": {"id": "anthropic", "name": "Anthropic"}
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = ClientBuilder::new()
+        .base_url(mock.uri())
+        .directory("/tmp/project")
+        .build()
+        .unwrap();
+
+    let models = client.v2().model().list().await.unwrap();
+    assert_eq!(models.location.directory.as_deref(), Some("/tmp/project"));
+    assert_eq!(models.data.len(), 1);
+
+    let providers = client.v2().provider().list().await.unwrap();
+    assert_eq!(providers.data.len(), 1);
+
+    let provider = client.v2().provider().get("anthropic").await.unwrap();
+    assert_eq!(provider.data["id"], "anthropic");
+}
+
+#[tokio::test]
+async fn v2_permission_and_question_groups_support_list_and_204_replies() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/permission/request"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{
+                "id": "per_1",
+                "sessionID": "ses_1",
+                "action": "fs.write",
+                "resources": ["/tmp/project/src/lib.rs"]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/session/ses_1/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{
+                "id": "per_1",
+                "sessionID": "ses_1",
+                "action": "fs.write",
+                "resources": ["/tmp/project/src/lib.rs"]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/session/ses_1/permission/per_1/reply"))
+        .and(body_json(
+            serde_json::json!({"reply": "always", "message": "ok"}),
+        ))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/question/request"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{
+                "id": "que_1",
+                "sessionID": "ses_1",
+                "questions": [{"question": "Continue?"}]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/session/ses_1/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{
+                "id": "que_1",
+                "sessionID": "ses_1",
+                "questions": [{"question": "Continue?"}]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/session/ses_1/question/que_1/reply"))
+        .and(body_json(serde_json::json!({"answers": [["Yes"]]})))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/session/ses_1/question/que_1/reject"))
+        .and(body_json(serde_json::json!({})))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    let client = ClientBuilder::new()
+        .base_url(mock.uri())
+        .directory("/tmp/project")
+        .build()
+        .unwrap();
+
+    let permissions = client.v2().permission().list_requests().await.unwrap();
+    assert_eq!(permissions.data.len(), 1);
+    assert_eq!(
+        permissions.location.directory.as_deref(),
+        Some("/tmp/project")
+    );
+
+    let session_permissions = client
+        .v2()
+        .permission()
+        .list_session_requests("ses_1")
+        .await
+        .unwrap();
+    assert_eq!(session_permissions.data[0].id, "per_1");
+
+    client
+        .v2()
+        .permission()
+        .reply(
+            "ses_1",
+            "per_1",
+            &PermissionReplyRequest {
+                reply: PermissionReply::Always,
+                message: Some("ok".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let questions = client.v2().question().list_requests().await.unwrap();
+    assert_eq!(questions.data.len(), 1);
+
+    let session_questions = client
+        .v2()
+        .question()
+        .list_session_requests("ses_1")
+        .await
+        .unwrap();
+    assert_eq!(session_questions.data[0].id, "que_1");
+
+    client
+        .v2()
+        .question()
+        .reply(
+            "ses_1",
+            "que_1",
+            &QuestionReply {
+                answers: vec![vec!["Yes".to_string()]],
+            },
+        )
+        .await
+        .unwrap();
+
+    client
+        .v2()
+        .question()
+        .reject("ses_1", "que_1")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn v2_optional_connector_fs_and_reference_groups_cover_json_only_endpoints() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/connector"))
+        .and(query_param("location[directory]", "/tmp/project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"id": "con_1", "name": "GitHub"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/connector/con_1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": {"id": "con_1", "name": "GitHub"}
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/connector/con_1/connect/key"))
+        .and(body_json(
+            serde_json::json!({"methodID": "key", "key": "secret", "inputs": {}}),
+        ))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/connector/con_1/connect/oauth"))
+        .and(body_json(
+            serde_json::json!({"methodID": "oauth", "inputs": {}}),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": {"attemptID": "att_1", "url": "https://example.com/oauth"}
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/connector/oauth/att_1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": {"status": "pending"}
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/connector/oauth/att_1/complete"))
+        .and(body_json(serde_json::json!({"code": "abc123"})))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api/connector/oauth/att_1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/fs/list"))
+        .and(query_param("path", "src"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"path": "src/lib.rs", "type": "file", "mime": "text/x-rust"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/fs/find"))
+        .and(query_param("query", "lib"))
+        .and(query_param("type", "file"))
+        .and(query_param("limit", "10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"path": "src/lib.rs", "type": "file", "mime": "text/x-rust"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/reference"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "location": {"directory": "/tmp/project"},
+            "data": [{"name": "docs", "path": "/tmp/project/docs"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = ClientBuilder::new()
+        .base_url(mock.uri())
+        .directory("/tmp/project")
+        .build()
+        .unwrap();
+
+    let connectors = client.v2().connector().list().await.unwrap();
+    assert_eq!(connectors.data.len(), 1);
+
+    let connector = client.v2().connector().get("con_1").await.unwrap();
+    assert_eq!(connector.data.unwrap()["id"], "con_1");
+
+    client
+        .v2()
+        .connector()
+        .connect_key(
+            "con_1",
+            &serde_json::json!({"methodID": "key", "key": "secret", "inputs": {}}),
+        )
+        .await
+        .unwrap();
+
+    let attempt = client
+        .v2()
+        .connector()
+        .connect_oauth_begin(
+            "con_1",
+            &serde_json::json!({"methodID": "oauth", "inputs": {}}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(attempt.data["attemptID"], "att_1");
+
+    let status = client.v2().connector().oauth_status("att_1").await.unwrap();
+    assert_eq!(status.data["status"], "pending");
+
+    client
+        .v2()
+        .connector()
+        .oauth_complete("att_1", &serde_json::json!({"code": "abc123"}))
+        .await
+        .unwrap();
+    client.v2().connector().oauth_cancel("att_1").await.unwrap();
+
+    let entries = client.v2().fs().list(Some("src")).await.unwrap();
+    assert_eq!(entries.data.len(), 1);
+
+    let found = client
+        .v2()
+        .fs()
+        .find("lib", Some("file"), Some(10))
+        .await
+        .unwrap();
+    assert_eq!(found.data.len(), 1);
+
+    let references = client.v2().reference().list().await.unwrap();
+    assert_eq!(references.data.len(), 1);
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ If you're trying to get running, start with setup and branch out from there. The
 - Troubleshooting: [`./troubleshooting.md`](./troubleshooting.md)
 - Why this stack: [`./why_this_stack.md`](./why_this_stack.md)
 
+## Upgrades
+
+- OpenCode upgrade (1.15.7 → 1.17.4): [`./opencode_1_17_4_upgrade.md`](./opencode_1_17_4_upgrade.md)
+
 ## Setup paths
 
 - Fresh install on a new machine: [`./setup/fresh_install.md`](./setup/fresh_install.md)

--- a/docs/opencode_1_17_4_upgrade.md
+++ b/docs/opencode_1_17_4_upgrade.md
@@ -1,0 +1,120 @@
+# OpenCode upgrade: 1.15.7 → 1.17.4
+
+## Summary
+
+- `opencode_rs` and `opencode-orchestrator-mcp` now require exact OpenCode `1.17.4` after optional `v` prefix normalization.
+- The orchestrator still uses the legacy endpoints that upstream `1.17.4` continues to serve.
+- The Rust SDK now also exposes a parallel V2 surface through `client.v2()` for `/api/*` endpoints.
+- Mise-managed local iteration pins remain on `1.15.7` by explicit exception.
+
+## What changed
+
+### Exact version pin
+
+The supported runtime target is now exactly `1.17.4` everywhere in this repo except the mise pin files.
+
+Examples:
+
+```bash
+bun install -g opencode-ai@1.17.4
+OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4"
+```
+
+### Legacy orchestrator behavior is preserved
+
+This upgrade does **not** force the orchestrator onto `/api/*` routes. Existing orchestrator hot paths still rely on the legacy endpoints for:
+
+- session lifecycle
+- prompt/command dispatch
+- permission handling
+- question handling
+- startup health/version validation
+
+That keeps the orchestrator runtime stable while the repo adds additive V2 SDK support in parallel.
+
+### New parallel V2 SDK surface
+
+The SDK now exposes a separate V2 client:
+
+```rust
+use opencode_rs::ClientBuilder;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = ClientBuilder::new()
+        .base_url("http://127.0.0.1:4096")
+        .directory("/path/to/repo")
+        .build()?;
+
+    let health = client.v2().health().get().await?;
+    let location = client.v2().location().get().await?;
+    let models = client.v2().model().list().await?;
+
+    println!("healthy={}", health.healthy);
+    println!("directory={:?}", location.directory);
+    println!("models={}", models.data.len());
+    Ok(())
+}
+```
+
+Implemented V2 groups in this upgrade:
+
+- core: health, location, session, message, model, provider, permission, question
+- additive optional: connector, fs (`list`/`find` only), reference
+
+Explicitly deferred in this slice:
+
+- `/api/fs/read/*` raw binary reads
+- `/api/event` SSE streaming
+- `/api/permission/saved*`
+
+## V2 location semantics
+
+Legacy SDK requests inject flat `directory` / `workspace` query params.
+
+The new V2 transport does **not** reuse that behavior. Instead it sends V2 location context as:
+
+- `location[directory]`
+- `location[workspace]`
+
+and expects V2 envelope differences such as:
+
+- `{ data, cursor }` for list responses
+- `{ location, data }` for location-wrapped responses
+
+## Running live checks locally
+
+Ignored integration tests still exist, but they remain environment-gated and are **not** a reliable CI gate today.
+
+SDK live example:
+
+```bash
+OPENCODE_BINARY=bunx \
+OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
+OPENCODE_INTEGRATION=1 \
+cargo test -p opencode_rs --features server --test integration -- --ignored
+```
+
+Orchestrator live example:
+
+```bash
+OPENCODE_BINARY=bunx \
+OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" \
+OPENCODE_ORCHESTRATOR_INTEGRATION=1 \
+cargo test -p opencode-orchestrator-mcp --test integration -- --ignored --test-threads=1
+```
+
+## Verification limits
+
+- CI still does **not** prove end-to-end OpenCode compatibility because the live integration suites are ignored and env-gated.
+- This upgrade focused on deterministic unit/wiremock coverage plus crate/workspace checks.
+- If you hit a live OpenCode mismatch, re-run the ignored tests locally against `opencode-ai@1.17.4` first.
+
+## Mise exception
+
+The following remain intentionally pinned to `1.15.7` for local mise-managed iteration:
+
+- `crates/meta/xtask/src/mise.rs`
+- generated `mise.toml`
+
+That exception is deliberate and should not be treated as an upgrade miss.

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -28,7 +28,7 @@ Do these in this order. It saves a little backtracking later.
 5. Install **OpenCode** at the version this repo currently expects:
 
    ```bash
-   bun install -g opencode-ai@1.3.17
+    bun install -g opencode-ai@1.17.4
    ```
 
 6. Install **Claude Code** with whatever install method you already trust. The official docs are here: <https://code.claude.com/docs/en/authentication.md>.
@@ -71,7 +71,7 @@ Do this before you start blaming MCP wiring.
 
 ## OpenCode version pin (orchestrator)
 
-`opencode-orchestrator-mcp` validates against OpenCode **v1.3.17**. If you point it at another version, startup can fail.
+`opencode-orchestrator-mcp` validates against OpenCode **v1.17.4**. If you point it at another version, startup can fail.
 
 You usually do not need extra env vars here. `OPENCODE_BINARY` and `OPENCODE_BINARY_ARGS` are only for cases where the default pinned binary path or the plain `opencode` on `PATH` is not the one you want.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,9 +101,9 @@ If `OPENCODE_ORCHESTRATOR_LOG_DIR` is unset, the orchestrator falls back to the 
 
 ## Orchestrator says OpenCode version is wrong
 
-`opencode-orchestrator-mcp` expects OpenCode `v1.3.17`.
+`opencode-orchestrator-mcp` expects OpenCode `v1.17.4`.
 
-If the binary on `PATH` is not the one you want, set `OPENCODE_BINARY`. If you are using launcher mode (for example `bunx --yes opencode-ai@1.3.17`), also set `OPENCODE_BINARY_ARGS`.
+If the binary on `PATH` is not the one you want, set `OPENCODE_BINARY`. If you are using launcher mode (for example `bunx --yes opencode-ai@1.17.4`), also set `OPENCODE_BINARY_ARGS`.
 
 ## One small gotcha worth knowing
 

--- a/mise.lock
+++ b/mise.lock
@@ -394,94 +394,105 @@ version = "0.4.6"
 backend = "cargo:systemfd"
 
 [[tools.claude]]
-version = "2.1.160"
+version = "2.1.175"
 backend = "aqua:anthropics/claude-code"
 
 [tools.claude."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-arm64/claude"
 
 [tools.claude."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-arm64-musl/claude"
 
 [tools.claude."platforms.linux-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64-musl/claude"
 
 [tools.claude."platforms.linux-x64-musl-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64-musl/claude"
 
 [tools.claude."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-arm64/claude"
 
 [tools.claude."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-x64/claude"
 
 [tools.claude."platforms.macos-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-x64/claude"
 
 [[tools."github:anomalyco/opencode"]]
-version = "1.15.7"
+version = "1.17.4"
 backend = "github:anomalyco/opencode"
 
 [tools."github:anomalyco/opencode"."platforms.linux-arm64"]
-checksum = "sha256:d2ca40f11b0eb1648cbffaf9850c122a83062b21ada18e5db29558c6bfafee0f"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253982"
+checksum = "sha256:5cb32d53238a205a4ad71f70be8d669aaf460f55121ebc16ff9d12909609dd0b"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246586"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.linux-arm64-musl"]
-checksum = "sha256:aae45df3aa8981875059045d87028926e7313d99998ac65598f1f95732d171f3"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-arm64-musl.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254007"
+checksum = "sha256:30dc23074b93476b395245e24c45f812a2e4252e170bef71884aa9ce5d757251"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246576"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.linux-x64"]
-checksum = "sha256:6f7f95f13917b9aab8421dbb7e121abf2fecfecdccd16fd5b497f522f454f928"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253984"
+checksum = "sha256:a2ece9181aab3817a6b59fa390b6d459b187e3ec917be802ecbca88b632c5ef9"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246550"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.linux-x64-baseline"]
-checksum = "sha256:6f7f95f13917b9aab8421dbb7e121abf2fecfecdccd16fd5b497f522f454f928"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253984"
+checksum = "sha256:a2ece9181aab3817a6b59fa390b6d459b187e3ec917be802ecbca88b632c5ef9"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246550"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.linux-x64-musl"]
-checksum = "sha256:7966e6f2fcde07b8390d5759d5d76097f6c3b8e2a1c8a479977b51e5f601abdb"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64-musl.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254009"
+checksum = "sha256:c6c590746e1706265b6c035c27376c81127d62680657da2e74972ea6ade0b866"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246558"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:7966e6f2fcde07b8390d5759d5d76097f6c3b8e2a1c8a479977b51e5f601abdb"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-linux-x64-musl.tar.gz"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426254009"
+checksum = "sha256:c6c590746e1706265b6c035c27376c81127d62680657da2e74972ea6ade0b866"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246558"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.macos-arm64"]
-checksum = "sha256:335307ee87d3dac84986bf8f0bd4273a43c35fcb9b124556c2f4fad4a510e3a4"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-arm64.zip"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253936"
+checksum = "sha256:7a26d5427ff33e4f5bc942ad923a3b5ce3c88c6705fdecca9c2e27b59365594a"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-darwin-arm64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246510"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.macos-x64"]
-checksum = "sha256:12e4a562bcd6e691eb846ceedc5c1f7bad88f047df3775be21aaf979bda959d7"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-x64.zip"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253938"
+checksum = "sha256:8d2023687e415c5ef2c70c7a790e5e2d6957bf1d195925d154e70b5fc15e999b"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246549"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.macos-x64-baseline"]
-checksum = "sha256:12e4a562bcd6e691eb846ceedc5c1f7bad88f047df3775be21aaf979bda959d7"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-darwin-x64.zip"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426253938"
+checksum = "sha256:8d2023687e415c5ef2c70c7a790e5e2d6957bf1d195925d154e70b5fc15e999b"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445246549"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.windows-x64"]
-checksum = "sha256:8ac96b52692a3daeb84a20295cc7ed43aa3c698078e802926a47aef83748eab2"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-windows-x64.zip"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426255364"
+checksum = "sha256:7e2f486e4551ac3e053c6c82d3283cdbef206e928f5b8680850f4cb86fada648"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445248811"
+provenance = "github-attestations"
 
 [tools."github:anomalyco/opencode"."platforms.windows-x64-baseline"]
-checksum = "sha256:8ac96b52692a3daeb84a20295cc7ed43aa3c698078e802926a47aef83748eab2"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.15.7/opencode-windows-x64.zip"
-url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/426255364"
+checksum = "sha256:7e2f486e4551ac3e053c6c82d3283cdbef206e928f5b8680850f4cb86fada648"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/445248811"
+provenance = "github-attestations"
 
 [[tools."github:bnjbvr/cargo-machete"]]
 version = "0.9.1"

--- a/mise.toml
+++ b/mise.toml
@@ -28,8 +28,8 @@ _.path = ["tools/bin"]
 # instead of compiling from source. Using github backend for proper lockfile support.
 "github:cargo-bins/cargo-binstall" = "latest"
 # BEGIN:xtask:autogen mise:tool-pins
-claude = "2.1.160"
-"github:anomalyco/opencode" = "1.15.7"
+claude = "2.1.175"
+"github:anomalyco/opencode" = "1.17.4"
 # END:xtask:autogen
 just = "latest"
 shellcheck = "0.11.0"


### PR DESCRIPTION
## Summary
- upgrade opencode-rs and opencode-orchestrator-mcp exact OpenCode support to 1.17.4
- add additive SDK support for V2 /api endpoints while keeping orchestrator runtime on supported legacy APIs
- harden unknown legacy session statuses, improve endpoint coverage checks, and document the upgrade workflow

## Verification
- just crate-check opencode_rs
- just crate-test opencode_rs
- just crate-check opencode-orchestrator-mcp
- just crate-test opencode-orchestrator-mcp
- just crate-check xtask
- just crate-test xtask
- just endpoint-coverage-check
- just fmt-check
- just check
- just test

## Notes
- Live ignored OpenCode integration tests are documented but were not used as the merge gate in this environment.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

The repo still hard-pinned OpenCode support to `1.15.7` and relied on a legacy SDK/orchestrator surface that did not represent the newer `1.17.4` `/api/*` endpoints. At the same time, the orchestrator's hot paths still needed to stay on the legacy endpoints that upstream `1.17.4` continues to serve.

This PR upgrades the supported OpenCode target to `1.17.4`, keeps the orchestrator's runtime behavior stable on legacy APIs, adds additive V2 SDK coverage for the important `/api/*` groups, hardens legacy session-status handling against new upstream variants, and makes endpoint coverage checks validate something deterministic instead of only proving that the tool ran.

## What user-facing changes did I ship?

- `opencode_rs` and `opencode-orchestrator-mcp` now require exact OpenCode `1.17.4` after `v`-prefix normalization.
- The Rust SDK now exposes a parallel `client.v2()` surface for V2 `/api/*` endpoints.
- Core V2 SDK groups were added for:
  - health
  - location
  - session
  - message
  - model
  - provider
  - permission
  - question
- Straightforward additive optional V2 groups were added for:
  - connector
  - fs (`list` and `find` only)
  - reference
- Explicitly deferred in this slice:
  - `/api/fs/read/*` raw/binary reads
  - `/api/event` SSE streaming
  - `/api/permission/saved*`
- Legacy session-status handling is now more conservative: unknown upstream legacy statuses are treated as busy instead of idle.
- Docs now include an upgrade guide for the `1.15.7 -> 1.17.4` move and updated setup/troubleshooting references.

## How I implemented it

- Bumped the exact OpenCode pin and all non-mise user-facing references from `1.15.7` to `1.17.4`.
- Preserved orchestrator runtime behavior on legacy endpoints rather than migrating the orchestrator hot paths to `/api/*` during this upgrade.
- Added `SessionStatusInfo::Unknown` plus `is_busy_like()` in the legacy SDK types, then updated SDK/orchestrator busy detection and summaries to treat unknown statuses conservatively as busy.
- Added a parallel `http::v2` transport that injects V2 location semantics (`location[directory]` / `location[workspace]`) instead of reusing the legacy flat `directory` / `workspace` query injection.
- Exposed that new transport through `Client::v2()` and implemented the V2 group APIs in isolated modules so the legacy modules remain unchanged.
- Added dedicated V2 DTOs and response wrappers for `{ data, cursor }` and `{ location, data }` envelope differences.
- Added wiremock coverage for the V2 transport and each implemented V2 group, including the optional additive groups that are JSON-only and low-risk.
- Repaired endpoint coverage manifest drift (including missing legacy session endpoints), added the implemented V2 inventory, and changed xtask check-mode to parse JSON and enforce deterministic inventory invariants.
- Added a new upgrade guide in `docs/` and linked it from the docs index, including explicit notes about deferred V2 coverage and ignored live integration tests.

## How to verify it

- [x] I ran the `check` and `test` recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification run for this PR:

- `just crate-check opencode_rs`
- `just crate-test opencode_rs`
- `just crate-check opencode-orchestrator-mcp`
- `just crate-test opencode-orchestrator-mcp`
- `just crate-check xtask`
- `just crate-test xtask`
- `just endpoint-coverage-check`
- `just fmt-check`
- `just check`
- `just test`

Not run in this environment:

- Ignored live OpenCode integration tests for `opencode_rs`
- Ignored live OpenCode integration tests for `opencode-orchestrator-mcp`

Those remain documented and env-gated, but they were not used as the merge gate here.

## Description for the changelog

Upgrade OpenCode support to `1.17.4`, add additive V2 SDK coverage for key `/api/*` endpoints, harden legacy unknown session-status handling, improve endpoint coverage checks, and document the upgrade workflow.
<!-- END:describe_pr:autogen -->
