### PR TITLE
feat: add gwt-worktree crate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
       "mcp__orchestrator__list_commands",
       "mcp__orchestrator__get_session_state",
       "mcp__orchestrator__respond_permission",
-      "mcp__orchestrator__respond_question"
+      "mcp__orchestrator__respond_question",
+      "mcp__orchestrator__list_agents"
     ],
     "deny": [
       "Bash",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,7 +38,9 @@
       "TaskUpdate",
       "EnterPlanMode",
       "ExitPlanMode",
-      "AskUserQuestion"
+      "AskUserQuestion",
+      "Workflow",
+      "DesignSync"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Guidance for Claude Code when working with this repository.
 - `agentic-config` (lib) - `crates/infra/agentic-config/`
 - `thoughts-tool` (lib) - `crates/infra/thoughts-core/`
 - `agentic_logging` (lib) - `crates/infra/agentic-logging/`
+- `gwt-worktree` (lib) - `crates/infra/gwt-worktree/`
 
 ### legacy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,6 +2902,7 @@ name = "gwt-worktree"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "filetime",
  "git2",
  "serde",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-worktree"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "git2",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   # Infra family
   "crates/infra/agentic-config",
   "crates/infra/agentic-logging",
+  "crates/infra/gwt-worktree",
   "crates/infra/thoughts-core",
 
   # Legacy family

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ opencode_rs = "0.11.2"
 
 - [`agentic-config`](crates/infra/agentic-config) - Unified configuration system for agentic tools ecosystem
 - [`agentic_logging`](crates/infra/agentic-logging) - Centralized JSONL logging infrastructure for agentic tools
+- [`gwt-worktree`](crates/infra/gwt-worktree) - Programmatic gwt-compatible git worktree management library
 - [`thoughts-tool`](crates/infra/thoughts-core) - Flexible thought management using filesystem mounts for git repositories
 
 ### linear

--- a/TODO.md
+++ b/TODO.md
@@ -30,6 +30,11 @@ These items have dependencies and should be done in order.
 
 ## To plan/design:
 
+### `gwt-worktree` follow-up work
+
+- Consider a CLI/tooling layer on top of `crates/infra/gwt-worktree/` for direct user-facing worktree operations.
+- Consider a pure-gix backend alternative if we later want to reduce libgit2 coupling while preserving the current plan/execute API.
+
 ### Optional config escape hatch for project-wide orchestrator session listing
 
 - TODO(3): Consider an `agentic.toml` boolean to opt orchestrator session browsing into project-wide listing instead of launch-directory scope. Deferred for now because it feels like scope creep and probably not worth this migration PR.

--- a/TODO.md
+++ b/TODO.md
@@ -32,8 +32,8 @@ These items have dependencies and should be done in order.
 
 ### `gwt-worktree` follow-up work
 
-- Consider a CLI/tooling layer on top of `crates/infra/gwt-worktree/` for direct user-facing worktree operations.
-- Consider a pure-gix backend alternative if we later want to reduce libgit2 coupling while preserving the current plan/execute API.
+- TODO(3): Consider a CLI/tooling layer on top of `crates/infra/gwt-worktree/` for direct user-facing worktree operations.
+- TODO(3): Consider a pure-gix backend alternative if we later want to reduce libgit2 coupling while preserving the current plan/execute API.
 
 ### Optional config escape hatch for project-wide orchestrator session listing
 

--- a/crates/infra/gwt-worktree/CLAUDE.md
+++ b/crates/infra/gwt-worktree/CLAUDE.md
@@ -16,9 +16,15 @@ Programmatic, gwt-compatible git worktree management library for typed listing, 
 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
-just crate-check gwt-worktree
-just crate-test gwt-worktree
-just crate-build gwt-worktree
+# Lint & Clippy
+cargo fmt -p gwt-worktree -- --check
+cargo clippy -p gwt-worktree --all-targets -- -D warnings
+
+# Tests
+cargo test -p gwt-worktree
+
+# Build
+cargo build -p gwt-worktree
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/gwt-worktree/CLAUDE.md
+++ b/crates/infra/gwt-worktree/CLAUDE.md
@@ -10,21 +10,15 @@
 
 ## Overview
 
-Briefly describe the purpose of this crate and how to use it.
+Programmatic, gwt-compatible git worktree management library for typed listing, switching/creating, removing, and GC flows.
 
 ## Quick Commands
 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
-# Lint & Clippy
-cargo fmt -p gwt-worktree -- --check
-cargo clippy -p gwt-worktree --all-targets -- -D warnings
-
-# Tests
-cargo test -p gwt-worktree
-
-# Build
-cargo build -p gwt-worktree
+just crate-check gwt-worktree
+just crate-test gwt-worktree
+just crate-build gwt-worktree
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/gwt-worktree/CLAUDE.md
+++ b/crates/infra/gwt-worktree/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md - gwt-worktree
+
+<!-- BEGIN:xtask:autogen header -->
+- Crate: gwt-worktree
+- Path: crates/infra/gwt-worktree/
+- Role: lib
+- Family: infra
+- Integrations: mcp=false, logging=false, napi=false
+<!-- END:xtask:autogen -->
+
+## Overview
+
+Briefly describe the purpose of this crate and how to use it.
+
+## Quick Commands
+
+<!-- BEGIN:xtask:autogen commands -->
+```bash
+# Lint & Clippy
+cargo fmt -p gwt-worktree -- --check
+cargo clippy -p gwt-worktree --all-targets -- -D warnings
+
+# Tests
+cargo test -p gwt-worktree
+
+# Build
+cargo build -p gwt-worktree
+```
+<!-- END:xtask:autogen -->
+
+## Notes
+
+Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.

--- a/crates/infra/gwt-worktree/Cargo.toml
+++ b/crates/infra/gwt-worktree/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 toml = "0.8"
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3"
 
 [lints]

--- a/crates/infra/gwt-worktree/Cargo.toml
+++ b/crates/infra/gwt-worktree/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "gwt-worktree"
+version = "0.1.0"
+edition = "2024"
+authors = ["Allison Durham"]
+description = "Programmatic gwt-compatible git worktree management library"
+license = "MIT"
+repository = "https://github.com/allisoneer/agentic_auxilary"
+homepage = "https://github.com/allisoneer/agentic_auxilary"
+readme = "README.md"
+keywords = ["git", "worktree", "gwt"]
+categories = ["development-tools"]
+
+[package.metadata.repo]
+role = "lib"
+family = "infra"
+
+[package.metadata.repo.integrations]
+mcp = false
+logging = false
+napi = false
+
+[dependencies]
+dirs = { workspace = true }
+git2 = { version = "0.20", features = ["vendored-openssl", "ssh", "https"] }
+serde = { workspace = true }
+thiserror = { workspace = true }
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/infra/gwt-worktree/README.md
+++ b/crates/infra/gwt-worktree/README.md
@@ -1,0 +1,25 @@
+# gwt-worktree
+
+`gwt-worktree` is a Rust library for gwt-compatible git worktree management.
+
+## v1 scope
+
+- gwt-compatible config load/save for `~/.config/gwt/config.toml`
+- exact `.gwt` base-path and `README.md` sentinel behavior
+- worktree listing with synthesized main-worktree entries
+- typed planning and execution for switch/create, remove, and gc
+- trait-based integration points for remote refresh, remote delete, and PR lookup
+
+## Compatibility promises
+
+- preserve `repos.<git_dir>` config key semantics
+- omit `default_repo` when unset
+- use raw branch paths under `<repo>.gwt/`
+- keep reversible encoded admin names for libgit2 worktree identities
+
+## Non-goals
+
+- no CLI in v1
+- no shell integration or subprocess calls to `git`/`gh`
+- no built-in network refresh or PR provider implementation
+- no execution of `post_create_commands` or `clean_command`; they remain typed data

--- a/crates/infra/gwt-worktree/src/command.rs
+++ b/crates/infra/gwt-worktree/src/command.rs
@@ -1,0 +1,45 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommandSpec(String);
+
+impl CommandSpec {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for CommandSpec {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for CommandSpec {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl AsRef<str> for CommandSpec {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for CommandSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/infra/gwt-worktree/src/config.rs
+++ b/crates/infra/gwt-worktree/src/config.rs
@@ -1,0 +1,182 @@
+use crate::command::CommandSpec;
+use crate::error::Error;
+use crate::error::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+use toml::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct GwtConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_repo: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub repos: BTreeMap<String, RepoConfig>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct RepoConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_create_commands: Vec<CommandSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clean_command: Option<CommandSpec>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl GwtConfig {
+    pub fn load() -> Result<Self> {
+        Self::load_from_path(&config_path()?)
+    }
+
+    pub fn load_or_create_default() -> Result<Self> {
+        Self::load_or_create_default_at(&config_path()?)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        self.save_to_path(&config_path()?)
+    }
+
+    pub fn load_from_path(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let contents = std::fs::read_to_string(path)?;
+        if contents.trim().is_empty() {
+            return Ok(Self::default());
+        }
+
+        Ok(toml::from_str(&contents)?)
+    }
+
+    pub fn load_or_create_default_at(path: &Path) -> Result<Self> {
+        if path.exists() {
+            return Self::load_from_path(path);
+        }
+
+        let config = Self::default();
+        config.save_to_path(path)?;
+        Ok(config)
+    }
+
+    pub fn save_to_path(&self, path: &Path) -> Result<()> {
+        let Some(parent) = path.parent() else {
+            return Err(Error::Io(std::io::Error::other(
+                "config path has no parent directory",
+            )));
+        };
+
+        std::fs::create_dir_all(parent)?;
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+}
+
+pub fn config_dir() -> Result<PathBuf> {
+    dirs::config_dir()
+        .map(|path| path.join("gwt"))
+        .ok_or(Error::ConfigDirectoryUnavailable)
+}
+
+pub fn config_path() -> Result<PathBuf> {
+    Ok(config_dir()?.join("config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const LIVE_SHAPE: &str = r#"[repos."/home/allison/general_wisdom/monorepo/.git"]
+post_create_commands = [
+    "just setup",
+    "thoughts init",
+    "echo 'Worktree setup complete!'",
+]
+
+[repos."/home/allison/git/agentic_auxilary/.git"]
+post_create_commands = [
+    "thoughts init",
+    "echo 'Worktree setup complete!'",
+]
+"#;
+
+    #[test]
+    fn load_missing_file_is_side_effect_free() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("config.toml");
+
+        let config = GwtConfig::load_from_path(&path).unwrap();
+
+        assert_eq!(config, GwtConfig::default());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn load_or_create_default_writes_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("gwt").join("config.toml");
+
+        let config = GwtConfig::load_or_create_default_at(&path).unwrap();
+
+        assert_eq!(config, GwtConfig::default());
+        assert!(path.exists());
+        let saved = std::fs::read_to_string(path).unwrap();
+        assert!(!saved.contains("default_repo"));
+    }
+
+    #[test]
+    fn omits_default_repo_when_unset() {
+        let config = GwtConfig::default();
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+
+        assert!(!serialized.contains("default_repo"));
+    }
+
+    #[test]
+    fn live_shape_round_trips() {
+        let config: GwtConfig = toml::from_str(LIVE_SHAPE).unwrap();
+
+        assert_eq!(config.default_repo, None);
+        assert!(
+            config
+                .repos
+                .contains_key("/home/allison/general_wisdom/monorepo/.git")
+        );
+        assert!(
+            config
+                .repos
+                .contains_key("/home/allison/git/agentic_auxilary/.git")
+        );
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reparsed: Value = serialized.parse::<Value>().unwrap();
+        let original: Value = LIVE_SHAPE.parse::<Value>().unwrap();
+        assert_eq!(reparsed, original);
+    }
+
+    #[test]
+    fn preserves_unknown_keys() {
+        let input = r#"default_repo = "/tmp/repo/.git"
+custom_root = "root-value"
+
+[repos."/tmp/repo/.git"]
+post_create_commands = ["thoughts init"]
+custom_repo_flag = true
+"#;
+
+        let config: GwtConfig = toml::from_str(input).unwrap();
+        let round_trip = toml::to_string_pretty(&config).unwrap();
+        let reparsed: Value = round_trip.parse::<Value>().unwrap();
+        let original: Value = input.parse::<Value>().unwrap();
+
+        assert_eq!(reparsed, original);
+    }
+}

--- a/crates/infra/gwt-worktree/src/error.rs
+++ b/crates/infra/gwt-worktree/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use std::path::PathBuf;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
@@ -40,4 +42,8 @@ pub enum Error {
     WorktreeOutsideBase,
     #[error("remote branch deleter is required")]
     MissingRemoteBranchDeleter,
+    #[error("worktree path no longer exists: {0}")]
+    MissingWorktreePath(PathBuf),
+    #[error("registered worktree not found for path: {0}")]
+    RegisteredWorktreeNotFound(PathBuf),
 }

--- a/crates/infra/gwt-worktree/src/error.rs
+++ b/crates/infra/gwt-worktree/src/error.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("gwt config directory is unavailable")]
+    ConfigDirectoryUnavailable,
+    #[error("git error: {0}")]
+    Git(#[from] git2::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML deserialize error: {0}")]
+    TomlDeserialize(#[from] toml::de::Error),
+    #[error("TOML serialize error: {0}")]
+    TomlSerialize(#[from] toml::ser::Error),
+    #[error("could not resolve control repository")]
+    ControlRepoNotFound,
+    #[error("invalid branch name: {0}")]
+    InvalidBranchName(String),
+    #[error("invalid worktree admin name: {0}")]
+    InvalidAdminName(String),
+    #[error("invalid worktree admin encoding: {0}")]
+    InvalidAdminEncoding(String),
+    #[error("remote refresh capability is required")]
+    MissingRemoteRefresher,
+    #[error("branch not found: {0}")]
+    BranchNotFound(String),
+    #[error("missing switch start point for force-create")]
+    MissingStartPoint,
+    #[error("invalid object id: {0}")]
+    InvalidObjectId(String),
+    #[error("cannot remove the main worktree")]
+    CannotRemoveMainWorktree,
+    #[error("worktree has uncommitted changes")]
+    DirtyWorktree,
+    #[error("worktree is locked")]
+    LockedWorktree,
+    #[error("worktree is outside the canonical .gwt base")]
+    WorktreeOutsideBase,
+    #[error("remote branch deleter is required")]
+    MissingRemoteBranchDeleter,
+}

--- a/crates/infra/gwt-worktree/src/error.rs
+++ b/crates/infra/gwt-worktree/src/error.rs
@@ -42,8 +42,14 @@ pub enum Error {
     WorktreeOutsideBase,
     #[error("remote branch deleter is required")]
     MissingRemoteBranchDeleter,
+    #[error("could not resolve remote for deleting branch: {branch}")]
+    RemoteDeleteRemoteUnresolved { branch: String },
+    #[error("configured delete remote not found for branch {branch}: {remote}")]
+    RemoteDeleteRemoteMissing { branch: String, remote: String },
     #[error("worktree path no longer exists: {0}")]
     MissingWorktreePath(PathBuf),
+    #[error("switch target path is outside worktree base: base={base:?} target={target:?}")]
+    SwitchTargetOutsideBase { base: PathBuf, target: PathBuf },
     #[error("registered worktree not found for path: {0}")]
     RegisteredWorktreeNotFound(PathBuf),
 }

--- a/crates/infra/gwt-worktree/src/exec/gc.rs
+++ b/crates/infra/gwt-worktree/src/exec/gc.rs
@@ -1,11 +1,13 @@
 use crate::command::CommandSpec;
+use crate::error::Error;
 use crate::error::Result;
 use crate::plan::gc::GcPlan;
 use crate::repo::ControlRepo;
+use crate::worktree::find_worktree_by_path;
 use git2::BranchType;
 use git2::Repository;
-use git2::Worktree;
 use git2::WorktreePruneOptions;
+use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GcExecutionResult {
@@ -20,21 +22,12 @@ pub fn execute_gc_plan(control_repo: &ControlRepo, plan: &GcPlan) -> Result<GcEx
     let mut pruned_paths = Vec::new();
 
     for item in &plan.prunable {
-        if let Ok(linked_repo) = Repository::open(&item.path) {
-            let worktree = Worktree::open_from_repository(&linked_repo)?;
-            let mut prune_options = WorktreePruneOptions::new();
-            prune_options.valid(true).working_tree(true).locked(true);
-            worktree.prune(Some(&mut prune_options))?;
-            pruned_paths.push(item.path.clone());
-        }
+        prune_at_path(&control, &item.path, item.locked)?;
+        pruned_paths.push(item.path.clone());
     }
 
     for item in &plan.to_delete {
-        let linked_repo = Repository::open(&item.path)?;
-        let worktree = Worktree::open_from_repository(&linked_repo)?;
-        let mut prune_options = WorktreePruneOptions::new();
-        prune_options.valid(true).working_tree(true).locked(false);
-        worktree.prune(Some(&mut prune_options))?;
+        prune_at_path(&control, &item.path, false)?;
         if let Some(branch) = &item.branch
             && let Ok(mut local_branch) = control.find_branch(branch, BranchType::Local)
         {
@@ -48,4 +41,14 @@ pub fn execute_gc_plan(control_repo: &ControlRepo, plan: &GcPlan) -> Result<GcEx
         deleted_paths,
         pruned_paths,
     })
+}
+
+fn prune_at_path(control: &Repository, path: &Path, locked: bool) -> Result<()> {
+    let worktree = find_worktree_by_path(control, path)?
+        .ok_or_else(|| Error::RegisteredWorktreeNotFound(path.to_path_buf()))?;
+
+    let mut prune_options = WorktreePruneOptions::new();
+    prune_options.valid(true).working_tree(true).locked(locked);
+    worktree.prune(Some(&mut prune_options))?;
+    Ok(())
 }

--- a/crates/infra/gwt-worktree/src/exec/gc.rs
+++ b/crates/infra/gwt-worktree/src/exec/gc.rs
@@ -1,0 +1,51 @@
+use crate::command::CommandSpec;
+use crate::error::Result;
+use crate::plan::gc::GcPlan;
+use crate::repo::ControlRepo;
+use git2::BranchType;
+use git2::Repository;
+use git2::Worktree;
+use git2::WorktreePruneOptions;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcExecutionResult {
+    pub commands_to_run: Vec<CommandSpec>,
+    pub deleted_paths: Vec<std::path::PathBuf>,
+    pub pruned_paths: Vec<std::path::PathBuf>,
+}
+
+pub fn execute_gc_plan(control_repo: &ControlRepo, plan: &GcPlan) -> Result<GcExecutionResult> {
+    let control = Repository::open(&control_repo.common_dir)?;
+    let mut deleted_paths = Vec::new();
+    let mut pruned_paths = Vec::new();
+
+    for item in &plan.prunable {
+        if let Ok(linked_repo) = Repository::open(&item.path) {
+            let worktree = Worktree::open_from_repository(&linked_repo)?;
+            let mut prune_options = WorktreePruneOptions::new();
+            prune_options.valid(true).working_tree(true).locked(true);
+            worktree.prune(Some(&mut prune_options))?;
+            pruned_paths.push(item.path.clone());
+        }
+    }
+
+    for item in &plan.to_delete {
+        let linked_repo = Repository::open(&item.path)?;
+        let worktree = Worktree::open_from_repository(&linked_repo)?;
+        let mut prune_options = WorktreePruneOptions::new();
+        prune_options.valid(true).working_tree(true).locked(false);
+        worktree.prune(Some(&mut prune_options))?;
+        if let Some(branch) = &item.branch
+            && let Ok(mut local_branch) = control.find_branch(branch, BranchType::Local)
+        {
+            local_branch.delete()?;
+        }
+        deleted_paths.push(item.path.clone());
+    }
+
+    Ok(GcExecutionResult {
+        commands_to_run: plan.commands_to_run.clone(),
+        deleted_paths,
+        pruned_paths,
+    })
+}

--- a/crates/infra/gwt-worktree/src/exec/mod.rs
+++ b/crates/infra/gwt-worktree/src/exec/mod.rs
@@ -1,0 +1,3 @@
+pub mod gc;
+pub mod remove;
+pub mod switch;

--- a/crates/infra/gwt-worktree/src/exec/remove.rs
+++ b/crates/infra/gwt-worktree/src/exec/remove.rs
@@ -3,10 +3,10 @@ use crate::error::Result;
 use crate::plan::remove::RemovePlan;
 use crate::remote::RemoteBranchDeleter;
 use crate::repo::ControlRepo;
+use crate::worktree::find_worktree_by_path;
 use crate::worktree::is_worktree_dirty;
 use git2::BranchType;
 use git2::Repository;
-use git2::Worktree;
 use git2::WorktreePruneOptions;
 
 pub fn execute_remove_plan(
@@ -21,13 +21,18 @@ pub fn execute_remove_plan(
         return Err(Error::WorktreeOutsideBase);
     }
 
-    let linked_repo = Repository::open(&plan.worktree_path)?;
-    if is_worktree_dirty(&linked_repo)? && !plan.force {
-        return Err(Error::DirtyWorktree);
+    if !plan.prunable && plan.worktree_path.exists() {
+        let linked_repo = Repository::open(&plan.worktree_path)?;
+        if is_worktree_dirty(&linked_repo)? && !plan.force {
+            return Err(Error::DirtyWorktree);
+        }
     }
 
-    let worktree = Worktree::open_from_repository(&linked_repo)?;
-    if !matches!(worktree.is_locked()?, git2::WorktreeLockStatus::Unlocked) && !plan.force {
+    let control = Repository::open(&control_repo.common_dir)?;
+    let worktree = find_worktree_by_path(&control, &plan.worktree_path)?
+        .ok_or_else(|| Error::RegisteredWorktreeNotFound(plan.worktree_path.clone()))?;
+    let locked = !matches!(worktree.is_locked()?, git2::WorktreeLockStatus::Unlocked);
+    if locked && !plan.force {
         return Err(Error::LockedWorktree);
     }
 
@@ -41,10 +46,9 @@ pub fn execute_remove_plan(
     prune_options
         .valid(true)
         .working_tree(true)
-        .locked(plan.force);
+        .locked(plan.force || locked);
     worktree.prune(Some(&mut prune_options))?;
 
-    let control = Repository::open(&control_repo.common_dir)?;
     if let Ok(mut branch) = control.find_branch(plan.branch.as_str(), BranchType::Local) {
         branch.delete()?;
     }

--- a/crates/infra/gwt-worktree/src/exec/remove.rs
+++ b/crates/infra/gwt-worktree/src/exec/remove.rs
@@ -54,7 +54,12 @@ pub fn execute_remove_plan(
     }
 
     if let Some(deleter) = deleter {
-        deleter.delete_remote_branch(&control, "origin", &plan.branch)?;
+        let remote = plan.remote_to_delete.as_deref().ok_or_else(|| {
+            Error::RemoteDeleteRemoteUnresolved {
+                branch: plan.branch.to_string(),
+            }
+        })?;
+        deleter.delete_remote_branch(&control, remote, &plan.branch)?;
     }
 
     Ok(())

--- a/crates/infra/gwt-worktree/src/exec/remove.rs
+++ b/crates/infra/gwt-worktree/src/exec/remove.rs
@@ -1,0 +1,57 @@
+use crate::error::Error;
+use crate::error::Result;
+use crate::plan::remove::RemovePlan;
+use crate::remote::RemoteBranchDeleter;
+use crate::repo::ControlRepo;
+use crate::worktree::is_worktree_dirty;
+use git2::BranchType;
+use git2::Repository;
+use git2::Worktree;
+use git2::WorktreePruneOptions;
+
+pub fn execute_remove_plan(
+    control_repo: &ControlRepo,
+    plan: &RemovePlan,
+    remote_deleter: Option<&dyn RemoteBranchDeleter>,
+) -> Result<()> {
+    if plan.is_main {
+        return Err(Error::CannotRemoveMainWorktree);
+    }
+    if plan.outside_base && !plan.allow_outside_base {
+        return Err(Error::WorktreeOutsideBase);
+    }
+
+    let linked_repo = Repository::open(&plan.worktree_path)?;
+    if is_worktree_dirty(&linked_repo)? && !plan.force {
+        return Err(Error::DirtyWorktree);
+    }
+
+    let worktree = Worktree::open_from_repository(&linked_repo)?;
+    if !matches!(worktree.is_locked()?, git2::WorktreeLockStatus::Unlocked) && !plan.force {
+        return Err(Error::LockedWorktree);
+    }
+
+    let deleter = if plan.delete_remote {
+        Some(remote_deleter.ok_or(Error::MissingRemoteBranchDeleter)?)
+    } else {
+        None
+    };
+
+    let mut prune_options = WorktreePruneOptions::new();
+    prune_options
+        .valid(true)
+        .working_tree(true)
+        .locked(plan.force);
+    worktree.prune(Some(&mut prune_options))?;
+
+    let control = Repository::open(&control_repo.common_dir)?;
+    if let Ok(mut branch) = control.find_branch(plan.branch.as_str(), BranchType::Local) {
+        branch.delete()?;
+    }
+
+    if let Some(deleter) = deleter {
+        deleter.delete_remote_branch(&control, "origin", &plan.branch)?;
+    }
+
+    Ok(())
+}

--- a/crates/infra/gwt-worktree/src/exec/switch.rs
+++ b/crates/infra/gwt-worktree/src/exec/switch.rs
@@ -10,6 +10,8 @@ use git2::BranchType;
 use git2::Oid;
 use git2::Repository;
 use git2::WorktreeAddOptions;
+use std::path::Component;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,18 +36,22 @@ pub fn execute_switch_plan(
             plan.target_path.clone()
         }
         SwitchPlanKind::ExistingLocalBranch => {
+            ensure_target_path_within_base(&control_repo.worktree_base, &plan.target_path)?;
             attach_existing_branch(&repo, plan)?;
             plan.target_path.clone()
         }
         SwitchPlanKind::CreateBranch { start_point } => {
+            ensure_target_path_within_base(&control_repo.worktree_base, &plan.target_path)?;
             create_branch_and_worktree(&repo, plan, start_point, false)?;
             plan.target_path.clone()
         }
         SwitchPlanKind::ForceCreateBranch { start_point } => {
+            ensure_target_path_within_base(&control_repo.worktree_base, &plan.target_path)?;
             create_branch_and_worktree(&repo, plan, start_point, true)?;
             plan.target_path.clone()
         }
         SwitchPlanKind::CreateTrackingBranch { .. } => {
+            ensure_target_path_within_base(&control_repo.worktree_base, &plan.target_path)?;
             create_tracking_branch_and_worktree(
                 &repo,
                 plan,
@@ -116,4 +122,33 @@ fn resolve_start_point<'a>(
             Ok(branch.get().peel_to_commit()?)
         }
     }
+}
+
+fn ensure_target_path_within_base(base: &Path, target: &Path) -> Result<()> {
+    if normalize_path(target).starts_with(normalize_path(base)) {
+        Ok(())
+    } else {
+        Err(Error::SwitchTargetOutsideBase {
+            base: base.to_path_buf(),
+            target: target.to_path_buf(),
+        })
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
 }

--- a/crates/infra/gwt-worktree/src/exec/switch.rs
+++ b/crates/infra/gwt-worktree/src/exec/switch.rs
@@ -1,0 +1,114 @@
+use crate::command::CommandSpec;
+use crate::error::Error;
+use crate::error::Result;
+use crate::plan::switch::SwitchPlan;
+use crate::plan::switch::SwitchPlanKind;
+use crate::plan::switch::SwitchStartPoint;
+use crate::remote::RemoteRefresher;
+use crate::repo::ControlRepo;
+use git2::BranchType;
+use git2::Oid;
+use git2::Repository;
+use git2::WorktreeAddOptions;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchExecutionResult {
+    pub path: PathBuf,
+    pub post_create_commands: Vec<CommandSpec>,
+}
+
+pub fn execute_switch_plan(
+    control_repo: &ControlRepo,
+    plan: &SwitchPlan,
+    remote_refresher: Option<&dyn RemoteRefresher>,
+) -> Result<SwitchExecutionResult> {
+    let repo = Repository::open(&control_repo.common_dir)?;
+    control_repo.ensure_worktree_base()?;
+
+    let path = match &plan.kind {
+        SwitchPlanKind::Main | SwitchPlanKind::ExistingWorktree => plan.target_path.clone(),
+        SwitchPlanKind::ExistingLocalBranch => {
+            attach_existing_branch(&repo, plan)?;
+            plan.target_path.clone()
+        }
+        SwitchPlanKind::CreateBranch { start_point } => {
+            create_branch_and_worktree(&repo, plan, start_point, false)?;
+            plan.target_path.clone()
+        }
+        SwitchPlanKind::ForceCreateBranch { start_point } => {
+            create_branch_and_worktree(&repo, plan, start_point, true)?;
+            plan.target_path.clone()
+        }
+        SwitchPlanKind::CreateTrackingBranch { .. } => {
+            create_tracking_branch_and_worktree(
+                &repo,
+                plan,
+                remote_refresher.ok_or(Error::MissingRemoteRefresher)?,
+            )?;
+            plan.target_path.clone()
+        }
+    };
+
+    Ok(SwitchExecutionResult {
+        path,
+        post_create_commands: plan.post_create_commands.clone(),
+    })
+}
+
+fn attach_existing_branch(repo: &Repository, plan: &SwitchPlan) -> Result<()> {
+    std::fs::create_dir_all(plan.target_path.parent().unwrap_or(&plan.target_path))?;
+    let branch = repo.find_branch(plan.branch.as_str(), BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree(plan.admin_name.as_str(), &plan.target_path, Some(&options))?;
+    Ok(())
+}
+
+fn create_branch_and_worktree(
+    repo: &Repository,
+    plan: &SwitchPlan,
+    start_point: &SwitchStartPoint,
+    force: bool,
+) -> Result<()> {
+    std::fs::create_dir_all(plan.target_path.parent().unwrap_or(&plan.target_path))?;
+    let commit = resolve_start_point(repo, start_point)?;
+    repo.branch(plan.branch.as_str(), &commit, force)?;
+    attach_existing_branch(repo, plan)
+}
+
+fn create_tracking_branch_and_worktree(
+    repo: &Repository,
+    plan: &SwitchPlan,
+    remote_refresher: &dyn RemoteRefresher,
+) -> Result<()> {
+    remote_refresher.refresh(repo)?;
+    let target = remote_refresher
+        .resolve_branch_target(repo, &plan.branch)?
+        .ok_or_else(|| Error::BranchNotFound(plan.branch.to_string()))?;
+    let oid = Oid::from_str(&target.commit_oid)
+        .map_err(|_| Error::InvalidObjectId(target.commit_oid.clone()))?;
+    repo.reference(&target.refname, oid, true, "create remote-tracking ref")?;
+    let commit = repo.find_commit(oid)?;
+    let mut branch = repo.branch(plan.branch.as_str(), &commit, false)?;
+    branch.set_upstream(Some(&format!("{}/{}", target.remote, plan.branch.as_str())))?;
+    attach_existing_branch(repo, plan)
+}
+
+fn resolve_start_point<'a>(
+    repo: &'a Repository,
+    start_point: &SwitchStartPoint,
+) -> Result<git2::Commit<'a>> {
+    match start_point {
+        SwitchStartPoint::Head => Ok(repo.head()?.peel_to_commit()?),
+        SwitchStartPoint::Commit(oid) => {
+            let oid = Oid::from_str(oid).map_err(|_| Error::InvalidObjectId(oid.clone()))?;
+            Ok(repo.find_commit(oid)?)
+        }
+        SwitchStartPoint::LocalBranch(branch) => {
+            let branch = repo.find_branch(branch, BranchType::Local)?;
+            Ok(branch.get().peel_to_commit()?)
+        }
+    }
+}

--- a/crates/infra/gwt-worktree/src/exec/switch.rs
+++ b/crates/infra/gwt-worktree/src/exec/switch.rs
@@ -27,7 +27,12 @@ pub fn execute_switch_plan(
     control_repo.ensure_worktree_base()?;
 
     let path = match &plan.kind {
-        SwitchPlanKind::Main | SwitchPlanKind::ExistingWorktree => plan.target_path.clone(),
+        SwitchPlanKind::Main | SwitchPlanKind::ExistingWorktree => {
+            if !plan.target_path.exists() {
+                return Err(Error::MissingWorktreePath(plan.target_path.clone()));
+            }
+            plan.target_path.clone()
+        }
         SwitchPlanKind::ExistingLocalBranch => {
             attach_existing_branch(&repo, plan)?;
             plan.target_path.clone()

--- a/crates/infra/gwt-worktree/src/lib.rs
+++ b/crates/infra/gwt-worktree/src/lib.rs
@@ -1,0 +1,15 @@
+//! Programmatic gwt-compatible git worktree management.
+
+pub mod command;
+pub mod config;
+pub mod error;
+pub mod exec;
+pub mod plan;
+pub mod pr;
+pub mod remote;
+pub mod repo;
+pub mod types;
+pub mod worktree;
+
+pub use error::Error;
+pub use error::Result;

--- a/crates/infra/gwt-worktree/src/plan/gc.rs
+++ b/crates/infra/gwt-worktree/src/plan/gc.rs
@@ -1,0 +1,113 @@
+use crate::command::CommandSpec;
+use crate::config::RepoConfig;
+use crate::error::Result;
+use crate::repo::ControlRepo;
+use crate::worktree::is_worktree_dirty;
+use crate::worktree::list_worktrees;
+use git2::Repository;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcPolicy {
+    pub clean_days: u64,
+    pub delete_days: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcItem {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub age_days: u64,
+    pub dirty: bool,
+    pub merged_to_main: bool,
+    pub locked: bool,
+    pub prunable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GcPlan {
+    pub commands_to_run: Vec<CommandSpec>,
+    pub to_clean: Vec<GcItem>,
+    pub to_delete: Vec<GcItem>,
+    pub dirty: Vec<GcItem>,
+    pub unmerged: Vec<GcItem>,
+    pub skip: Vec<GcItem>,
+    pub prunable: Vec<GcItem>,
+}
+
+pub fn plan_gc(
+    control_repo: &ControlRepo,
+    repo_config: Option<&RepoConfig>,
+    policy: &GcPolicy,
+) -> Result<GcPlan> {
+    let repo = Repository::open(&control_repo.common_dir)?;
+    let main_oid = repo
+        .head()
+        .ok()
+        .and_then(|head| head.peel_to_commit().ok())
+        .map(|commit| commit.id());
+    let mut plan = GcPlan::default();
+    if let Some(clean_command) = repo_config.and_then(|config| config.clean_command.clone()) {
+        plan.commands_to_run.push(clean_command);
+    }
+
+    for entry in list_worktrees(control_repo)? {
+        if entry.is_main {
+            continue;
+        }
+
+        let metadata = std::fs::metadata(&entry.path)?;
+        let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        let age_days = SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default()
+            .as_secs()
+            / 86_400;
+        let linked_repo = Repository::open(&entry.path)?;
+        let dirty = is_worktree_dirty(&linked_repo)?;
+        let merged_to_main = match (
+            main_oid,
+            linked_repo
+                .head()
+                .ok()
+                .and_then(|head| head.peel_to_commit().ok()),
+        ) {
+            (Some(main), Some(head_commit)) => {
+                head_commit.id() == main
+                    || repo
+                        .graph_descendant_of(main, head_commit.id())
+                        .unwrap_or(false)
+            }
+            _ => false,
+        };
+        let item = GcItem {
+            path: entry.path,
+            branch: entry.branch,
+            age_days,
+            dirty,
+            merged_to_main,
+            locked: entry.locked,
+            prunable: entry.prunable,
+        };
+
+        if item.prunable {
+            plan.prunable.push(item.clone());
+        }
+        if item.locked {
+            plan.skip.push(item);
+        } else if item.dirty {
+            plan.dirty.push(item);
+        } else if !item.merged_to_main && item.age_days >= policy.delete_days {
+            plan.unmerged.push(item);
+        } else if item.age_days >= policy.delete_days {
+            plan.to_delete.push(item);
+        } else if item.age_days >= policy.clean_days {
+            plan.to_clean.push(item);
+        } else {
+            plan.skip.push(item);
+        }
+    }
+
+    Ok(plan)
+}

--- a/crates/infra/gwt-worktree/src/plan/gc.rs
+++ b/crates/infra/gwt-worktree/src/plan/gc.rs
@@ -57,6 +57,19 @@ pub fn plan_gc(
             continue;
         }
 
+        if entry.prunable || !entry.path.exists() {
+            plan.prunable.push(GcItem {
+                path: entry.path,
+                branch: entry.branch,
+                age_days: 0,
+                dirty: false,
+                merged_to_main: false,
+                locked: entry.locked,
+                prunable: true,
+            });
+            continue;
+        }
+
         let metadata = std::fs::metadata(&entry.path)?;
         let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
         let age_days = SystemTime::now()
@@ -91,9 +104,6 @@ pub fn plan_gc(
             prunable: entry.prunable,
         };
 
-        if item.prunable {
-            plan.prunable.push(item.clone());
-        }
         if item.locked {
             plan.skip.push(item);
         } else if item.dirty {

--- a/crates/infra/gwt-worktree/src/plan/gc.rs
+++ b/crates/infra/gwt-worktree/src/plan/gc.rs
@@ -5,6 +5,7 @@ use crate::repo::ControlRepo;
 use crate::worktree::is_worktree_dirty;
 use crate::worktree::list_worktrees;
 use git2::Repository;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -70,14 +71,44 @@ pub fn plan_gc(
             continue;
         }
 
-        let metadata = std::fs::metadata(&entry.path)?;
+        let metadata = match std::fs::metadata(&entry.path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                plan.prunable.push(GcItem {
+                    path: entry.path,
+                    branch: entry.branch,
+                    age_days: 0,
+                    dirty: false,
+                    merged_to_main: false,
+                    locked: entry.locked,
+                    prunable: true,
+                });
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
         let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
         let age_days = SystemTime::now()
             .duration_since(modified)
             .unwrap_or_default()
             .as_secs()
             / 86_400;
-        let linked_repo = Repository::open(&entry.path)?;
+        let linked_repo = match Repository::open(&entry.path) {
+            Ok(linked_repo) => linked_repo,
+            Err(error) if error.code() == git2::ErrorCode::NotFound => {
+                plan.prunable.push(GcItem {
+                    path: entry.path,
+                    branch: entry.branch,
+                    age_days: 0,
+                    dirty: false,
+                    merged_to_main: false,
+                    locked: entry.locked,
+                    prunable: true,
+                });
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
         let dirty = is_worktree_dirty(&linked_repo)?;
         let merged_to_main = match (
             main_oid,

--- a/crates/infra/gwt-worktree/src/plan/mod.rs
+++ b/crates/infra/gwt-worktree/src/plan/mod.rs
@@ -1,0 +1,3 @@
+pub mod gc;
+pub mod remove;
+pub mod switch;

--- a/crates/infra/gwt-worktree/src/plan/remove.rs
+++ b/crates/infra/gwt-worktree/src/plan/remove.rs
@@ -43,7 +43,7 @@ pub fn plan_remove(
         .into_iter()
         .find(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
         .ok_or_else(|| Error::BranchNotFound(request.branch.to_string()))?;
-    let dirty = if entry.is_main {
+    let dirty = if entry.is_main || entry.prunable || !entry.path.exists() {
         false
     } else {
         is_worktree_dirty(&Repository::open(&entry.path)?)?

--- a/crates/infra/gwt-worktree/src/plan/remove.rs
+++ b/crates/infra/gwt-worktree/src/plan/remove.rs
@@ -1,0 +1,70 @@
+use crate::error::Error;
+use crate::error::Result;
+use crate::pr::PullRequestLookup;
+use crate::pr::PullRequestState;
+use crate::repo::ControlRepo;
+use crate::types::BranchName;
+use crate::worktree::is_worktree_dirty;
+use crate::worktree::list_worktrees;
+use git2::Repository;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoveRequest {
+    pub branch: BranchName,
+    pub force: bool,
+    pub allow_outside_base: bool,
+    pub delete_remote: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemovePlan {
+    pub branch: BranchName,
+    pub worktree_path: PathBuf,
+    pub is_main: bool,
+    pub dirty: bool,
+    pub locked: bool,
+    pub prunable: bool,
+    pub outside_base: bool,
+    pub force: bool,
+    pub allow_outside_base: bool,
+    pub delete_remote: bool,
+    pub requires_remote_deleter: bool,
+    pub pr_state: Option<PullRequestState>,
+}
+
+pub fn plan_remove(
+    control_repo: &ControlRepo,
+    request: &RemoveRequest,
+    pr_lookup: Option<&dyn PullRequestLookup>,
+) -> Result<RemovePlan> {
+    let entries = list_worktrees(control_repo)?;
+    let entry = entries
+        .into_iter()
+        .find(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
+        .ok_or_else(|| Error::BranchNotFound(request.branch.to_string()))?;
+    let dirty = if entry.is_main {
+        false
+    } else {
+        is_worktree_dirty(&Repository::open(&entry.path)?)?
+    };
+    let outside_base = !entry.path.starts_with(&control_repo.worktree_base);
+    let pr_state = pr_lookup
+        .map(|lookup| lookup.lookup_pull_request_state(&request.branch))
+        .transpose()?;
+
+    Ok(RemovePlan {
+        branch: request.branch.clone(),
+        worktree_path: entry.path,
+        is_main: entry.is_main,
+        dirty,
+        locked: entry.locked,
+        prunable: entry.prunable,
+        outside_base,
+        force: request.force,
+        allow_outside_base: request.allow_outside_base,
+        delete_remote: request.delete_remote,
+        requires_remote_deleter: request.delete_remote,
+        pr_state,
+    })
+}

--- a/crates/infra/gwt-worktree/src/plan/remove.rs
+++ b/crates/infra/gwt-worktree/src/plan/remove.rs
@@ -2,11 +2,14 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::pr::PullRequestLookup;
 use crate::pr::PullRequestState;
+use crate::remote::resolve_remote_for_branch_deletion;
 use crate::repo::ControlRepo;
 use crate::types::BranchName;
 use crate::worktree::is_worktree_dirty;
 use crate::worktree::list_worktrees;
 use git2::Repository;
+use std::path::Component;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,6 +33,7 @@ pub struct RemovePlan {
     pub allow_outside_base: bool,
     pub delete_remote: bool,
     pub requires_remote_deleter: bool,
+    pub remote_to_delete: Option<String>,
     pub pr_state: Option<PullRequestState>,
 }
 
@@ -38,6 +42,7 @@ pub fn plan_remove(
     request: &RemoveRequest,
     pr_lookup: Option<&dyn PullRequestLookup>,
 ) -> Result<RemovePlan> {
+    let control = Repository::open(&control_repo.common_dir)?;
     let entries = list_worktrees(control_repo)?;
     let entry = entries
         .into_iter()
@@ -48,7 +53,16 @@ pub fn plan_remove(
     } else {
         is_worktree_dirty(&Repository::open(&entry.path)?)?
     };
-    let outside_base = !entry.path.starts_with(&control_repo.worktree_base);
+    let outside_base =
+        !path_within_base_canonicalize_when_possible(&control_repo.worktree_base, &entry.path);
+    let remote_to_delete = if request.delete_remote {
+        Some(resolve_remote_for_branch_deletion(
+            &control,
+            &request.branch,
+        )?)
+    } else {
+        None
+    };
     let pr_state = pr_lookup
         .map(|lookup| lookup.lookup_pull_request_state(&request.branch))
         .transpose()?;
@@ -65,6 +79,32 @@ pub fn plan_remove(
         allow_outside_base: request.allow_outside_base,
         delete_remote: request.delete_remote,
         requires_remote_deleter: request.delete_remote,
+        remote_to_delete,
         pr_state,
     })
+}
+
+fn path_within_base_canonicalize_when_possible(base: &Path, path: &Path) -> bool {
+    match (base.canonicalize(), path.canonicalize()) {
+        (Ok(canonical_base), Ok(canonical_path)) => canonical_path.starts_with(canonical_base),
+        _ => normalize_path(path).starts_with(normalize_path(base)),
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
 }

--- a/crates/infra/gwt-worktree/src/plan/switch.rs
+++ b/crates/infra/gwt-worktree/src/plan/switch.rs
@@ -77,10 +77,11 @@ pub fn plan_switch(
         });
     }
 
-    if let Some(entry) = list_worktrees(control_repo)?
-        .into_iter()
-        .find(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
-    {
+    if let Some(entry) = list_worktrees(control_repo)?.into_iter().find(|entry| {
+        entry.branch.as_deref() == Some(request.branch.as_str())
+            && !entry.prunable
+            && entry.path.exists()
+    }) {
         return Ok(SwitchPlan {
             branch: request.branch.clone(),
             admin_name,

--- a/crates/infra/gwt-worktree/src/plan/switch.rs
+++ b/crates/infra/gwt-worktree/src/plan/switch.rs
@@ -77,14 +77,14 @@ pub fn plan_switch(
         });
     }
 
-    if list_worktrees(control_repo)?
-        .iter()
-        .any(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
+    if let Some(entry) = list_worktrees(control_repo)?
+        .into_iter()
+        .find(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
     {
         return Ok(SwitchPlan {
             branch: request.branch.clone(),
             admin_name,
-            target_path,
+            target_path: entry.path,
             kind: SwitchPlanKind::ExistingWorktree,
             post_create_commands,
         });

--- a/crates/infra/gwt-worktree/src/plan/switch.rs
+++ b/crates/infra/gwt-worktree/src/plan/switch.rs
@@ -1,0 +1,149 @@
+use crate::command::CommandSpec;
+use crate::config::RepoConfig;
+use crate::error::Error;
+use crate::error::Result;
+use crate::repo::ControlRepo;
+use crate::types::AdminName;
+use crate::types::BranchName;
+use crate::worktree::list_worktrees;
+use git2::BranchType;
+use git2::Repository;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwitchStartPoint {
+    Head,
+    Commit(String),
+    LocalBranch(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchRequest {
+    pub branch: BranchName,
+    pub create: bool,
+    pub force_create: bool,
+    pub start_point: Option<SwitchStartPoint>,
+    pub guess_remote: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwitchPlanKind {
+    Main,
+    ExistingWorktree,
+    ExistingLocalBranch,
+    CreateBranch { start_point: SwitchStartPoint },
+    ForceCreateBranch { start_point: SwitchStartPoint },
+    CreateTrackingBranch { refresh_required: bool },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchPlan {
+    pub branch: BranchName,
+    pub admin_name: AdminName,
+    pub target_path: PathBuf,
+    pub kind: SwitchPlanKind,
+    pub post_create_commands: Vec<CommandSpec>,
+}
+
+pub fn default_start_point() -> SwitchStartPoint {
+    SwitchStartPoint::Head
+}
+
+pub fn plan_switch(
+    control_repo: &ControlRepo,
+    request: &SwitchRequest,
+    repo_config: Option<&RepoConfig>,
+) -> Result<SwitchPlan> {
+    let repo = Repository::open(&control_repo.common_dir)?;
+    let target_path = control_repo.worktree_base.join(request.branch.as_str());
+    let admin_name = request.branch.encode_admin_name();
+    let post_create_commands = repo_config
+        .map(|config| config.post_create_commands.clone())
+        .unwrap_or_default();
+
+    let main_branch = repo
+        .head()
+        .ok()
+        .and_then(|head| head.shorthand().map(ToOwned::to_owned));
+    if main_branch.as_deref() == Some(request.branch.as_str())
+        && control_repo.main_workdir.is_some()
+    {
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path: control_repo.main_workdir.clone().unwrap_or(target_path),
+            kind: SwitchPlanKind::Main,
+            post_create_commands,
+        });
+    }
+
+    if list_worktrees(control_repo)?
+        .iter()
+        .any(|entry| entry.branch.as_deref() == Some(request.branch.as_str()))
+    {
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path,
+            kind: SwitchPlanKind::ExistingWorktree,
+            post_create_commands,
+        });
+    }
+
+    if repo
+        .find_branch(request.branch.as_str(), BranchType::Local)
+        .is_ok()
+        && !request.create
+        && !request.force_create
+    {
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path,
+            kind: SwitchPlanKind::ExistingLocalBranch,
+            post_create_commands,
+        });
+    }
+
+    if request.force_create {
+        let Some(start_point) = request.start_point.clone() else {
+            return Err(Error::MissingStartPoint);
+        };
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path,
+            kind: SwitchPlanKind::ForceCreateBranch { start_point },
+            post_create_commands,
+        });
+    }
+
+    if request.create {
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path,
+            kind: SwitchPlanKind::CreateBranch {
+                start_point: request
+                    .start_point
+                    .clone()
+                    .unwrap_or_else(default_start_point),
+            },
+            post_create_commands,
+        });
+    }
+
+    if request.guess_remote {
+        return Ok(SwitchPlan {
+            branch: request.branch.clone(),
+            admin_name,
+            target_path,
+            kind: SwitchPlanKind::CreateTrackingBranch {
+                refresh_required: true,
+            },
+            post_create_commands,
+        });
+    }
+
+    Err(Error::BranchNotFound(request.branch.to_string()))
+}

--- a/crates/infra/gwt-worktree/src/pr.rs
+++ b/crates/infra/gwt-worktree/src/pr.rs
@@ -1,0 +1,14 @@
+use crate::error::Result;
+use crate::types::BranchName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PullRequestState {
+    Open,
+    Closed,
+    Merged,
+    Unknown,
+}
+
+pub trait PullRequestLookup {
+    fn lookup_pull_request_state(&self, branch: &BranchName) -> Result<PullRequestState>;
+}

--- a/crates/infra/gwt-worktree/src/remote.rs
+++ b/crates/infra/gwt-worktree/src/remote.rs
@@ -1,0 +1,28 @@
+use crate::error::Result;
+use crate::types::BranchName;
+use git2::Repository;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteBranchTarget {
+    pub remote: String,
+    pub refname: String,
+    pub commit_oid: String,
+}
+
+pub trait RemoteRefresher {
+    fn refresh(&self, repo: &Repository) -> Result<()>;
+    fn resolve_branch_target(
+        &self,
+        repo: &Repository,
+        branch: &BranchName,
+    ) -> Result<Option<RemoteBranchTarget>>;
+}
+
+pub trait RemoteBranchDeleter {
+    fn delete_remote_branch(
+        &self,
+        repo: &Repository,
+        remote: &str,
+        branch: &BranchName,
+    ) -> Result<()>;
+}

--- a/crates/infra/gwt-worktree/src/remote.rs
+++ b/crates/infra/gwt-worktree/src/remote.rs
@@ -49,7 +49,11 @@ pub(crate) fn resolve_remote_for_branch_deletion(
 }
 
 fn upstream_remote_name(repo: &Repository, branch: &BranchName) -> Result<Option<String>> {
-    let branch = repo.find_branch(branch.as_str(), BranchType::Local)?;
+    let branch = match repo.find_branch(branch.as_str(), BranchType::Local) {
+        Ok(branch) => branch,
+        Err(error) if error.code() == git2::ErrorCode::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
     let upstream = match branch.upstream() {
         Ok(upstream) => upstream,
         Err(error) if error.code() == git2::ErrorCode::NotFound => return Ok(None),

--- a/crates/infra/gwt-worktree/src/remote.rs
+++ b/crates/infra/gwt-worktree/src/remote.rs
@@ -1,5 +1,7 @@
+use crate::error::Error;
 use crate::error::Result;
 use crate::types::BranchName;
+use git2::BranchType;
 use git2::Repository;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,4 +27,59 @@ pub trait RemoteBranchDeleter {
         remote: &str,
         branch: &BranchName,
     ) -> Result<()>;
+}
+
+pub(crate) fn resolve_remote_for_branch_deletion(
+    repo: &Repository,
+    branch: &BranchName,
+) -> Result<String> {
+    if let Some(remote) = upstream_remote_name(repo, branch)? {
+        ensure_remote_exists(repo, branch, &remote)?;
+        return Ok(remote);
+    }
+
+    let origin = String::from("origin");
+    if has_remote(repo, &origin)? {
+        return Ok(origin);
+    }
+
+    Err(Error::RemoteDeleteRemoteUnresolved {
+        branch: branch.to_string(),
+    })
+}
+
+fn upstream_remote_name(repo: &Repository, branch: &BranchName) -> Result<Option<String>> {
+    let branch = repo.find_branch(branch.as_str(), BranchType::Local)?;
+    let upstream = match branch.upstream() {
+        Ok(upstream) => upstream,
+        Err(error) if error.code() == git2::ErrorCode::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let Some(name) = upstream.name()? else {
+        return Ok(None);
+    };
+    let Some((remote, _)) = name.split_once('/') else {
+        return Ok(None);
+    };
+    if remote == "." {
+        Ok(None)
+    } else {
+        Ok(Some(remote.to_owned()))
+    }
+}
+
+fn ensure_remote_exists(repo: &Repository, branch: &BranchName, remote: &str) -> Result<()> {
+    if has_remote(repo, remote)? {
+        Ok(())
+    } else {
+        Err(Error::RemoteDeleteRemoteMissing {
+            branch: branch.to_string(),
+            remote: remote.to_owned(),
+        })
+    }
+}
+
+fn has_remote(repo: &Repository, remote: &str) -> Result<bool> {
+    let remotes = repo.remotes()?;
+    Ok(remotes.iter().flatten().any(|name| name == remote))
 }

--- a/crates/infra/gwt-worktree/src/repo.rs
+++ b/crates/infra/gwt-worktree/src/repo.rs
@@ -7,6 +7,8 @@ use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
+// Compatibility-critical sentinel written for upstream gwt interoperability.
+// Do not edit without intentionally updating byte-for-byte regression coverage.
 const README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/General-Wisdom/gwt\n";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,6 +231,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    const EXPECTED_README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/General-Wisdom/gwt\n";
+
     #[test]
     fn computes_base_for_normal_repo_git_dir() {
         let temp = TempDir::new().unwrap();
@@ -283,7 +287,7 @@ mod tests {
 
     #[test]
     fn readme_sentinel_uses_canonical_gwt_url() {
-        assert!(readme_sentinel_contents().contains("https://github.com/General-Wisdom/gwt"));
+        assert_eq!(readme_sentinel_contents(), EXPECTED_README_SENTINEL);
     }
 
     #[test]

--- a/crates/infra/gwt-worktree/src/repo.rs
+++ b/crates/infra/gwt-worktree/src/repo.rs
@@ -1,11 +1,13 @@
 use crate::config::GwtConfig;
 use crate::error::Error;
 use crate::error::Result;
+use git2::ErrorCode;
 use git2::Repository;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
-const README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/username/gwt\n";
+const README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/General-Wisdom/gwt\n";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlRepo {
@@ -41,12 +43,12 @@ impl ControlRepo {
     }
 
     pub fn resolve(options: &ResolveControlRepoOptions<'_>) -> Result<Self> {
-        if let Some(repo) = options
-            .path
-            .or(options.cwd)
-            .and_then(|path| resolve_from_discovery(path).ok())
-        {
-            return Ok(repo);
+        if let Some(path) = options.path.or(options.cwd) {
+            match resolve_from_discovery(path) {
+                Ok(repo) => return Ok(repo),
+                Err(Error::Git(error)) if error.code() == ErrorCode::NotFound => {}
+                Err(err) => return Err(err),
+            }
         }
 
         if let Some(env_git_dir) = options.env_git_dir {
@@ -89,11 +91,12 @@ pub fn compute_gwt_base_from_parts(git_dir: &str, resolved_git_dir: &Path) -> Pa
         ));
     }
 
-    if has_exact_git_suffix(git_dir) {
-        return PathBuf::from(format!("{}.gwt", git_dir.trim_end_matches(".git")));
+    let trimmed = git_dir.trim_end_matches('/');
+    if has_exact_git_suffix(trimmed) {
+        return PathBuf::from(format!("{}.gwt", trimmed.trim_end_matches(".git")));
     }
 
-    PathBuf::from(format!("{}.gwt", git_dir.trim_end_matches('/')))
+    PathBuf::from(format!("{trimmed}.gwt"))
 }
 
 pub fn main_worktree_path(git_dir: &str) -> Option<PathBuf> {
@@ -183,7 +186,29 @@ fn resolve_gitdir_pointer(dot_git_file: &Path) -> Result<String> {
             .join(raw_path)
     };
 
+    let resolved = resolved
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_path(resolved.as_path()));
+
     Ok(resolved.to_string_lossy().into_owned())
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
 }
 
 fn normalize_git_dir_key(path: &Path) -> String {
@@ -224,6 +249,12 @@ mod tests {
     }
 
     #[test]
+    fn computes_base_for_bare_suffix_repo_with_trailing_slash() {
+        let base = compute_gwt_base("/tmp/example.git/");
+        assert_eq!(base, PathBuf::from("/tmp/example.gwt"));
+    }
+
+    #[test]
     fn computes_base_for_fallback_path() {
         let base = compute_gwt_base("/tmp/example/");
         assert_eq!(base, PathBuf::from("/tmp/example.gwt"));
@@ -248,6 +279,11 @@ mod tests {
         ensure_worktree_base_dir(&base).unwrap();
 
         assert_eq!(std::fs::read_to_string(&readme).unwrap(), "custom");
+    }
+
+    #[test]
+    fn readme_sentinel_uses_canonical_gwt_url() {
+        assert!(readme_sentinel_contents().contains("https://github.com/General-Wisdom/gwt"));
     }
 
     #[test]
@@ -343,6 +379,32 @@ mod tests {
 
         assert!(resolved.git_dir_key.contains(".git/worktrees/feature"));
         assert_eq!(resolved.common_dir, main_repo.join(".git"));
+    }
+
+    #[test]
+    fn resolves_gitdir_pointer_to_normalized_path() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().join("repo");
+        let dot_git = repo_root.join(".git");
+        let private_gitdir = temp
+            .path()
+            .join("private")
+            .join("worktrees")
+            .join("feature");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        std::fs::create_dir_all(&private_gitdir).unwrap();
+        std::fs::write(
+            &dot_git,
+            "gitdir: ../private/./worktrees/feature/../feature\n",
+        )
+        .unwrap();
+
+        let resolved = resolve_gitdir_pointer(&dot_git).unwrap();
+
+        assert_eq!(
+            PathBuf::from(resolved),
+            private_gitdir.canonicalize().unwrap()
+        );
     }
 
     fn commit_initial(repo: &Repository) {

--- a/crates/infra/gwt-worktree/src/repo.rs
+++ b/crates/infra/gwt-worktree/src/repo.rs
@@ -1,0 +1,358 @@
+use crate::config::GwtConfig;
+use crate::error::Error;
+use crate::error::Result;
+use git2::Repository;
+use std::path::Path;
+use std::path::PathBuf;
+
+const README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/username/gwt\n";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlRepo {
+    pub git_dir_key: String,
+    pub common_dir: PathBuf,
+    pub worktree_base: PathBuf,
+    pub main_workdir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ResolveControlRepoOptions<'a> {
+    pub path: Option<&'a Path>,
+    pub cwd: Option<&'a Path>,
+    pub env_git_dir: Option<&'a str>,
+    pub config: Option<&'a GwtConfig>,
+}
+
+impl ControlRepo {
+    pub fn from_git_dir(git_dir_key: impl Into<String>) -> Result<Self> {
+        let git_dir_key = normalize_git_dir_input(git_dir_key.into())?;
+        let common_dir = PathBuf::from(&git_dir_key);
+        let repo = Repository::open(&common_dir)?;
+        let common_dir = repo.commondir().to_path_buf();
+        let worktree_base = compute_gwt_base_from_parts(&git_dir_key, &common_dir);
+        let main_workdir = main_workdir_from_repo(&repo);
+
+        Ok(Self {
+            git_dir_key,
+            common_dir,
+            worktree_base,
+            main_workdir,
+        })
+    }
+
+    pub fn resolve(options: &ResolveControlRepoOptions<'_>) -> Result<Self> {
+        if let Some(repo) = options
+            .path
+            .or(options.cwd)
+            .and_then(|path| resolve_from_discovery(path).ok())
+        {
+            return Ok(repo);
+        }
+
+        if let Some(env_git_dir) = options.env_git_dir {
+            return Self::from_git_dir(env_git_dir);
+        }
+
+        if let Some(config) = options.config
+            && let Some(default_repo) = &config.default_repo
+        {
+            return Self::from_git_dir(default_repo.clone());
+        }
+
+        Err(Error::ControlRepoNotFound)
+    }
+
+    pub fn ensure_worktree_base(&self) -> Result<()> {
+        ensure_worktree_base_dir(&self.worktree_base)
+    }
+}
+
+pub fn compute_gwt_base(git_dir: &str) -> PathBuf {
+    let resolved = Path::new(git_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(git_dir));
+    compute_gwt_base_from_parts(git_dir, &resolved)
+}
+
+pub fn compute_gwt_base_from_parts(git_dir: &str, resolved_git_dir: &Path) -> PathBuf {
+    if resolved_git_dir
+        .file_name()
+        .is_some_and(|name| name == ".git")
+        && resolved_git_dir.is_dir()
+    {
+        return PathBuf::from(format!(
+            "{}.gwt",
+            resolved_git_dir
+                .parent()
+                .unwrap_or(resolved_git_dir)
+                .display()
+        ));
+    }
+
+    if has_exact_git_suffix(git_dir) {
+        return PathBuf::from(format!("{}.gwt", git_dir.trim_end_matches(".git")));
+    }
+
+    PathBuf::from(format!("{}.gwt", git_dir.trim_end_matches('/')))
+}
+
+pub fn main_worktree_path(git_dir: &str) -> Option<PathBuf> {
+    let resolved = Path::new(git_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(git_dir));
+    if resolved.file_name().is_some_and(|name| name == ".git") && resolved.is_dir() {
+        resolved.parent().map(Path::to_path_buf)
+    } else {
+        None
+    }
+}
+
+pub fn ensure_worktree_base_dir(base_dir: &Path) -> Result<()> {
+    if base_dir.exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(base_dir)?;
+    std::fs::write(base_dir.join("README.md"), README_SENTINEL)?;
+    Ok(())
+}
+
+pub fn readme_sentinel_contents() -> &'static str {
+    README_SENTINEL
+}
+
+fn resolve_from_discovery(path: &Path) -> Result<ControlRepo> {
+    let repo = Repository::discover(path)?;
+    let common_dir = repo.commondir().to_path_buf();
+    let git_dir_key = normalize_git_dir_key(&common_dir);
+    let worktree_base = compute_gwt_base_from_parts(&git_dir_key, &common_dir);
+    let main_workdir = main_workdir_from_repo(&repo);
+
+    Ok(ControlRepo {
+        git_dir_key,
+        common_dir,
+        worktree_base,
+        main_workdir,
+    })
+}
+
+fn main_workdir_from_repo(repo: &Repository) -> Option<PathBuf> {
+    if repo.is_bare() {
+        None
+    } else {
+        repo.workdir().map(Path::to_path_buf)
+    }
+}
+
+fn normalize_git_dir_input(git_dir: String) -> Result<String> {
+    let input = PathBuf::from(&git_dir);
+
+    if input.is_dir() {
+        let dot_git = input.join(".git");
+        if dot_git.is_dir() {
+            return Ok(dot_git.to_string_lossy().into_owned());
+        }
+        if dot_git.is_file() {
+            return resolve_gitdir_pointer(&dot_git);
+        }
+    }
+
+    if input.is_file() && input.file_name().is_some_and(|name| name == ".git") {
+        return resolve_gitdir_pointer(&input);
+    }
+
+    Ok(git_dir)
+}
+
+fn resolve_gitdir_pointer(dot_git_file: &Path) -> Result<String> {
+    let contents = std::fs::read_to_string(dot_git_file)?;
+    let Some(line) = contents.lines().next() else {
+        return Ok(dot_git_file.to_string_lossy().into_owned());
+    };
+    let Some(pointer) = line.strip_prefix("gitdir:") else {
+        return Ok(dot_git_file.to_string_lossy().into_owned());
+    };
+
+    let raw_path = PathBuf::from(pointer.trim());
+    let resolved = if raw_path.is_absolute() {
+        raw_path
+    } else {
+        dot_git_file
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(raw_path)
+    };
+
+    Ok(resolved.to_string_lossy().into_owned())
+}
+
+fn normalize_git_dir_key(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    if raw.len() > 1 {
+        raw.trim_end_matches('/').to_owned()
+    } else {
+        raw.into_owned()
+    }
+}
+
+fn has_exact_git_suffix(git_dir: &str) -> bool {
+    git_dir.as_bytes().ends_with(b".git")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn computes_base_for_normal_repo_git_dir() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let git_dir = repo_root.join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        let base = compute_gwt_base(git_dir.to_str().unwrap());
+
+        assert_eq!(base, repo_root.with_extension("gwt"));
+    }
+
+    #[test]
+    fn computes_base_for_bare_suffix_repo() {
+        let base = compute_gwt_base("/tmp/example.git");
+        assert_eq!(base, PathBuf::from("/tmp/example.gwt"));
+    }
+
+    #[test]
+    fn computes_base_for_fallback_path() {
+        let base = compute_gwt_base("/tmp/example/");
+        assert_eq!(base, PathBuf::from("/tmp/example.gwt"));
+    }
+
+    #[test]
+    fn main_worktree_path_is_none_for_bare_style_repo() {
+        assert_eq!(main_worktree_path("/tmp/example.git"), None);
+    }
+
+    #[test]
+    fn creates_readme_only_on_first_base_creation() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path().join("repo.gwt");
+
+        ensure_worktree_base_dir(&base).unwrap();
+        let readme = base.join("README.md");
+        let first_contents = std::fs::read_to_string(&readme).unwrap();
+        assert_eq!(first_contents, readme_sentinel_contents());
+
+        std::fs::write(&readme, "custom").unwrap();
+        ensure_worktree_base_dir(&base).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&readme).unwrap(), "custom");
+    }
+
+    #[test]
+    fn resolves_bare_repo_without_main_workdir() {
+        let temp = TempDir::new().unwrap();
+        let bare_path = temp.path().join("example.git");
+        Repository::init_bare(&bare_path).unwrap();
+
+        let repo = ControlRepo::from_git_dir(bare_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(repo.main_workdir, None);
+        assert_eq!(repo.worktree_base, temp.path().join("example.gwt"));
+    }
+
+    #[test]
+    fn normalizes_repo_root_inputs_to_dot_git() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().join("repo");
+        Repository::init(&repo_root).unwrap();
+
+        let repo = ControlRepo::from_git_dir(repo_root.to_str().unwrap()).unwrap();
+
+        assert_eq!(repo.git_dir_key, repo_root.join(".git").to_string_lossy());
+    }
+
+    #[test]
+    fn resolves_from_explicit_path_before_env_and_config() {
+        let temp = TempDir::new().unwrap();
+        let path_repo = temp.path().join("path-repo");
+        let env_repo = temp.path().join("env-repo");
+        let cfg_repo = temp.path().join("cfg-repo");
+        Repository::init(&path_repo).unwrap();
+        Repository::init(&env_repo).unwrap();
+        Repository::init(&cfg_repo).unwrap();
+
+        let config = GwtConfig {
+            default_repo: Some(cfg_repo.join(".git").to_string_lossy().into_owned()),
+            ..GwtConfig::default()
+        };
+
+        let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
+            path: Some(path_repo.as_path()),
+            cwd: None,
+            env_git_dir: Some(env_repo.join(".git").to_str().unwrap()),
+            config: Some(&config),
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.git_dir_key,
+            path_repo.join(".git").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn resolves_from_env_before_config_when_discovery_missing() {
+        let temp = TempDir::new().unwrap();
+        let env_repo = temp.path().join("env-repo");
+        let cfg_repo = temp.path().join("cfg-repo");
+        Repository::init(&env_repo).unwrap();
+        Repository::init(&cfg_repo).unwrap();
+
+        let config = GwtConfig {
+            default_repo: Some(cfg_repo.join(".git").to_string_lossy().into_owned()),
+            ..GwtConfig::default()
+        };
+
+        let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
+            path: Some(temp.path()),
+            cwd: None,
+            env_git_dir: Some(env_repo.join(".git").to_str().unwrap()),
+            config: Some(&config),
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.git_dir_key,
+            env_repo.join(".git").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn resolves_worktree_gitfile_inputs_to_private_gitdir() {
+        let temp = TempDir::new().unwrap();
+        let main_repo = temp.path().join("main");
+        let worktree_path = temp.path().join("main.gwt").join("feature");
+        let repo = Repository::init(&main_repo).unwrap();
+        commit_initial(&repo);
+        std::fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+        repo.worktree("feature", &worktree_path, None).unwrap();
+
+        let resolved = ControlRepo::from_git_dir(worktree_path.to_str().unwrap()).unwrap();
+
+        assert!(resolved.git_dir_key.contains(".git/worktrees/feature"));
+        assert_eq!(resolved.common_dir, main_repo.join(".git"));
+    }
+
+    fn commit_initial(repo: &Repository) {
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+}

--- a/crates/infra/gwt-worktree/src/repo.rs
+++ b/crates/infra/gwt-worktree/src/repo.rs
@@ -236,7 +236,8 @@ mod tests {
     #[test]
     fn computes_base_for_normal_repo_git_dir() {
         let temp = TempDir::new().unwrap();
-        let repo_root = temp.path().join("repo");
+        let temp_root = canonical_temp_root(&temp);
+        let repo_root = temp_root.join("repo");
         std::fs::create_dir_all(&repo_root).unwrap();
         let git_dir = repo_root.join(".git");
         std::fs::create_dir_all(&git_dir).unwrap();
@@ -272,7 +273,8 @@ mod tests {
     #[test]
     fn creates_readme_only_on_first_base_creation() {
         let temp = TempDir::new().unwrap();
-        let base = temp.path().join("repo.gwt");
+        let temp_root = canonical_temp_root(&temp);
+        let base = temp_root.join("repo.gwt");
 
         ensure_worktree_base_dir(&base).unwrap();
         let readme = base.join("README.md");
@@ -293,19 +295,21 @@ mod tests {
     #[test]
     fn resolves_bare_repo_without_main_workdir() {
         let temp = TempDir::new().unwrap();
-        let bare_path = temp.path().join("example.git");
+        let temp_root = canonical_temp_root(&temp);
+        let bare_path = temp_root.join("example.git");
         Repository::init_bare(&bare_path).unwrap();
 
         let repo = ControlRepo::from_git_dir(bare_path.to_str().unwrap()).unwrap();
 
         assert_eq!(repo.main_workdir, None);
-        assert_eq!(repo.worktree_base, temp.path().join("example.gwt"));
+        assert_eq!(repo.worktree_base, temp_root.join("example.gwt"));
     }
 
     #[test]
     fn normalizes_repo_root_inputs_to_dot_git() {
         let temp = TempDir::new().unwrap();
-        let repo_root = temp.path().join("repo");
+        let temp_root = canonical_temp_root(&temp);
+        let repo_root = temp_root.join("repo");
         Repository::init(&repo_root).unwrap();
 
         let repo = ControlRepo::from_git_dir(repo_root.to_str().unwrap()).unwrap();
@@ -316,9 +320,10 @@ mod tests {
     #[test]
     fn resolves_from_explicit_path_before_env_and_config() {
         let temp = TempDir::new().unwrap();
-        let path_repo = temp.path().join("path-repo");
-        let env_repo = temp.path().join("env-repo");
-        let cfg_repo = temp.path().join("cfg-repo");
+        let temp_root = canonical_temp_root(&temp);
+        let path_repo = temp_root.join("path-repo");
+        let env_repo = temp_root.join("env-repo");
+        let cfg_repo = temp_root.join("cfg-repo");
         Repository::init(&path_repo).unwrap();
         Repository::init(&env_repo).unwrap();
         Repository::init(&cfg_repo).unwrap();
@@ -345,8 +350,9 @@ mod tests {
     #[test]
     fn resolves_from_env_before_config_when_discovery_missing() {
         let temp = TempDir::new().unwrap();
-        let env_repo = temp.path().join("env-repo");
-        let cfg_repo = temp.path().join("cfg-repo");
+        let temp_root = canonical_temp_root(&temp);
+        let env_repo = temp_root.join("env-repo");
+        let cfg_repo = temp_root.join("cfg-repo");
         Repository::init(&env_repo).unwrap();
         Repository::init(&cfg_repo).unwrap();
 
@@ -356,7 +362,7 @@ mod tests {
         };
 
         let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
-            path: Some(temp.path()),
+            path: Some(temp_root.as_path()),
             cwd: None,
             env_git_dir: Some(env_repo.join(".git").to_str().unwrap()),
             config: Some(&config),
@@ -372,8 +378,9 @@ mod tests {
     #[test]
     fn resolves_worktree_gitfile_inputs_to_private_gitdir() {
         let temp = TempDir::new().unwrap();
-        let main_repo = temp.path().join("main");
-        let worktree_path = temp.path().join("main.gwt").join("feature");
+        let temp_root = canonical_temp_root(&temp);
+        let main_repo = temp_root.join("main");
+        let worktree_path = temp_root.join("main.gwt").join("feature");
         let repo = Repository::init(&main_repo).unwrap();
         commit_initial(&repo);
         std::fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
@@ -388,13 +395,10 @@ mod tests {
     #[test]
     fn resolves_gitdir_pointer_to_normalized_path() {
         let temp = TempDir::new().unwrap();
-        let repo_root = temp.path().join("repo");
+        let temp_root = canonical_temp_root(&temp);
+        let repo_root = temp_root.join("repo");
         let dot_git = repo_root.join(".git");
-        let private_gitdir = temp
-            .path()
-            .join("private")
-            .join("worktrees")
-            .join("feature");
+        let private_gitdir = temp_root.join("private").join("worktrees").join("feature");
         std::fs::create_dir_all(&repo_root).unwrap();
         std::fs::create_dir_all(&private_gitdir).unwrap();
         std::fs::write(
@@ -409,6 +413,19 @@ mod tests {
             PathBuf::from(resolved),
             private_gitdir.canonicalize().unwrap()
         );
+    }
+
+    fn canonical_temp_root(temp: &TempDir) -> PathBuf {
+        #[cfg(target_os = "macos")]
+        {
+            temp.path()
+                .canonicalize()
+                .expect("canonicalize TempDir path on macOS")
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            temp.path().to_path_buf()
+        }
     }
 
     fn commit_initial(repo: &Repository) {

--- a/crates/infra/gwt-worktree/src/types.rs
+++ b/crates/infra/gwt-worktree/src/types.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::error::Result;
+use git2::Reference;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
@@ -118,6 +119,12 @@ fn validate_branch_name(name: &str) -> Result<()> {
     if name.is_empty() || name.contains('\0') {
         return Err(Error::InvalidBranchName(name.to_owned()));
     }
+
+    let full_ref = format!("refs/heads/{name}");
+    if !Reference::is_valid_name(&full_ref) {
+        return Err(Error::InvalidBranchName(name.to_owned()));
+    }
+
     Ok(())
 }
 
@@ -175,5 +182,21 @@ mod tests {
         let admin = branch.encode_admin_name();
 
         assert_eq!(admin.decode_branch_name().unwrap(), branch);
+    }
+
+    #[test]
+    fn accepts_valid_slash_and_unicode_branch_names() {
+        assert!(BranchName::new("feature/foo").is_ok());
+        assert!(BranchName::new("føø/東京").is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_git_reference_names() {
+        for invalid in ["../x", "x/../y", "foo.lock", "foo/", "foo//bar"] {
+            assert_eq!(
+                BranchName::new(invalid).unwrap_err().to_string(),
+                Error::InvalidBranchName(invalid.to_owned()).to_string()
+            );
+        }
     }
 }

--- a/crates/infra/gwt-worktree/src/types.rs
+++ b/crates/infra/gwt-worktree/src/types.rs
@@ -2,12 +2,13 @@ use crate::error::Error;
 use crate::error::Result;
 use git2::Reference;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use std::fmt;
 
 const ADMIN_PREFIX: &str = "gwt-";
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct BranchName(String);
 
@@ -34,6 +35,16 @@ impl BranchName {
             encoded.push(hex_digit(byte & 0x0f));
         }
         AdminName(encoded)
+    }
+}
+
+impl<'de> Deserialize<'de> for BranchName {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Self::new(name).map_err(serde::de::Error::custom)
     }
 }
 
@@ -158,6 +169,8 @@ fn hex_value(value: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::de::value::Error as ValueError;
+    use serde::de::value::StrDeserializer;
 
     #[test]
     fn encodes_and_decodes_feature_branch() {
@@ -197,6 +210,26 @@ mod tests {
                 BranchName::new(invalid).unwrap_err().to_string(),
                 Error::InvalidBranchName(invalid.to_owned()).to_string()
             );
+        }
+    }
+
+    #[test]
+    fn branch_name_deserialize_accepts_valid_slash_and_unicode_names() {
+        let feature =
+            BranchName::deserialize(StrDeserializer::<ValueError>::new("feature/foo")).unwrap();
+        let unicode =
+            BranchName::deserialize(StrDeserializer::<ValueError>::new("føø/東京")).unwrap();
+
+        assert_eq!(feature.as_str(), "feature/foo");
+        assert_eq!(unicode.as_str(), "føø/東京");
+    }
+
+    #[test]
+    fn branch_name_deserialize_rejects_traversal_adjacent_names() {
+        for invalid in ["../x", "x/../y"] {
+            let error =
+                BranchName::deserialize(StrDeserializer::<ValueError>::new(invalid)).unwrap_err();
+            assert!(error.to_string().contains(invalid));
         }
     }
 }

--- a/crates/infra/gwt-worktree/src/types.rs
+++ b/crates/infra/gwt-worktree/src/types.rs
@@ -1,0 +1,179 @@
+use crate::error::Error;
+use crate::error::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+const ADMIN_PREFIX: &str = "gwt-";
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BranchName(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AdminName(String);
+
+impl BranchName {
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        validate_branch_name(&name)?;
+        Ok(Self(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn encode_admin_name(&self) -> AdminName {
+        let mut encoded = String::with_capacity(ADMIN_PREFIX.len() + (self.0.len() * 2));
+        encoded.push_str(ADMIN_PREFIX);
+        for byte in self.0.as_bytes() {
+            encoded.push(hex_digit(byte >> 4));
+            encoded.push(hex_digit(byte & 0x0f));
+        }
+        AdminName(encoded)
+    }
+}
+
+impl AdminName {
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        validate_admin_name(&name)?;
+        Ok(Self(name))
+    }
+
+    pub fn decode_branch_name(&self) -> Result<BranchName> {
+        let Some(payload) = self.0.strip_prefix(ADMIN_PREFIX) else {
+            return Err(Error::InvalidAdminEncoding(self.0.clone()));
+        };
+        if payload.len() % 2 != 0 {
+            return Err(Error::InvalidAdminEncoding(self.0.clone()));
+        }
+
+        let mut bytes = Vec::with_capacity(payload.len() / 2);
+        for chunk in payload.as_bytes().chunks_exact(2) {
+            let high =
+                hex_value(chunk[0]).ok_or_else(|| Error::InvalidAdminEncoding(self.0.clone()))?;
+            let low =
+                hex_value(chunk[1]).ok_or_else(|| Error::InvalidAdminEncoding(self.0.clone()))?;
+            bytes.push((high << 4) | low);
+        }
+
+        let decoded =
+            String::from_utf8(bytes).map_err(|_| Error::InvalidAdminEncoding(self.0.clone()))?;
+        BranchName::new(decoded)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for BranchName {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for BranchName {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for AdminName {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for AdminName {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for AdminName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+fn validate_branch_name(name: &str) -> Result<()> {
+    if name.is_empty() || name.contains('\0') {
+        return Err(Error::InvalidBranchName(name.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_admin_name(name: &str) -> Result<()> {
+    if name.is_empty() || name.contains('/') || name.contains('\0') {
+        return Err(Error::InvalidAdminName(name.to_owned()));
+    }
+    if !name.starts_with(ADMIN_PREFIX) {
+        return Err(Error::InvalidAdminName(name.to_owned()));
+    }
+    Ok(())
+}
+
+fn hex_digit(value: u8) -> char {
+    match value {
+        0..=9 => char::from(b'0' + value),
+        10..=15 => char::from(b'a' + (value - 10)),
+        _ => unreachable!(),
+    }
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_and_decodes_feature_branch() {
+        let branch = BranchName::new("feature/foo").unwrap();
+        let admin = branch.encode_admin_name();
+
+        assert!(!admin.as_str().contains('/'));
+        assert_eq!(admin.decode_branch_name().unwrap(), branch);
+    }
+
+    #[test]
+    fn encodes_mixed_case_and_punctuation() {
+        let branch = BranchName::new("Feature/Foo-Bar.baz_123").unwrap();
+        let admin = branch.encode_admin_name();
+
+        assert_eq!(admin.decode_branch_name().unwrap(), branch);
+    }
+
+    #[test]
+    fn encodes_unicode() {
+        let branch = BranchName::new("føø/東京").unwrap();
+        let admin = branch.encode_admin_name();
+
+        assert_eq!(admin.decode_branch_name().unwrap(), branch);
+    }
+}

--- a/crates/infra/gwt-worktree/src/worktree.rs
+++ b/crates/infra/gwt-worktree/src/worktree.rs
@@ -1,0 +1,99 @@
+use crate::error::Result;
+use crate::repo::ControlRepo;
+use git2::ErrorCode;
+use git2::Repository;
+use git2::StatusOptions;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeInfo {
+    pub path: PathBuf,
+    pub head: Option<String>,
+    pub branch: Option<String>,
+    pub is_main: bool,
+    pub locked: bool,
+    pub prunable: bool,
+    pub detached: bool,
+}
+
+pub fn list_worktrees(control_repo: &ControlRepo) -> Result<Vec<WorktreeInfo>> {
+    let repo = Repository::open(&control_repo.common_dir)?;
+    let mut items = Vec::new();
+
+    if let Some(main_workdir) = &control_repo.main_workdir {
+        items.push(worktree_info_from_repo(
+            main_workdir.clone(),
+            &repo,
+            true,
+            false,
+            false,
+        )?);
+    }
+
+    let worktrees = repo.worktrees()?;
+    for name in (&worktrees).into_iter().flatten() {
+        let worktree = repo.find_worktree(name)?;
+        let linked_repo = Repository::open_from_worktree(&worktree)?;
+        let locked = !matches!(worktree.is_locked()?, git2::WorktreeLockStatus::Unlocked);
+        let prunable = worktree.is_prunable(None)?;
+        items.push(worktree_info_from_repo(
+            worktree.path().to_path_buf(),
+            &linked_repo,
+            false,
+            locked,
+            prunable,
+        )?);
+    }
+
+    Ok(items)
+}
+
+pub fn is_worktree_dirty(repo: &Repository) -> Result<bool> {
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .exclude_submodules(true);
+    let statuses = repo.statuses(Some(&mut opts))?;
+    Ok(!statuses.is_empty())
+}
+
+fn worktree_info_from_repo(
+    path: PathBuf,
+    repo: &Repository,
+    is_main: bool,
+    locked: bool,
+    prunable: bool,
+) -> Result<WorktreeInfo> {
+    let (head, branch, detached) = inspect_head(repo)?;
+    Ok(WorktreeInfo {
+        path,
+        head,
+        branch,
+        is_main,
+        locked,
+        prunable,
+        detached,
+    })
+}
+
+fn inspect_head(repo: &Repository) -> Result<(Option<String>, Option<String>, bool)> {
+    match repo.head() {
+        Ok(head) => {
+            let branch = head.shorthand().map(ToOwned::to_owned);
+            let detached = !head.is_branch();
+            let head = head
+                .peel_to_commit()
+                .ok()
+                .map(|commit| commit.id().to_string().chars().take(10).collect());
+            Ok((head, branch, detached))
+        }
+        Err(error) if error.code() == ErrorCode::UnbornBranch => {
+            let branch = repo
+                .find_reference("HEAD")?
+                .symbolic_target()
+                .map(|name| name.trim_start_matches("refs/heads/").to_owned());
+            Ok((None, branch, false))
+        }
+        Err(error) => Err(error.into()),
+    }
+}

--- a/crates/infra/gwt-worktree/src/worktree.rs
+++ b/crates/infra/gwt-worktree/src/worktree.rs
@@ -1,8 +1,11 @@
 use crate::error::Result;
 use crate::repo::ControlRepo;
+use crate::types::AdminName;
 use git2::ErrorCode;
 use git2::Repository;
 use git2::StatusOptions;
+use git2::Worktree;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,19 +36,29 @@ pub fn list_worktrees(control_repo: &ControlRepo) -> Result<Vec<WorktreeInfo>> {
     let worktrees = repo.worktrees()?;
     for name in (&worktrees).into_iter().flatten() {
         let worktree = repo.find_worktree(name)?;
-        let linked_repo = Repository::open_from_worktree(&worktree)?;
         let locked = !matches!(worktree.is_locked()?, git2::WorktreeLockStatus::Unlocked);
         let prunable = worktree.is_prunable(None)?;
-        items.push(worktree_info_from_repo(
-            worktree.path().to_path_buf(),
-            &linked_repo,
-            false,
-            locked,
-            prunable,
+        items.push(worktree_info_from_linked(
+            &repo, &worktree, locked, prunable,
         )?);
     }
 
     Ok(items)
+}
+
+pub(crate) fn find_worktree_by_path(
+    repo: &Repository,
+    target_path: &Path,
+) -> Result<Option<Worktree>> {
+    let worktrees = repo.worktrees()?;
+    for name in (&worktrees).into_iter().flatten() {
+        let worktree = repo.find_worktree(name)?;
+        if worktree.path() == target_path {
+            return Ok(Some(worktree));
+        }
+    }
+
+    Ok(None)
 }
 
 pub fn is_worktree_dirty(repo: &Repository) -> Result<bool> {
@@ -76,6 +89,29 @@ fn worktree_info_from_repo(
     })
 }
 
+fn worktree_info_from_linked(
+    control_repo: &Repository,
+    worktree: &Worktree,
+    locked: bool,
+    prunable: bool,
+) -> Result<WorktreeInfo> {
+    let path = worktree.path().to_path_buf();
+
+    if let Some(linked_repo) = open_linked_repo_from_private_gitdir(control_repo, worktree)? {
+        return worktree_info_from_repo(path, &linked_repo, false, locked, prunable);
+    }
+
+    Ok(WorktreeInfo {
+        path,
+        head: None,
+        branch: infer_branch_from_worktree_name(worktree.name()),
+        is_main: false,
+        locked,
+        prunable,
+        detached: false,
+    })
+}
+
 fn inspect_head(repo: &Repository) -> Result<(Option<String>, Option<String>, bool)> {
     match repo.head() {
         Ok(head) => {
@@ -96,4 +132,30 @@ fn inspect_head(repo: &Repository) -> Result<(Option<String>, Option<String>, bo
         }
         Err(error) => Err(error.into()),
     }
+}
+
+fn open_linked_repo_from_private_gitdir(
+    control_repo: &Repository,
+    worktree: &Worktree,
+) -> Result<Option<Repository>> {
+    let Some(name) = worktree.name() else {
+        return Ok(None);
+    };
+    let private_gitdir = control_repo.commondir().join("worktrees").join(name);
+
+    match Repository::open(&private_gitdir) {
+        Ok(repo) => Ok(Some(repo)),
+        Err(error) if error.code() == ErrorCode::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn infer_branch_from_worktree_name(name: Option<&str>) -> Option<String> {
+    let name = name?;
+
+    AdminName::new(name.to_owned())
+        .and_then(|admin| admin.decode_branch_name())
+        .map(|branch| branch.to_string())
+        .ok()
+        .or_else(|| Some(name.to_owned()))
 }

--- a/crates/infra/gwt-worktree/tests/gc.rs
+++ b/crates/infra/gwt-worktree/tests/gc.rs
@@ -67,6 +67,82 @@ fn gc_execution_deletes_only_authorized_entries() -> Result<(), Box<dyn Error>> 
     Ok(())
 }
 
+#[test]
+fn gc_plan_keeps_prunable_entries_exclusive() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+    std::fs::remove_dir_all(&fixture.prunable_path)?;
+
+    let plan = plan_gc(
+        &fixture.control,
+        None,
+        &GcPolicy {
+            clean_days: 0,
+            delete_days: 0,
+        },
+    )?;
+
+    assert!(
+        plan.prunable
+            .iter()
+            .any(|item| item.path == fixture.prunable_path && item.prunable)
+    );
+    assert!(
+        !plan
+            .to_delete
+            .iter()
+            .any(|item| item.path == fixture.prunable_path)
+    );
+    assert!(
+        !plan
+            .to_clean
+            .iter()
+            .any(|item| item.path == fixture.prunable_path)
+    );
+    assert!(
+        !plan
+            .dirty
+            .iter()
+            .any(|item| item.path == fixture.prunable_path)
+    );
+    assert!(
+        !plan
+            .unmerged
+            .iter()
+            .any(|item| item.path == fixture.prunable_path)
+    );
+    assert!(
+        !plan
+            .skip
+            .iter()
+            .any(|item| item.path == fixture.prunable_path)
+    );
+    Ok(())
+}
+
+#[test]
+fn gc_execution_prunes_prunable_entries() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+    std::fs::remove_dir_all(&fixture.prunable_path)?;
+    let plan = plan_gc(
+        &fixture.control,
+        None,
+        &GcPolicy {
+            clean_days: 0,
+            delete_days: 0,
+        },
+    )?;
+
+    let result = execute_gc_plan(&fixture.control, &plan)?;
+
+    assert!(result.pruned_paths.contains(&fixture.prunable_path));
+    let control_repo = Repository::open(&fixture.control.common_dir)?;
+    assert!(
+        control_repo.find_worktree("prunable").is_err(),
+        "prunable worktree should be removed from git registry"
+    );
+    Ok(())
+}
+
 fn mark_repo_dirty(path: &std::path::Path) -> Result<(), Box<dyn Error>> {
     let linked_repo = Repository::open(path)?;
     std::fs::write(path.join("dirty.txt"), "data")?;
@@ -81,6 +157,7 @@ struct GcFixture {
     merged_path: std::path::PathBuf,
     dirty_path: std::path::PathBuf,
     unmerged_path: std::path::PathBuf,
+    prunable_path: std::path::PathBuf,
 }
 
 fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
@@ -92,9 +169,11 @@ fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
     let merged_path = main_repo.with_extension("gwt").join("merged");
     let dirty_path = main_repo.with_extension("gwt").join("dirty");
     let unmerged_path = main_repo.with_extension("gwt").join("unmerged");
+    let prunable_path = main_repo.with_extension("gwt").join("prunable");
     create_branch_worktree(&repo, &merged_path, "merged", true)?;
     create_branch_worktree(&repo, &dirty_path, "dirty", true)?;
     create_branch_worktree(&repo, &unmerged_path, "unmerged", false)?;
+    create_branch_worktree(&repo, &prunable_path, "prunable", true)?;
     let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
 
     Ok(GcFixture {
@@ -103,6 +182,7 @@ fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
         merged_path,
         dirty_path,
         unmerged_path,
+        prunable_path,
     })
 }
 

--- a/crates/infra/gwt-worktree/tests/gc.rs
+++ b/crates/infra/gwt-worktree/tests/gc.rs
@@ -200,7 +200,8 @@ struct GcFixture {
 
 fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
 
@@ -242,6 +243,19 @@ fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
         prunable_path,
         broken_open_path,
     })
+}
+
+fn canonical_temp_root(temp: &TempDir) -> std::path::PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        temp.path()
+            .canonicalize()
+            .expect("canonicalize TempDir path on macOS")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        temp.path().to_path_buf()
+    }
 }
 
 fn set_age_days(path: &std::path::Path, age_days: u64) -> Result<(), Box<dyn Error>> {

--- a/crates/infra/gwt-worktree/tests/gc.rs
+++ b/crates/infra/gwt-worktree/tests/gc.rs
@@ -1,0 +1,149 @@
+use git2::Repository;
+use gwt_worktree::config::RepoConfig;
+use gwt_worktree::exec::gc::execute_gc_plan;
+use gwt_worktree::plan::gc::GcPolicy;
+use gwt_worktree::plan::gc::plan_gc;
+use gwt_worktree::repo::ControlRepo;
+use std::error::Error;
+use tempfile::TempDir;
+
+#[test]
+fn gc_plan_partitions_and_carries_clean_command() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+    mark_repo_dirty(&fixture.dirty_path)?;
+
+    let plan = plan_gc(
+        &fixture.control,
+        Some(&RepoConfig {
+            clean_command: Some("just clean".into()),
+            ..RepoConfig::default()
+        }),
+        &GcPolicy {
+            clean_days: 0,
+            delete_days: 0,
+        },
+    )?;
+
+    assert_eq!(plan.commands_to_run.len(), 1);
+    assert!(
+        plan.to_delete
+            .iter()
+            .any(|item| item.path == fixture.merged_path)
+    );
+    assert!(
+        plan.dirty
+            .iter()
+            .any(|item| item.path == fixture.dirty_path)
+    );
+    assert!(
+        plan.unmerged
+            .iter()
+            .chain(plan.skip.iter())
+            .chain(plan.dirty.iter())
+            .any(|item| item.path == fixture.unmerged_path)
+    );
+    Ok(())
+}
+
+#[test]
+fn gc_execution_deletes_only_authorized_entries() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+    mark_repo_dirty(&fixture.dirty_path)?;
+    let plan = plan_gc(
+        &fixture.control,
+        None,
+        &GcPolicy {
+            clean_days: 0,
+            delete_days: 0,
+        },
+    )?;
+
+    let result = execute_gc_plan(&fixture.control, &plan)?;
+
+    assert!(result.deleted_paths.contains(&fixture.merged_path));
+    assert!(!fixture.merged_path.exists());
+    assert!(fixture.unmerged_path.exists());
+    assert!(fixture.dirty_path.exists());
+    Ok(())
+}
+
+fn mark_repo_dirty(path: &std::path::Path) -> Result<(), Box<dyn Error>> {
+    let linked_repo = Repository::open(path)?;
+    std::fs::write(path.join("dirty.txt"), "data")?;
+    let mut index = linked_repo.index()?;
+    index.add_path(std::path::Path::new("dirty.txt"))?;
+    Ok(())
+}
+
+struct GcFixture {
+    _temp: TempDir,
+    control: ControlRepo,
+    merged_path: std::path::PathBuf,
+    dirty_path: std::path::PathBuf,
+    unmerged_path: std::path::PathBuf,
+}
+
+fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+
+    let merged_path = main_repo.with_extension("gwt").join("merged");
+    let dirty_path = main_repo.with_extension("gwt").join("dirty");
+    let unmerged_path = main_repo.with_extension("gwt").join("unmerged");
+    create_branch_worktree(&repo, &merged_path, "merged", true)?;
+    create_branch_worktree(&repo, &dirty_path, "dirty", true)?;
+    create_branch_worktree(&repo, &unmerged_path, "unmerged", false)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    Ok(GcFixture {
+        _temp: temp,
+        control,
+        merged_path,
+        dirty_path,
+        unmerged_path,
+    })
+}
+
+fn create_branch_worktree(
+    repo: &Repository,
+    path: &std::path::Path,
+    branch_name: &str,
+    merge_to_main: bool,
+) -> Result<(), Box<dyn Error>> {
+    let commit = repo.head()?.peel_to_commit()?;
+    repo.branch(branch_name, &commit, false)?;
+    std::fs::create_dir_all(path.parent().ok_or("missing parent")?)?;
+    let branch = repo.find_branch(branch_name, git2::BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = git2::WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree(branch_name, path, Some(&options))?;
+
+    if !merge_to_main {
+        let linked_repo = Repository::open(path)?;
+        std::fs::write(path.join("new.txt"), branch_name)?;
+        let sig = git2::Signature::now("Test", "test@example.com")?;
+        let tree_id = {
+            let mut index = linked_repo.index()?;
+            index.add_path(std::path::Path::new("new.txt"))?;
+            index.write_tree()?
+        };
+        let tree = linked_repo.find_tree(tree_id)?;
+        let parent = linked_repo.head()?.peel_to_commit()?;
+        linked_repo.commit(Some("HEAD"), &sig, &sig, "branch change", &tree, &[&parent])?;
+    }
+    Ok(())
+}
+
+fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let sig = git2::Signature::now("Test", "test@example.com")?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])?;
+    Ok(())
+}

--- a/crates/infra/gwt-worktree/tests/gc.rs
+++ b/crates/infra/gwt-worktree/tests/gc.rs
@@ -1,16 +1,22 @@
+use filetime::FileTime;
+use filetime::set_file_mtime;
 use git2::Repository;
 use gwt_worktree::config::RepoConfig;
+use gwt_worktree::error::Error as GwtError;
 use gwt_worktree::exec::gc::execute_gc_plan;
+use gwt_worktree::plan::gc::GcItem;
+use gwt_worktree::plan::gc::GcPlan;
 use gwt_worktree::plan::gc::GcPolicy;
 use gwt_worktree::plan::gc::plan_gc;
 use gwt_worktree::repo::ControlRepo;
 use std::error::Error;
+use std::time::Duration;
+use std::time::SystemTime;
 use tempfile::TempDir;
 
 #[test]
-fn gc_plan_partitions_and_carries_clean_command() -> Result<(), Box<dyn Error>> {
+fn gc_plan_puts_unmerged_only_in_unmerged_bucket() -> Result<(), Box<dyn Error>> {
     let fixture = make_gc_fixture()?;
-    mark_repo_dirty(&fixture.dirty_path)?;
 
     let plan = plan_gc(
         &fixture.control,
@@ -26,49 +32,52 @@ fn gc_plan_partitions_and_carries_clean_command() -> Result<(), Box<dyn Error>> 
 
     assert_eq!(plan.commands_to_run.len(), 1);
     assert!(
+        plan.unmerged
+            .iter()
+            .any(|item| item.path == fixture.unmerged_path)
+    );
+    assert_not_in_bucket(&plan.to_delete, &fixture.unmerged_path);
+    assert_not_in_bucket(&plan.to_clean, &fixture.unmerged_path);
+    assert_not_in_bucket(&plan.skip, &fixture.unmerged_path);
+    assert_not_in_bucket(&plan.dirty, &fixture.unmerged_path);
+    assert_not_in_bucket(&plan.prunable, &fixture.unmerged_path);
+    Ok(())
+}
+
+#[test]
+fn gc_plan_partitions_to_clean_to_delete_skip_by_age_thresholds() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+
+    let plan = plan_gc(
+        &fixture.control,
+        None,
+        &GcPolicy {
+            clean_days: 3,
+            delete_days: 7,
+        },
+    )?;
+
+    assert!(
         plan.to_delete
             .iter()
             .any(|item| item.path == fixture.merged_path)
     );
     assert!(
+        plan.to_clean
+            .iter()
+            .any(|item| item.path == fixture.clean_path)
+    );
+    assert!(plan.skip.iter().any(|item| item.path == fixture.young_path));
+    assert!(
         plan.dirty
             .iter()
             .any(|item| item.path == fixture.dirty_path)
     );
-    assert!(
-        plan.unmerged
-            .iter()
-            .chain(plan.skip.iter())
-            .chain(plan.dirty.iter())
-            .any(|item| item.path == fixture.unmerged_path)
-    );
     Ok(())
 }
 
 #[test]
-fn gc_execution_deletes_only_authorized_entries() -> Result<(), Box<dyn Error>> {
-    let fixture = make_gc_fixture()?;
-    mark_repo_dirty(&fixture.dirty_path)?;
-    let plan = plan_gc(
-        &fixture.control,
-        None,
-        &GcPolicy {
-            clean_days: 0,
-            delete_days: 0,
-        },
-    )?;
-
-    let result = execute_gc_plan(&fixture.control, &plan)?;
-
-    assert!(result.deleted_paths.contains(&fixture.merged_path));
-    assert!(!fixture.merged_path.exists());
-    assert!(fixture.unmerged_path.exists());
-    assert!(fixture.dirty_path.exists());
-    Ok(())
-}
-
-#[test]
-fn gc_plan_keeps_prunable_entries_exclusive() -> Result<(), Box<dyn Error>> {
+fn gc_plan_keeps_missing_prunable_entries_exclusive() -> Result<(), Box<dyn Error>> {
     let fixture = make_gc_fixture()?;
     std::fs::remove_dir_all(&fixture.prunable_path)?;
 
@@ -76,8 +85,8 @@ fn gc_plan_keeps_prunable_entries_exclusive() -> Result<(), Box<dyn Error>> {
         &fixture.control,
         None,
         &GcPolicy {
-            clean_days: 0,
-            delete_days: 0,
+            clean_days: 3,
+            delete_days: 7,
         },
     )?;
 
@@ -86,60 +95,159 @@ fn gc_plan_keeps_prunable_entries_exclusive() -> Result<(), Box<dyn Error>> {
             .iter()
             .any(|item| item.path == fixture.prunable_path && item.prunable)
     );
-    assert!(
-        !plan
-            .to_delete
-            .iter()
-            .any(|item| item.path == fixture.prunable_path)
-    );
-    assert!(
-        !plan
-            .to_clean
-            .iter()
-            .any(|item| item.path == fixture.prunable_path)
-    );
-    assert!(
-        !plan
-            .dirty
-            .iter()
-            .any(|item| item.path == fixture.prunable_path)
-    );
-    assert!(
-        !plan
-            .unmerged
-            .iter()
-            .any(|item| item.path == fixture.prunable_path)
-    );
-    assert!(
-        !plan
-            .skip
-            .iter()
-            .any(|item| item.path == fixture.prunable_path)
-    );
+    assert_not_in_bucket(&plan.to_delete, &fixture.prunable_path);
+    assert_not_in_bucket(&plan.to_clean, &fixture.prunable_path);
+    assert_not_in_bucket(&plan.skip, &fixture.prunable_path);
+    assert_not_in_bucket(&plan.dirty, &fixture.prunable_path);
+    assert_not_in_bucket(&plan.unmerged, &fixture.prunable_path);
     Ok(())
 }
 
 #[test]
-fn gc_execution_prunes_prunable_entries() -> Result<(), Box<dyn Error>> {
+fn gc_plan_emits_broken_open_worktree_as_prunable_instead_of_erroring() -> Result<(), Box<dyn Error>>
+{
+    let fixture = make_gc_fixture()?;
+    std::fs::remove_file(fixture.broken_open_path.join(".git"))?;
+
+    let plan = plan_gc(
+        &fixture.control,
+        None,
+        &GcPolicy {
+            clean_days: 3,
+            delete_days: 7,
+        },
+    )?;
+
+    assert!(
+        plan.prunable
+            .iter()
+            .any(|item| item.path == fixture.broken_open_path && item.prunable)
+    );
+    assert_not_in_bucket(&plan.to_delete, &fixture.broken_open_path);
+    assert_not_in_bucket(&plan.to_clean, &fixture.broken_open_path);
+    assert_not_in_bucket(&plan.skip, &fixture.broken_open_path);
+    assert_not_in_bucket(&plan.dirty, &fixture.broken_open_path);
+    assert_not_in_bucket(&plan.unmerged, &fixture.broken_open_path);
+    Ok(())
+}
+
+#[test]
+fn gc_execution_deletes_and_prunes_only_authorized_entries() -> Result<(), Box<dyn Error>> {
     let fixture = make_gc_fixture()?;
     std::fs::remove_dir_all(&fixture.prunable_path)?;
     let plan = plan_gc(
         &fixture.control,
         None,
         &GcPolicy {
-            clean_days: 0,
-            delete_days: 0,
+            clean_days: 3,
+            delete_days: 7,
         },
     )?;
 
     let result = execute_gc_plan(&fixture.control, &plan)?;
 
+    assert!(result.deleted_paths.contains(&fixture.merged_path));
     assert!(result.pruned_paths.contains(&fixture.prunable_path));
-    let control_repo = Repository::open(&fixture.control.common_dir)?;
-    assert!(
-        control_repo.find_worktree("prunable").is_err(),
-        "prunable worktree should be removed from git registry"
-    );
+    assert!(!fixture.merged_path.exists());
+    assert!(fixture.clean_path.exists());
+    assert!(fixture.young_path.exists());
+    assert!(fixture.unmerged_path.exists());
+    assert!(fixture.dirty_path.exists());
+    Ok(())
+}
+
+#[test]
+fn gc_execution_surfaces_prune_failures_for_unregistered_path() -> Result<(), Box<dyn Error>> {
+    let fixture = make_gc_fixture()?;
+    let unregistered_path = fixture.control.worktree_base.join("unregistered");
+    let plan = GcPlan {
+        prunable: vec![GcItem {
+            path: unregistered_path.clone(),
+            branch: Some(String::from("ghost")),
+            age_days: 0,
+            dirty: false,
+            merged_to_main: false,
+            locked: false,
+            prunable: true,
+        }],
+        ..GcPlan::default()
+    };
+
+    match execute_gc_plan(&fixture.control, &plan) {
+        Err(GwtError::RegisteredWorktreeNotFound(path)) => assert_eq!(path, unregistered_path),
+        Err(other) => return Err(format!("expected registered-worktree error, got {other}").into()),
+        Ok(result) => return Err(format!("expected failure, got {result:?}").into()),
+    }
+
+    Ok(())
+}
+
+fn assert_not_in_bucket(bucket: &[GcItem], path: &std::path::Path) {
+    assert!(!bucket.iter().any(|item| item.path == path));
+}
+
+struct GcFixture {
+    _temp: TempDir,
+    control: ControlRepo,
+    merged_path: std::path::PathBuf,
+    clean_path: std::path::PathBuf,
+    young_path: std::path::PathBuf,
+    dirty_path: std::path::PathBuf,
+    unmerged_path: std::path::PathBuf,
+    prunable_path: std::path::PathBuf,
+    broken_open_path: std::path::PathBuf,
+}
+
+fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+
+    let merged_path = main_repo.with_extension("gwt").join("merged");
+    let clean_path = main_repo.with_extension("gwt").join("clean");
+    let young_path = main_repo.with_extension("gwt").join("young");
+    let dirty_path = main_repo.with_extension("gwt").join("dirty");
+    let unmerged_path = main_repo.with_extension("gwt").join("unmerged");
+    let prunable_path = main_repo.with_extension("gwt").join("prunable");
+    let broken_open_path = main_repo.with_extension("gwt").join("broken-open");
+
+    create_branch_worktree(&repo, &merged_path, "merged", true)?;
+    create_branch_worktree(&repo, &clean_path, "clean", true)?;
+    create_branch_worktree(&repo, &young_path, "young", true)?;
+    create_branch_worktree(&repo, &dirty_path, "dirty", true)?;
+    create_branch_worktree(&repo, &unmerged_path, "unmerged", false)?;
+    create_branch_worktree(&repo, &prunable_path, "prunable", true)?;
+    create_branch_worktree(&repo, &broken_open_path, "broken-open", true)?;
+
+    set_age_days(&merged_path, 10)?;
+    set_age_days(&clean_path, 5)?;
+    set_age_days(&young_path, 1)?;
+    set_age_days(&dirty_path, 10)?;
+    set_age_days(&unmerged_path, 10)?;
+    set_age_days(&prunable_path, 10)?;
+    set_age_days(&broken_open_path, 10)?;
+    mark_repo_dirty(&dirty_path)?;
+
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    Ok(GcFixture {
+        _temp: temp,
+        control,
+        merged_path,
+        clean_path,
+        young_path,
+        dirty_path,
+        unmerged_path,
+        prunable_path,
+        broken_open_path,
+    })
+}
+
+fn set_age_days(path: &std::path::Path, age_days: u64) -> Result<(), Box<dyn Error>> {
+    let seconds = age_days.saturating_mul(86_400);
+    let timestamp = SystemTime::now() - Duration::from_secs(seconds);
+    set_file_mtime(path, FileTime::from_system_time(timestamp))?;
     Ok(())
 }
 
@@ -151,41 +259,6 @@ fn mark_repo_dirty(path: &std::path::Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-struct GcFixture {
-    _temp: TempDir,
-    control: ControlRepo,
-    merged_path: std::path::PathBuf,
-    dirty_path: std::path::PathBuf,
-    unmerged_path: std::path::PathBuf,
-    prunable_path: std::path::PathBuf,
-}
-
-fn make_gc_fixture() -> Result<GcFixture, Box<dyn Error>> {
-    let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let repo = Repository::init(&main_repo)?;
-    commit_initial(&repo)?;
-
-    let merged_path = main_repo.with_extension("gwt").join("merged");
-    let dirty_path = main_repo.with_extension("gwt").join("dirty");
-    let unmerged_path = main_repo.with_extension("gwt").join("unmerged");
-    let prunable_path = main_repo.with_extension("gwt").join("prunable");
-    create_branch_worktree(&repo, &merged_path, "merged", true)?;
-    create_branch_worktree(&repo, &dirty_path, "dirty", true)?;
-    create_branch_worktree(&repo, &unmerged_path, "unmerged", false)?;
-    create_branch_worktree(&repo, &prunable_path, "prunable", true)?;
-    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
-
-    Ok(GcFixture {
-        _temp: temp,
-        control,
-        merged_path,
-        dirty_path,
-        unmerged_path,
-        prunable_path,
-    })
-}
-
 fn create_branch_worktree(
     repo: &Repository,
     path: &std::path::Path,
@@ -194,26 +267,26 @@ fn create_branch_worktree(
 ) -> Result<(), Box<dyn Error>> {
     let commit = repo.head()?.peel_to_commit()?;
     repo.branch(branch_name, &commit, false)?;
+
+    if !merge_to_main {
+        let sig = git2::Signature::now("Test", "test@example.com")?;
+        let tree = commit.tree()?;
+        repo.commit(
+            Some(&format!("refs/heads/{branch_name}")),
+            &sig,
+            &sig,
+            "branch change",
+            &tree,
+            &[&commit],
+        )?;
+    }
+
     std::fs::create_dir_all(path.parent().ok_or("missing parent")?)?;
     let branch = repo.find_branch(branch_name, git2::BranchType::Local)?;
     let reference = branch.into_reference();
     let mut options = git2::WorktreeAddOptions::new();
     options.reference(Some(&reference));
     repo.worktree(branch_name, path, Some(&options))?;
-
-    if !merge_to_main {
-        let linked_repo = Repository::open(path)?;
-        std::fs::write(path.join("new.txt"), branch_name)?;
-        let sig = git2::Signature::now("Test", "test@example.com")?;
-        let tree_id = {
-            let mut index = linked_repo.index()?;
-            index.add_path(std::path::Path::new("new.txt"))?;
-            index.write_tree()?
-        };
-        let tree = linked_repo.find_tree(tree_id)?;
-        let parent = linked_repo.head()?.peel_to_commit()?;
-        linked_repo.commit(Some("HEAD"), &sig, &sig, "branch change", &tree, &[&parent])?;
-    }
     Ok(())
 }
 

--- a/crates/infra/gwt-worktree/tests/remove.rs
+++ b/crates/infra/gwt-worktree/tests/remove.rs
@@ -182,6 +182,35 @@ fn remote_delete_prefers_upstream_remote() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn remote_delete_uses_origin_when_local_branch_is_missing() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("remote-missing-local")?;
+    fixture
+        .repo
+        .remote("origin", "https://example.com/origin.git")?;
+    fixture
+        .repo
+        .find_reference("refs/heads/remote-missing-local")?
+        .delete()?;
+
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("remote-missing-local")?,
+            force: true,
+            allow_outside_base: false,
+            delete_remote: true,
+        },
+        None,
+    )?;
+
+    assert_eq!(plan.remote_to_delete.as_deref(), Some("origin"));
+    let deleter = CapturingRemoteDeleter::default();
+    execute_remove_plan(&fixture.control, &plan, Some(&deleter))?;
+    assert_eq!(deleter.calls.borrow().as_slice(), [String::from("origin")]);
+    Ok(())
+}
+
+#[test]
 fn remote_delete_fails_without_upstream_or_origin() -> Result<(), Box<dyn Error>> {
     let fixture = make_worktree_fixture("remote-missing")?;
     fixture

--- a/crates/infra/gwt-worktree/tests/remove.rs
+++ b/crates/infra/gwt-worktree/tests/remove.rs
@@ -131,6 +131,40 @@ fn remote_delete_requires_deleter_and_pr_lookup_is_plugged() -> Result<(), Box<d
     Ok(())
 }
 
+#[test]
+fn removes_prunable_missing_worktree() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("prunable")?;
+    std::fs::remove_dir_all(&fixture.linked_path)?;
+
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("prunable")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    assert!(plan.prunable);
+    assert!(!plan.dirty);
+
+    execute_remove_plan(&fixture.control, &plan, None)?;
+    assert!(
+        fixture
+            .repo
+            .find_branch("prunable", git2::BranchType::Local)
+            .is_err()
+    );
+    assert!(
+        Repository::open(&fixture.control.common_dir)?
+            .find_worktree("prunable")
+            .is_err()
+    );
+    Ok(())
+}
+
 struct RemoveFixture {
     _temp: TempDir,
     repo: Repository,

--- a/crates/infra/gwt-worktree/tests/remove.rs
+++ b/crates/infra/gwt-worktree/tests/remove.rs
@@ -1,0 +1,201 @@
+use git2::Repository;
+use gwt_worktree::exec::remove::execute_remove_plan;
+use gwt_worktree::plan::remove::RemoveRequest;
+use gwt_worktree::plan::remove::plan_remove;
+use gwt_worktree::pr::PullRequestLookup;
+use gwt_worktree::pr::PullRequestState;
+use gwt_worktree::remote::RemoteBranchDeleter;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::types::BranchName;
+use std::error::Error;
+use tempfile::TempDir;
+
+#[test]
+fn removes_clean_worktree() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("feature")?;
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("feature")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    execute_remove_plan(&fixture.control, &plan, None)?;
+    assert!(!fixture.linked_path.exists());
+    assert!(
+        fixture
+            .repo
+            .find_branch("feature", git2::BranchType::Local)
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn dirty_worktree_requires_force() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("dirty")?;
+    std::fs::write(fixture.linked_path.join("dirty.txt"), "data")?;
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("dirty")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    let error = execute_remove_plan(&fixture.control, &plan, None).expect_err("dirty should fail");
+    assert!(error.to_string().contains("uncommitted changes"));
+    Ok(())
+}
+
+#[test]
+fn locked_worktree_requires_force() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("locked")?;
+    let linked_repo = Repository::open(&fixture.linked_path)?;
+    git2::Worktree::open_from_repository(&linked_repo)?.lock(None)?;
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("locked")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    let error = execute_remove_plan(&fixture.control, &plan, None).expect_err("locked should fail");
+    assert!(error.to_string().contains("locked"));
+    Ok(())
+}
+
+#[test]
+fn outside_base_requires_override() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let outside_path = temp.path().join("elsewhere").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    repo.branch("outside", &repo.head()?.peel_to_commit()?, false)?;
+    std::fs::create_dir_all(outside_path.parent().ok_or("missing parent")?)?;
+    let branch = repo.find_branch("outside", git2::BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = git2::WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree("outside", &outside_path, Some(&options))?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let plan = plan_remove(
+        &control,
+        &RemoveRequest {
+            branch: BranchName::new("outside")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    let error = execute_remove_plan(&control, &plan, None).expect_err("outside-base should fail");
+    assert!(error.to_string().contains("outside"));
+    Ok(())
+}
+
+#[test]
+fn remote_delete_requires_deleter_and_pr_lookup_is_plugged() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("remote")?;
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("remote")?,
+            force: true,
+            allow_outside_base: false,
+            delete_remote: true,
+        },
+        Some(&StubPrLookup),
+    )?;
+
+    assert_eq!(plan.pr_state, Some(PullRequestState::Merged));
+    let error = execute_remove_plan(&fixture.control, &plan, None)
+        .expect_err("remote delete should need deleter");
+    assert!(error.to_string().contains("deleter"));
+
+    execute_remove_plan(&fixture.control, &plan, Some(&StubRemoteDeleter))?;
+    Ok(())
+}
+
+struct RemoveFixture {
+    _temp: TempDir,
+    repo: Repository,
+    control: ControlRepo,
+    linked_path: std::path::PathBuf,
+}
+
+struct StubPrLookup;
+
+impl PullRequestLookup for StubPrLookup {
+    fn lookup_pull_request_state(
+        &self,
+        _branch: &BranchName,
+    ) -> gwt_worktree::Result<PullRequestState> {
+        Ok(PullRequestState::Merged)
+    }
+}
+
+struct StubRemoteDeleter;
+
+impl RemoteBranchDeleter for StubRemoteDeleter {
+    fn delete_remote_branch(
+        &self,
+        _repo: &Repository,
+        _remote: &str,
+        _branch: &BranchName,
+    ) -> gwt_worktree::Result<()> {
+        Ok(())
+    }
+}
+
+fn make_worktree_fixture(branch_name: &str) -> Result<RemoveFixture, Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let linked_path = main_repo.with_extension("gwt").join(branch_name);
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    {
+        let commit = repo.head()?.peel_to_commit()?;
+        repo.branch(branch_name, &commit, false)?;
+    }
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    {
+        let branch = repo.find_branch(branch_name, git2::BranchType::Local)?;
+        let reference = branch.into_reference();
+        let mut options = git2::WorktreeAddOptions::new();
+        options.reference(Some(&reference));
+        repo.worktree(branch_name, &linked_path, Some(&options))?;
+    }
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+    Ok(RemoveFixture {
+        _temp: temp,
+        repo,
+        control,
+        linked_path,
+    })
+}
+
+fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let sig = git2::Signature::now("Test", "test@example.com")?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])?;
+    Ok(())
+}

--- a/crates/infra/gwt-worktree/tests/remove.rs
+++ b/crates/infra/gwt-worktree/tests/remove.rs
@@ -1,4 +1,5 @@
 use git2::Repository;
+use gwt_worktree::error::Error as GwtError;
 use gwt_worktree::exec::remove::execute_remove_plan;
 use gwt_worktree::plan::remove::RemoveRequest;
 use gwt_worktree::plan::remove::plan_remove;
@@ -7,6 +8,7 @@ use gwt_worktree::pr::PullRequestState;
 use gwt_worktree::remote::RemoteBranchDeleter;
 use gwt_worktree::repo::ControlRepo;
 use gwt_worktree::types::BranchName;
+use std::cell::RefCell;
 use std::error::Error;
 use tempfile::TempDir;
 
@@ -111,6 +113,9 @@ fn outside_base_requires_override() -> Result<(), Box<dyn Error>> {
 #[test]
 fn remote_delete_requires_deleter_and_pr_lookup_is_plugged() -> Result<(), Box<dyn Error>> {
     let fixture = make_worktree_fixture("remote")?;
+    fixture
+        .repo
+        .remote("origin", "https://example.com/origin.git")?;
     let plan = plan_remove(
         &fixture.control,
         &RemoveRequest {
@@ -123,11 +128,120 @@ fn remote_delete_requires_deleter_and_pr_lookup_is_plugged() -> Result<(), Box<d
     )?;
 
     assert_eq!(plan.pr_state, Some(PullRequestState::Merged));
+    assert_eq!(plan.remote_to_delete.as_deref(), Some("origin"));
     let error = execute_remove_plan(&fixture.control, &plan, None)
         .expect_err("remote delete should need deleter");
     assert!(error.to_string().contains("deleter"));
 
-    execute_remove_plan(&fixture.control, &plan, Some(&StubRemoteDeleter))?;
+    let deleter = CapturingRemoteDeleter::default();
+    execute_remove_plan(&fixture.control, &plan, Some(&deleter))?;
+    assert_eq!(deleter.calls.borrow().as_slice(), [String::from("origin")]);
+    Ok(())
+}
+
+#[test]
+fn remote_delete_prefers_upstream_remote() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("remote-upstream")?;
+    let head_oid = fixture.repo.head()?.peel_to_commit()?.id();
+    fixture
+        .repo
+        .remote("origin", "https://example.com/origin.git")?;
+    fixture
+        .repo
+        .remote("upstream", "https://example.com/upstream.git")?;
+    fixture.repo.reference(
+        "refs/remotes/upstream/remote-upstream",
+        head_oid,
+        true,
+        "test upstream ref",
+    )?;
+    fixture
+        .repo
+        .find_branch("remote-upstream", git2::BranchType::Local)?
+        .set_upstream(Some("upstream/remote-upstream"))?;
+
+    let plan = plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("remote-upstream")?,
+            force: true,
+            allow_outside_base: false,
+            delete_remote: true,
+        },
+        None,
+    )?;
+
+    assert_eq!(plan.remote_to_delete.as_deref(), Some("upstream"));
+    let deleter = CapturingRemoteDeleter::default();
+    execute_remove_plan(&fixture.control, &plan, Some(&deleter))?;
+    assert_eq!(
+        deleter.calls.borrow().as_slice(),
+        [String::from("upstream")]
+    );
+    Ok(())
+}
+
+#[test]
+fn remote_delete_fails_without_upstream_or_origin() -> Result<(), Box<dyn Error>> {
+    let fixture = make_worktree_fixture("remote-missing")?;
+    fixture
+        .repo
+        .remote("backup", "https://example.com/backup.git")?;
+
+    match plan_remove(
+        &fixture.control,
+        &RemoveRequest {
+            branch: BranchName::new("remote-missing")?,
+            force: true,
+            allow_outside_base: false,
+            delete_remote: true,
+        },
+        None,
+    ) {
+        Err(GwtError::RemoteDeleteRemoteUnresolved { branch }) => {
+            assert_eq!(branch, "remote-missing");
+        }
+        Err(other) => return Err(format!("expected unresolved remote error, got {other}").into()),
+        Ok(plan) => {
+            return Err(format!("expected remote resolution failure, got {plan:?}").into());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn remove_outside_base_detection_handles_symlink_alias() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    repo.branch("alias", &repo.head()?.peel_to_commit()?, false)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+    control.ensure_worktree_base()?;
+
+    let alias_base = temp.path().join("main-alias.gwt");
+    symlink(&control.worktree_base, &alias_base)?;
+    let alias_path = alias_base.join("alias");
+    create_registered_worktree(&repo, &alias_path, "alias")?;
+
+    let plan = plan_remove(
+        &control,
+        &RemoveRequest {
+            branch: BranchName::new("alias")?,
+            force: false,
+            allow_outside_base: false,
+            delete_remote: false,
+        },
+        None,
+    )?;
+
+    assert!(!plan.outside_base);
+    execute_remove_plan(&control, &plan, None)?;
+    assert!(!alias_path.exists());
     Ok(())
 }
 
@@ -183,15 +297,19 @@ impl PullRequestLookup for StubPrLookup {
     }
 }
 
-struct StubRemoteDeleter;
+#[derive(Default)]
+struct CapturingRemoteDeleter {
+    calls: RefCell<Vec<String>>,
+}
 
-impl RemoteBranchDeleter for StubRemoteDeleter {
+impl RemoteBranchDeleter for CapturingRemoteDeleter {
     fn delete_remote_branch(
         &self,
         _repo: &Repository,
-        _remote: &str,
+        remote: &str,
         _branch: &BranchName,
     ) -> gwt_worktree::Result<()> {
+        self.calls.borrow_mut().push(remote.to_owned());
         Ok(())
     }
 }
@@ -206,14 +324,7 @@ fn make_worktree_fixture(branch_name: &str) -> Result<RemoveFixture, Box<dyn Err
         let commit = repo.head()?.peel_to_commit()?;
         repo.branch(branch_name, &commit, false)?;
     }
-    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
-    {
-        let branch = repo.find_branch(branch_name, git2::BranchType::Local)?;
-        let reference = branch.into_reference();
-        let mut options = git2::WorktreeAddOptions::new();
-        options.reference(Some(&reference));
-        repo.worktree(branch_name, &linked_path, Some(&options))?;
-    }
+    create_registered_worktree(&repo, &linked_path, branch_name)?;
     let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
     Ok(RemoveFixture {
         _temp: temp,
@@ -221,6 +332,20 @@ fn make_worktree_fixture(branch_name: &str) -> Result<RemoveFixture, Box<dyn Err
         control,
         linked_path,
     })
+}
+
+fn create_registered_worktree(
+    repo: &Repository,
+    linked_path: &std::path::Path,
+    branch_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    let branch = repo.find_branch(branch_name, git2::BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = git2::WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree(branch_name, linked_path, Some(&options))?;
+    Ok(())
 }
 
 fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {

--- a/crates/infra/gwt-worktree/tests/repo_resolution.rs
+++ b/crates/infra/gwt-worktree/tests/repo_resolution.rs
@@ -3,8 +3,11 @@ use gwt_worktree::config::GwtConfig;
 use gwt_worktree::error::Error as GwtError;
 use gwt_worktree::repo::ControlRepo;
 use gwt_worktree::repo::ResolveControlRepoOptions;
+use gwt_worktree::repo::readme_sentinel_contents;
 use std::error::Error;
 use tempfile::TempDir;
+
+const EXPECTED_README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directory contains git worktrees managed by the gwt tool.\nEach subdirectory is a separate worktree for a branch.\n\nFor more information, see: https://github.com/General-Wisdom/gwt\n";
 
 #[test]
 fn resolves_from_cwd_discovery() -> Result<(), Box<dyn Error>> {
@@ -26,6 +29,11 @@ fn resolves_from_cwd_discovery() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(resolved.main_workdir, Some(repo_root));
     Ok(())
+}
+
+#[test]
+fn readme_sentinel_contents_is_byte_for_byte_expected() {
+    assert_eq!(readme_sentinel_contents(), EXPECTED_README_SENTINEL);
 }
 
 #[test]

--- a/crates/infra/gwt-worktree/tests/repo_resolution.rs
+++ b/crates/infra/gwt-worktree/tests/repo_resolution.rs
@@ -1,0 +1,62 @@
+use git2::Repository;
+use gwt_worktree::config::GwtConfig;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::repo::ResolveControlRepoOptions;
+use std::error::Error;
+use tempfile::TempDir;
+
+#[test]
+fn resolves_from_cwd_discovery() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let repo_root = temp.path().join("repo");
+    let repo = Repository::init(&repo_root)?;
+    commit_initial(&repo)?;
+    let nested = repo_root.join("src").join("nested");
+    std::fs::create_dir_all(&nested)?;
+
+    let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
+        cwd: Some(nested.as_path()),
+        ..ResolveControlRepoOptions::default()
+    })?;
+
+    assert_eq!(
+        resolved.git_dir_key,
+        repo_root.join(".git").to_string_lossy()
+    );
+    assert_eq!(resolved.main_workdir, Some(repo_root));
+    Ok(())
+}
+
+#[test]
+fn resolves_from_config_when_other_sources_missing() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let repo_root = temp.path().join("repo");
+    Repository::init(&repo_root)?;
+    let config = GwtConfig {
+        default_repo: Some(repo_root.join(".git").to_string_lossy().into_owned()),
+        ..GwtConfig::default()
+    };
+
+    let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
+        cwd: Some(temp.path()),
+        config: Some(&config),
+        ..ResolveControlRepoOptions::default()
+    })?;
+
+    assert_eq!(
+        resolved.git_dir_key,
+        repo_root.join(".git").to_string_lossy()
+    );
+    Ok(())
+}
+
+fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let sig = git2::Signature::now("Test", "test@example.com")?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])?;
+    Ok(())
+}

--- a/crates/infra/gwt-worktree/tests/repo_resolution.rs
+++ b/crates/infra/gwt-worktree/tests/repo_resolution.rs
@@ -12,7 +12,8 @@ const EXPECTED_README_SENTINEL: &str = "# Git Worktree Directory\n\nThis directo
 #[test]
 fn resolves_from_cwd_discovery() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let repo_root = temp.path().join("repo");
+    let temp_root = canonical_temp_root(&temp);
+    let repo_root = temp_root.join("repo");
     let repo = Repository::init(&repo_root)?;
     commit_initial(&repo)?;
     let nested = repo_root.join("src").join("nested");
@@ -39,7 +40,8 @@ fn readme_sentinel_contents_is_byte_for_byte_expected() {
 #[test]
 fn resolves_from_config_when_other_sources_missing() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let repo_root = temp.path().join("repo");
+    let temp_root = canonical_temp_root(&temp);
+    let repo_root = temp_root.join("repo");
     Repository::init(&repo_root)?;
     let config = GwtConfig {
         default_repo: Some(repo_root.join(".git").to_string_lossy().into_owned()),
@@ -47,7 +49,7 @@ fn resolves_from_config_when_other_sources_missing() -> Result<(), Box<dyn Error
     };
 
     let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
-        cwd: Some(temp.path()),
+        cwd: Some(temp_root.as_path()),
         config: Some(&config),
         ..ResolveControlRepoOptions::default()
     })?;
@@ -65,9 +67,10 @@ fn does_not_fall_through_on_non_not_found_discovery_errors() -> Result<(), Box<d
     use std::os::unix::fs::PermissionsExt;
 
     let temp = TempDir::new()?;
-    let blocked = temp.path().join("blocked");
+    let temp_root = canonical_temp_root(&temp);
+    let blocked = temp_root.join("blocked");
     let nested = blocked.join("nested");
-    let env_repo = temp.path().join("env-repo");
+    let env_repo = temp_root.join("env-repo");
     Repository::init(&env_repo)?;
     std::fs::create_dir_all(&nested)?;
 
@@ -93,6 +96,19 @@ fn does_not_fall_through_on_non_not_found_discovery_errors() -> Result<(), Box<d
     }
 
     Ok(())
+}
+
+fn canonical_temp_root(temp: &TempDir) -> std::path::PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        temp.path()
+            .canonicalize()
+            .expect("canonicalize TempDir path on macOS")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        temp.path().to_path_buf()
+    }
 }
 
 fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {

--- a/crates/infra/gwt-worktree/tests/repo_resolution.rs
+++ b/crates/infra/gwt-worktree/tests/repo_resolution.rs
@@ -1,5 +1,6 @@
 use git2::Repository;
 use gwt_worktree::config::GwtConfig;
+use gwt_worktree::error::Error as GwtError;
 use gwt_worktree::repo::ControlRepo;
 use gwt_worktree::repo::ResolveControlRepoOptions;
 use std::error::Error;
@@ -47,6 +48,42 @@ fn resolves_from_config_when_other_sources_missing() -> Result<(), Box<dyn Error
         resolved.git_dir_key,
         repo_root.join(".git").to_string_lossy()
     );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn does_not_fall_through_on_non_not_found_discovery_errors() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new()?;
+    let blocked = temp.path().join("blocked");
+    let nested = blocked.join("nested");
+    let env_repo = temp.path().join("env-repo");
+    Repository::init(&env_repo)?;
+    std::fs::create_dir_all(&nested)?;
+
+    let original_permissions = std::fs::metadata(&blocked)?.permissions();
+    let mut restricted = original_permissions.clone();
+    restricted.set_mode(0o000);
+    std::fs::set_permissions(&blocked, restricted)?;
+
+    let resolved = ControlRepo::resolve(&ResolveControlRepoOptions {
+        cwd: Some(nested.as_path()),
+        env_git_dir: Some(env_repo.join(".git").to_str().ok_or("non-utf8 env repo")?),
+        ..ResolveControlRepoOptions::default()
+    });
+
+    std::fs::set_permissions(&blocked, original_permissions)?;
+
+    match resolved {
+        Err(GwtError::Git(error)) => assert_ne!(error.code(), git2::ErrorCode::NotFound),
+        Err(other) => return Err(format!("expected git discovery error, got {other}").into()),
+        Ok(repo) => {
+            return Err(format!("expected discovery error, resolved {}", repo.git_dir_key).into());
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/infra/gwt-worktree/tests/smoke.rs
+++ b/crates/infra/gwt-worktree/tests/smoke.rs
@@ -1,0 +1,29 @@
+use gwt_worktree::command::CommandSpec;
+use gwt_worktree::config::GwtConfig;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::types::BranchName;
+use gwt_worktree::worktree::WorktreeInfo;
+use std::path::PathBuf;
+
+#[test]
+fn root_exports_compile() {
+    let _ = gwt_worktree::Result::<()>::Ok(());
+    let _ = CommandSpec::from("thoughts init");
+    let _ = GwtConfig::default();
+    let _ = ControlRepo {
+        git_dir_key: String::new(),
+        common_dir: PathBuf::new(),
+        worktree_base: PathBuf::new(),
+        main_workdir: None,
+    };
+    let _ = BranchName::new("feature/foo");
+    let _ = WorktreeInfo {
+        path: PathBuf::new(),
+        head: None,
+        branch: None,
+        is_main: false,
+        locked: false,
+        prunable: false,
+        detached: false,
+    };
+}

--- a/crates/infra/gwt-worktree/tests/switch_create.rs
+++ b/crates/infra/gwt-worktree/tests/switch_create.rs
@@ -1,0 +1,176 @@
+use git2::BranchType;
+use git2::Repository;
+use gwt_worktree::config::RepoConfig;
+use gwt_worktree::exec::switch::execute_switch_plan;
+use gwt_worktree::plan::switch::SwitchPlanKind;
+use gwt_worktree::plan::switch::SwitchRequest;
+use gwt_worktree::plan::switch::plan_switch;
+use gwt_worktree::remote::RemoteBranchTarget;
+use gwt_worktree::remote::RemoteRefresher;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::types::BranchName;
+use std::error::Error;
+use tempfile::TempDir;
+
+#[test]
+fn reuses_existing_worktree() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let linked_path = temp.path().join("main.gwt").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    repo.worktree("feature", &linked_path, None)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature")?,
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    )?;
+
+    assert!(matches!(plan.kind, SwitchPlanKind::ExistingWorktree));
+    let result = execute_switch_plan(&control, &plan, None)?;
+    assert_eq!(result.path, linked_path);
+    Ok(())
+}
+
+#[test]
+fn creates_new_branch_with_post_create_commands_as_data_only() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+    let repo_config = RepoConfig {
+        post_create_commands: vec!["thoughts init".into()],
+        ..RepoConfig::default()
+    };
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature/create")?,
+            create: true,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        Some(&repo_config),
+    )?;
+
+    assert!(matches!(plan.kind, SwitchPlanKind::CreateBranch { .. }));
+    let result = execute_switch_plan(&control, &plan, None)?;
+    assert_eq!(
+        result.post_create_commands,
+        repo_config.post_create_commands
+    );
+    assert!(result.path.exists());
+    Ok(())
+}
+
+#[test]
+fn force_create_requires_explicit_start_point() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let Err(error) = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature/force")?,
+            create: false,
+            force_create: true,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    ) else {
+        return Err("force-create should require a start point".into());
+    };
+
+    assert!(error.to_string().contains("missing switch start point"));
+    Ok(())
+}
+
+#[test]
+fn remote_guess_requires_provider_and_sets_upstream() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let repo = Repository::init(&main_repo)?;
+    let commit_oid = commit_initial(&repo)?;
+    repo.remote("origin", "https://example.com/origin.git")?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature/remote")?,
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: true,
+        },
+        None,
+    )?;
+
+    let Err(missing_provider) = execute_switch_plan(&control, &plan, None) else {
+        return Err("missing provider should fail".into());
+    };
+    assert!(
+        missing_provider
+            .to_string()
+            .contains("remote refresh capability")
+    );
+
+    let provider = StubRemoteRefresher {
+        target: Some(RemoteBranchTarget {
+            remote: "origin".to_string(),
+            refname: "refs/remotes/origin/feature/remote".to_string(),
+            commit_oid,
+        }),
+    };
+    execute_switch_plan(&control, &plan, Some(&provider))?;
+
+    let branch = repo.find_branch("feature/remote", BranchType::Local)?;
+    let upstream = branch.upstream()?;
+    assert_eq!(upstream.name()?, Some("origin/feature/remote"));
+    Ok(())
+}
+
+struct StubRemoteRefresher {
+    target: Option<RemoteBranchTarget>,
+}
+
+impl RemoteRefresher for StubRemoteRefresher {
+    fn refresh(&self, _repo: &Repository) -> gwt_worktree::Result<()> {
+        Ok(())
+    }
+
+    fn resolve_branch_target(
+        &self,
+        _repo: &Repository,
+        _branch: &BranchName,
+    ) -> gwt_worktree::Result<Option<RemoteBranchTarget>> {
+        Ok(self.target.clone())
+    }
+}
+
+fn commit_initial(repo: &Repository) -> Result<String, Box<dyn Error>> {
+    let sig = git2::Signature::now("Test", "test@example.com")?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    let oid = repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])?;
+    Ok(oid.to_string())
+}

--- a/crates/infra/gwt-worktree/tests/switch_create.rs
+++ b/crates/infra/gwt-worktree/tests/switch_create.rs
@@ -215,6 +215,36 @@ fn existing_worktree_execution_fails_when_target_path_is_missing() -> Result<(),
 }
 
 #[test]
+fn create_like_switch_execution_rejects_target_path_outside_base() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let outside_path = temp.path().join("elsewhere").join("feature-outside");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    repo.branch("feature-outside", &repo.head()?.peel_to_commit()?, false)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+    let plan = SwitchPlan {
+        branch: BranchName::new("feature-outside")?,
+        admin_name: BranchName::new("feature-outside")?.encode_admin_name(),
+        target_path: outside_path.clone(),
+        kind: SwitchPlanKind::ExistingLocalBranch,
+        post_create_commands: Vec::new(),
+    };
+
+    match execute_switch_plan(&control, &plan, None) {
+        Err(GwtError::SwitchTargetOutsideBase { base, target }) => {
+            assert_eq!(base, control.worktree_base);
+            assert_eq!(target, outside_path);
+        }
+        Err(other) => return Err(format!("expected containment error, got {other}").into()),
+        Ok(result) => return Err(format!("expected failure, got {:?}", result.path).into()),
+    }
+
+    assert!(!outside_path.exists());
+    Ok(())
+}
+
+#[test]
 fn main_switch_execution_fails_when_target_path_is_missing() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
     let control_git_dir = temp.path().join("control.git");

--- a/crates/infra/gwt-worktree/tests/switch_create.rs
+++ b/crates/infra/gwt-worktree/tests/switch_create.rs
@@ -11,14 +11,16 @@ use gwt_worktree::remote::RemoteBranchTarget;
 use gwt_worktree::remote::RemoteRefresher;
 use gwt_worktree::repo::ControlRepo;
 use gwt_worktree::types::BranchName;
+use gwt_worktree::worktree::list_worktrees;
 use std::error::Error;
 use tempfile::TempDir;
 
 #[test]
 fn reuses_existing_worktree() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let linked_path = temp.path().join("main.gwt").join("feature");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let linked_path = temp_root.join("main.gwt").join("feature");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
@@ -46,7 +48,8 @@ fn reuses_existing_worktree() -> Result<(), Box<dyn Error>> {
 #[test]
 fn creates_new_branch_with_post_create_commands_as_data_only() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
@@ -80,7 +83,8 @@ fn creates_new_branch_with_post_create_commands_as_data_only() -> Result<(), Box
 #[test]
 fn force_create_requires_explicit_start_point() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
@@ -106,7 +110,8 @@ fn force_create_requires_explicit_start_point() -> Result<(), Box<dyn Error>> {
 #[test]
 fn remote_guess_requires_provider_and_sets_upstream() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
     let repo = Repository::init(&main_repo)?;
     let commit_oid = commit_initial(&repo)?;
     repo.remote("origin", "https://example.com/origin.git")?;
@@ -151,8 +156,9 @@ fn remote_guess_requires_provider_and_sets_upstream() -> Result<(), Box<dyn Erro
 #[test]
 fn existing_worktree_plan_uses_actual_path_outside_base() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let outside_path = temp.path().join("elsewhere").join("feature");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let outside_path = temp_root.join("elsewhere").join("feature");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     repo.branch("feature", &repo.head()?.peel_to_commit()?, false)?;
@@ -184,8 +190,9 @@ fn existing_worktree_plan_uses_actual_path_outside_base() -> Result<(), Box<dyn 
 #[test]
 fn existing_worktree_execution_fails_when_target_path_is_missing() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let linked_path = temp.path().join("main.gwt").join("feature");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let linked_path = temp_root.join("main.gwt").join("feature");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
@@ -217,8 +224,9 @@ fn existing_worktree_execution_fails_when_target_path_is_missing() -> Result<(),
 #[test]
 fn create_like_switch_execution_rejects_target_path_outside_base() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let outside_path = temp.path().join("elsewhere").join("feature-outside");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let outside_path = temp_root.join("elsewhere").join("feature-outside");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     repo.branch("feature-outside", &repo.head()?.peel_to_commit()?, false)?;
@@ -247,10 +255,11 @@ fn create_like_switch_execution_rejects_target_path_outside_base() -> Result<(),
 #[test]
 fn main_switch_execution_fails_when_target_path_is_missing() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let control_git_dir = temp.path().join("control.git");
+    let temp_root = canonical_temp_root(&temp);
+    let control_git_dir = temp_root.join("control.git");
     Repository::init_bare(&control_git_dir)?;
     let control = ControlRepo::from_git_dir(control_git_dir.to_str().ok_or("non-utf8")?)?;
-    let missing_main_path = temp.path().join("missing-main");
+    let missing_main_path = temp_root.join("missing-main");
     let plan = SwitchPlan {
         branch: BranchName::new("main")?,
         admin_name: BranchName::new("main")?.encode_admin_name(),
@@ -266,6 +275,62 @@ fn main_switch_execution_fails_when_target_path_is_missing() -> Result<(), Box<d
     }
 
     Ok(())
+}
+
+#[test]
+fn stale_linked_entry_falls_through_to_existing_local_branch() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let linked_path = temp_root.join("main.gwt").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    repo.branch("feature", &repo.head()?.peel_to_commit()?, false)?;
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    let branch = repo.find_branch("feature", BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = git2::WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree("feature", &linked_path, Some(&options))?;
+    std::fs::remove_dir_all(&linked_path)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let entries = list_worktrees(&control)?;
+    assert!(entries.iter().any(|entry| {
+        !entry.is_main
+            && entry.path == linked_path
+            && entry.branch.as_deref() == Some("feature")
+            && entry.prunable
+    }));
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature")?,
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    )?;
+
+    assert!(matches!(plan.kind, SwitchPlanKind::ExistingLocalBranch));
+    assert_eq!(plan.target_path, linked_path);
+    Ok(())
+}
+
+fn canonical_temp_root(temp: &TempDir) -> std::path::PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        temp.path()
+            .canonicalize()
+            .expect("canonicalize TempDir path on macOS")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        temp.path().to_path_buf()
+    }
 }
 
 struct StubRemoteRefresher {

--- a/crates/infra/gwt-worktree/tests/switch_create.rs
+++ b/crates/infra/gwt-worktree/tests/switch_create.rs
@@ -1,7 +1,9 @@
 use git2::BranchType;
 use git2::Repository;
 use gwt_worktree::config::RepoConfig;
+use gwt_worktree::error::Error as GwtError;
 use gwt_worktree::exec::switch::execute_switch_plan;
+use gwt_worktree::plan::switch::SwitchPlan;
 use gwt_worktree::plan::switch::SwitchPlanKind;
 use gwt_worktree::plan::switch::SwitchRequest;
 use gwt_worktree::plan::switch::plan_switch;
@@ -143,6 +145,96 @@ fn remote_guess_requires_provider_and_sets_upstream() -> Result<(), Box<dyn Erro
     let branch = repo.find_branch("feature/remote", BranchType::Local)?;
     let upstream = branch.upstream()?;
     assert_eq!(upstream.name()?, Some("origin/feature/remote"));
+    Ok(())
+}
+
+#[test]
+fn existing_worktree_plan_uses_actual_path_outside_base() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let outside_path = temp.path().join("elsewhere").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    repo.branch("feature", &repo.head()?.peel_to_commit()?, false)?;
+    std::fs::create_dir_all(outside_path.parent().ok_or("missing parent")?)?;
+    let branch = repo.find_branch("feature", BranchType::Local)?;
+    let reference = branch.into_reference();
+    let mut options = git2::WorktreeAddOptions::new();
+    options.reference(Some(&reference));
+    repo.worktree("feature", &outside_path, Some(&options))?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature")?,
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    )?;
+
+    assert!(matches!(plan.kind, SwitchPlanKind::ExistingWorktree));
+    assert_eq!(plan.target_path, outside_path);
+    Ok(())
+}
+
+#[test]
+fn existing_worktree_execution_fails_when_target_path_is_missing() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let linked_path = temp.path().join("main.gwt").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    repo.worktree("feature", &linked_path, None)?;
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8")?)?;
+
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: BranchName::new("feature")?,
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    )?;
+    std::fs::remove_dir_all(&linked_path)?;
+
+    match execute_switch_plan(&control, &plan, None) {
+        Err(GwtError::MissingWorktreePath(path)) => assert_eq!(path, linked_path),
+        Err(other) => return Err(format!("expected missing-path error, got {other}").into()),
+        Ok(result) => return Err(format!("expected failure, got {:?}", result.path).into()),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn main_switch_execution_fails_when_target_path_is_missing() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let control_git_dir = temp.path().join("control.git");
+    Repository::init_bare(&control_git_dir)?;
+    let control = ControlRepo::from_git_dir(control_git_dir.to_str().ok_or("non-utf8")?)?;
+    let missing_main_path = temp.path().join("missing-main");
+    let plan = SwitchPlan {
+        branch: BranchName::new("main")?,
+        admin_name: BranchName::new("main")?.encode_admin_name(),
+        target_path: missing_main_path.clone(),
+        kind: SwitchPlanKind::Main,
+        post_create_commands: Vec::new(),
+    };
+
+    match execute_switch_plan(&control, &plan, None) {
+        Err(GwtError::MissingWorktreePath(path)) => assert_eq!(path, missing_main_path),
+        Err(other) => return Err(format!("expected missing-path error, got {other}").into()),
+        Ok(result) => return Err(format!("expected failure, got {:?}", result.path).into()),
+    }
+
     Ok(())
 }
 

--- a/crates/infra/gwt-worktree/tests/worktree_list.rs
+++ b/crates/infra/gwt-worktree/tests/worktree_list.rs
@@ -8,8 +8,9 @@ use tempfile::TempDir;
 #[test]
 fn listing_includes_main_and_linked_entries() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let linked_path = temp.path().join("main.gwt").join("feature");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let linked_path = temp_root.join("main.gwt").join("feature");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
@@ -48,8 +49,9 @@ fn dirty_helper_detects_untracked_files() -> Result<(), Box<dyn Error>> {
 #[test]
 fn listing_survives_missing_linked_worktree() -> Result<(), Box<dyn Error>> {
     let temp = TempDir::new()?;
-    let main_repo = temp.path().join("main");
-    let linked_path = temp.path().join("main.gwt").join("feature");
+    let temp_root = canonical_temp_root(&temp);
+    let main_repo = temp_root.join("main");
+    let linked_path = temp_root.join("main.gwt").join("feature");
     let repo = Repository::init(&main_repo)?;
     commit_initial(&repo)?;
     std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
@@ -66,6 +68,19 @@ fn listing_survives_missing_linked_worktree() -> Result<(), Box<dyn Error>> {
             && entry.prunable
     }));
     Ok(())
+}
+
+fn canonical_temp_root(temp: &TempDir) -> std::path::PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        temp.path()
+            .canonicalize()
+            .expect("canonicalize TempDir path on macOS")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        temp.path().to_path_buf()
+    }
 }
 
 fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {

--- a/crates/infra/gwt-worktree/tests/worktree_list.rs
+++ b/crates/infra/gwt-worktree/tests/worktree_list.rs
@@ -1,0 +1,57 @@
+use git2::Repository;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::worktree::is_worktree_dirty;
+use gwt_worktree::worktree::list_worktrees;
+use std::error::Error;
+use tempfile::TempDir;
+
+#[test]
+fn listing_includes_main_and_linked_entries() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let linked_path = temp.path().join("main.gwt").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    repo.worktree("feature", &linked_path, None)?;
+
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8 path")?)?;
+    let entries = list_worktrees(&control)?;
+
+    assert_eq!(entries.len(), 2);
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.is_main && entry.path == main_repo)
+    );
+    assert!(entries.iter().any(|entry| {
+        !entry.is_main
+            && entry.path == linked_path
+            && entry.branch.as_deref() == Some("feature")
+            && !entry.detached
+    }));
+    Ok(())
+}
+
+#[test]
+fn dirty_helper_detects_untracked_files() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let repo = Repository::init(temp.path())?;
+    commit_initial(&repo)?;
+
+    std::fs::write(temp.path().join("untracked.txt"), "data")?;
+
+    assert!(is_worktree_dirty(&repo)?);
+    Ok(())
+}
+
+fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let sig = git2::Signature::now("Test", "test@example.com")?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])?;
+    Ok(())
+}

--- a/crates/infra/gwt-worktree/tests/worktree_list.rs
+++ b/crates/infra/gwt-worktree/tests/worktree_list.rs
@@ -45,6 +45,29 @@ fn dirty_helper_detects_untracked_files() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn listing_survives_missing_linked_worktree() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let main_repo = temp.path().join("main");
+    let linked_path = temp.path().join("main.gwt").join("feature");
+    let repo = Repository::init(&main_repo)?;
+    commit_initial(&repo)?;
+    std::fs::create_dir_all(linked_path.parent().ok_or("missing parent")?)?;
+    repo.worktree("feature", &linked_path, None)?;
+    std::fs::remove_dir_all(&linked_path)?;
+
+    let control = ControlRepo::from_git_dir(main_repo.to_str().ok_or("non-utf8 path")?)?;
+    let entries = list_worktrees(&control)?;
+
+    assert!(entries.iter().any(|entry| {
+        !entry.is_main
+            && entry.path == linked_path
+            && entry.branch.as_deref() == Some("feature")
+            && entry.prunable
+    }));
+    Ok(())
+}
+
 fn commit_initial(repo: &Repository) -> Result<(), Box<dyn Error>> {
     let sig = git2::Signature::now("Test", "test@example.com")?;
     let tree_id = {

--- a/mise.lock
+++ b/mise.lock
@@ -394,35 +394,35 @@ version = "0.4.6"
 backend = "cargo:systemfd"
 
 [[tools.claude]]
-version = "2.1.160"
+version = "2.1.175"
 backend = "aqua:anthropics/claude-code"
 
 [tools.claude."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-arm64/claude"
 
 [tools.claude."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-arm64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-arm64-musl/claude"
 
 [tools.claude."platforms.linux-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64-musl/claude"
 
 [tools.claude."platforms.linux-x64-musl-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/linux-x64-musl/claude"
 
 [tools.claude."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-arm64/claude"
 
 [tools.claude."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-x64/claude"
 
 [tools.claude."platforms.macos-x64-baseline"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.160/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.175/darwin-x64/claude"
 
 [[tools."github:anomalyco/opencode"]]
 version = "1.15.7"

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ _.path = ["tools/bin"]
 # instead of compiling from source. Using github backend for proper lockfile support.
 "github:cargo-bins/cargo-binstall" = "latest"
 # BEGIN:xtask:autogen mise:tool-pins
-claude = "2.1.160"
+claude = "2.1.175"
 "github:anomalyco/opencode" = "1.15.7"
 # END:xtask:autogen
 just = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ _.path = ["tools/bin"]
 # instead of compiling from source. Using github backend for proper lockfile support.
 "github:cargo-bins/cargo-binstall" = "latest"
 # BEGIN:xtask:autogen mise:tool-pins
-claude = "2.1.175"
+claude = "2.1.160"
 "github:anomalyco/opencode" = "1.15.7"
 # END:xtask:autogen
 just = "latest"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -83,7 +83,7 @@ release = true
 name = "thoughts-tool"
 changelog_path = "crates/infra/thoughts-core/CHANGELOG.md"
 git_tag_name = "thoughts-tool-v{{ version }}"
-git_tag_enable = true
+git_tag_enable = false
 release = true
 
 [[package]]
@@ -97,7 +97,7 @@ release = true
 name = "agentic_logging"
 changelog_path = "crates/infra/agentic-logging/CHANGELOG.md"
 git_tag_name = "agentic_logging-v{{ version }}"
-git_tag_enable = true
+git_tag_enable = false
 release = true
 
 [[package]]
@@ -118,7 +118,7 @@ release = true
 name = "agentic-tools-registry"
 changelog_path = "crates/agentic-tools/registry/CHANGELOG.md"
 git_tag_name = "agentic-tools-registry-v{{ version }}"
-git_tag_enable = true
+git_tag_enable = false
 release = true
 
 [[package]]
@@ -188,7 +188,7 @@ release = true
 name = "web-retrieval"
 changelog_path = "crates/tools/web-retrieval/CHANGELOG.md"
 git_tag_name = "web-retrieval-v{{ version }}"
-git_tag_enable = true
+git_tag_enable = false
 release = true
 
 [[package]]
@@ -252,7 +252,7 @@ release = true
 name = "gwt-worktree"
 changelog_path = "crates/infra/gwt-worktree/CHANGELOG.md"
 git_tag_name = "gwt-worktree-v{{ version }}"
-git_tag_enable = true
+git_tag_enable = false
 release = true
 
 [[package]]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -249,6 +249,13 @@ git_tag_enable = false
 release = true
 
 [[package]]
+name = "gwt-worktree"
+changelog_path = "crates/infra/gwt-worktree/CHANGELOG.md"
+git_tag_name = "gwt-worktree-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
 name = "universal-tool-core"
 changelog_path = "crates/legacy/universal-tool-core/CHANGELOG.md"
 git_tag_name = "universal-tool-core-v{{ version }}"


### PR DESCRIPTION
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

This PR adds a reusable `gwt-worktree` Rust library so worktree management can be implemented programmatically inside this repo without shelling out to `git`, `gh`, or an external `gwt` CLI.

Before this change, there was no workspace crate for:
- resolving a control repo from discovery, env, or config
- reading and writing gwt-compatible config from `~/.config/gwt/config.toml`
- planning and executing worktree switch/create, remove, and gc flows with typed Rust APIs
- preserving the existing `.gwt` directory layout and admin-name semantics that gwt expects

The new crate is intended as an infra building block for future tooling, while keeping v1 intentionally focused on a small, testable API surface.

Implementation followed the plan in `thoughts/worktree_exploration/plans/gwt_rust_worktree_library_implementation.md`.

## What user-facing changes did I ship?

- Added a new publishable workspace crate: `crates/infra/gwt-worktree`
- Exposed typed APIs for:
  - gwt-compatible config load/save
  - control-repo and `.gwt` base resolution
  - worktree listing and dirty detection
  - planning and execution for `switch`/create, `remove`, and `gc`
- Added trait-based integration points so callers can plug in:
  - remote refresh / branch resolution
  - remote branch deletion
  - PR state lookup
- Registered the crate in workspace metadata and release automation:
  - workspace `Cargo.toml`
  - root `README.md`
  - root `CLAUDE.md`
  - `release-plz.toml`
- Added follow-up TODO notes for a future CLI/tooling layer and possible pure-gix backend exploration

There are no end-user CLI changes in this PR yet; this is an internal foundation crate.

## How I implemented it

- Created a new `gwt-worktree` infra crate with a small public module surface: `command`, `config`, `error`, `exec`, `plan`, `pr`, `remote`, `repo`, `types`, and `worktree`
- Modeled worktree operations with a strict plan/execute split so callers can inspect decisions before performing mutations
- Added validated branch/admin-name types, including reversible encoded admin names for libgit2 worktree identities
- Implemented repo resolution that supports:
  - normal repos
  - bare repos
  - linked-worktree `.git` file pointers
  - fallback resolution from explicit path, cwd discovery, env, or config
- Implemented gwt-compatible `.gwt` base-path computation and README sentinel creation
- Added worktree enumeration that synthesizes the main worktree entry alongside linked worktrees
- Implemented:
  - switch/create planning for main, existing worktree, existing local branch, force-create, and remote-tracking creation flows
  - remove planning/execution with safeguards for dirty, locked, main, and outside-base worktrees
  - gc planning/execution that partitions worktrees into prunable, delete, clean, dirty, unmerged, and skip buckets
- Kept network- and shell-dependent behavior out of the crate by using traits instead of built-in providers
- Added focused tests covering smoke exports, config behavior, repo resolution, worktree listing, switch/create flows, remove flows, and gc behavior
- Updated repo metadata so the new crate shows up in generated documentation and release configuration

No breaking migration work is expected from this PR because the crate is additive and does not replace an existing public interface yet.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-check gwt-worktree`
- [x] `just crate-test gwt-worktree`
- [x] `just xtask-sync`
- [x] `just check`
- [x] `just test`
- [x] `just xtask-verify-check`

## Description for the changelog

Add the new `gwt-worktree` infra crate for programmatic, gwt-compatible git worktree management with typed config, planning, execution, and test coverage.
<!-- END:describe_pr:autogen -->
