### PR TITLE
feat(workspace_tools): add workspace-scoped mcp file and todo tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Guidance for Claude Code when working with this repository.
 - `review_tools` (tool-lib) - `crates/tools/review-tools/`
 - `thoughts-mcp-tools` (tool-lib) - `crates/tools/thoughts-mcp-tools/`
 - `web-retrieval` (tool-lib) - `crates/tools/web-retrieval/`
+- `workspace_tools` (tool-lib) - `crates/tools/workspace-tools/`
 - `message-optimizer-bin` (app) - `apps/message-optimizer/`
 - `message_optimizer` (tool-lib) - `crates/tools/message-optimizer/`
 <!-- END:xtask:autogen -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "tokio",
  "tracing",
  "web-retrieval",
+ "workspace_tools",
 ]
 
 [[package]]
@@ -7819,6 +7820,21 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "workspace_tools"
+version = "0.1.0"
+dependencies = [
+ "agentic-config",
+ "agentic-tools-core",
+ "anyhow",
+ "atomicwrites",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "crates/tools/review-tools",
   "crates/tools/message-optimizer",
   "crates/tools/thoughts-mcp-tools",
+  "crates/tools/workspace-tools",
   "crates/tools/web-retrieval",
 
   # Infra family
@@ -87,6 +88,7 @@ agentic-tools-registry = { version = "0.4.6", path = "crates/agentic-tools/regis
 agentic_logging = { version = "0.2.0", path = "crates/infra/agentic-logging" }
 thoughts-tool = { version = "0.12.1", path = "crates/infra/thoughts-core" }
 thoughts-mcp-tools = { version = "0.3.2", path = "crates/tools/thoughts-mcp-tools" }
+workspace_tools = { version = "0.1.0", path = "crates/tools/workspace-tools" }
 coding_agent_tools = { version = "0.5.2", path = "crates/tools/coding-agent-tools" }
 pr_comments = { version = "0.8.3", path = "crates/tools/pr-comments" }
 gpt5_reasoner = { version = "0.11.5", path = "crates/tools/gpt5-reasoner" }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ opencode_rs = "0.12.0"
 - [`review_tools`](crates/tools/review-tools) - Review tools for agentic-mcp: diff snapshots, lens-based review, pagination
 - [`thoughts-mcp-tools`](crates/tools/thoughts-mcp-tools) - MCP tool wrappers for thoughts-tool using agentic-tools framework
 - [`web-retrieval`](crates/tools/web-retrieval) - Web fetch and web search MCP tools
+- [`workspace_tools`](crates/tools/workspace-tools) - Workspace-scoped file and todo MCP tools
 <!-- END:xtask:autogen -->
 
 ## Supporting Libraries

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ opencode_rs = "0.12.0"
 - [`review_tools`](crates/tools/review-tools) - Review tools for agentic-mcp: diff snapshots, lens-based review, pagination
 - [`thoughts-mcp-tools`](crates/tools/thoughts-mcp-tools) - MCP tool wrappers for thoughts-tool using agentic-tools framework
 - [`web-retrieval`](crates/tools/web-retrieval) - Web fetch and web search MCP tools
-- [`workspace_tools`](crates/tools/workspace-tools) - Workspace-scoped file and todo MCP tools
+- [`workspace_tools`](crates/tools/workspace-tools) - Workspace-scoped read/todowrite/edit/apply_patch tools
 <!-- END:xtask:autogen -->
 
 ## Supporting Libraries

--- a/agentic.schema.json
+++ b/agentic.schema.json
@@ -120,6 +120,16 @@
           "temperature": 0.2
         }
       }
+    },
+    "workspace_tools": {
+      "description": "Workspace-local file and todo tools configuration.",
+      "$ref": "#/$defs/WorkspaceToolsConfig",
+      "default": {
+        "workspace_apply_patch": false,
+        "workspace_edit": false,
+        "workspace_read": false,
+        "workspace_todowrite": false
+      }
     }
   },
   "$defs": {
@@ -587,6 +597,32 @@
           "type": "number",
           "format": "double",
           "default": 0.2
+        }
+      }
+    },
+    "WorkspaceToolsConfig": {
+      "description": "Configuration for workspace-local file and todo tools.",
+      "type": "object",
+      "properties": {
+        "workspace_apply_patch": {
+          "description": "Enable the `workspace_apply_patch` tool.",
+          "type": "boolean",
+          "default": false
+        },
+        "workspace_edit": {
+          "description": "Enable the `workspace_edit` tool.",
+          "type": "boolean",
+          "default": false
+        },
+        "workspace_read": {
+          "description": "Enable the `workspace_read` tool.",
+          "type": "boolean",
+          "default": false
+        },
+        "workspace_todowrite": {
+          "description": "Enable the `workspace_todowrite` tool.",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/agentic.toml.example
+++ b/agentic.toml.example
@@ -111,6 +111,18 @@ just_search_timeout_secs = 30
 extra_ignore_patterns = []
 
 # =============================================================================
+# Workspace Tools - Local workspace-scoped file and todo tools
+# =============================================================================
+[workspace_tools]
+# Disabled by default. When enabled, these tools only operate inside the current
+# workspace/repo root and strongly prefer workspace-relative paths like src/main.rs.
+# Absolute paths are only accepted when they still resolve inside the workspace root.
+workspace_read = false
+workspace_todowrite = false
+workspace_edit = false
+workspace_apply_patch = false
+
+# =============================================================================
 # Services - External API configurations
 # =============================================================================
 [services.anthropic]

--- a/apps/agentic-mcp/src/main.rs
+++ b/apps/agentic-mcp/src/main.rs
@@ -176,6 +176,7 @@ async fn main() -> anyhow::Result<()> {
     reg_cfg.reasoning = loaded.config.reasoning.clone();
     reg_cfg.web_retrieval = loaded.config.web_retrieval.clone();
     reg_cfg.cli_tools = loaded.config.cli_tools.clone();
+    reg_cfg.workspace_tools = loaded.config.workspace_tools.clone();
     reg_cfg.exa = loaded.config.services.exa.clone();
     reg_cfg.anthropic = loaded.config.services.anthropic.clone();
     reg_cfg.linear = loaded.config.services.linear.clone();

--- a/apps/agentic/src/commands/config.rs
+++ b/apps/agentic/src/commands/config.rs
@@ -348,6 +348,11 @@ mod tests {
         assert!(toml.contains("runtime_timeout_secs = 3600"));
         assert!(toml.contains("just_execute_timeout_secs = 1800"));
         assert!(toml.contains("just_search_timeout_secs = 30"));
+        assert!(toml.contains("[workspace_tools]"));
+        assert!(toml.contains("workspace_read = false"));
+        assert!(toml.contains("workspace_todowrite = false"));
+        assert!(toml.contains("workspace_edit = false"));
+        assert!(toml.contains("workspace_apply_patch = false"));
         assert!(toml.contains("[services.linear]"));
         assert!(toml.contains("connect_timeout_secs = 10"));
         assert!(toml.contains("[services.github]"));

--- a/crates/agentic-tools/registry/Cargo.toml
+++ b/crates/agentic-tools/registry/Cargo.toml
@@ -28,6 +28,8 @@ serde_json = { workspace = true }
 thoughts-mcp-tools = { workspace = true }
 tracing = { workspace = true }
 web-retrieval = { workspace = true }
+workspace_tools = { workspace = true }
+
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/agentic-tools/registry/src/lib.rs
+++ b/crates/agentic-tools/registry/src/lib.rs
@@ -37,6 +37,7 @@ use agentic_config::types::ReviewConfig;
 use agentic_config::types::SubagentsConfig;
 use agentic_config::types::ThoughtsConfig;
 use agentic_config::types::WebRetrievalConfig;
+use agentic_config::types::WorkspaceToolsConfig;
 use agentic_tools_core::ToolRegistry;
 use serde::Deserialize;
 use serde::Serialize;
@@ -59,6 +60,10 @@ pub struct AgenticToolsConfig {
     /// Tool-specific config for CLI tools (limits, ignore patterns).
     #[serde(default)]
     pub cli_tools: CliToolsConfig,
+
+    /// Tool-specific config for workspace-local file and todo tools.
+    #[serde(default)]
+    pub workspace_tools: WorkspaceToolsConfig,
 
     /// Tool-specific config for gpt5-reasoner.
     #[serde(default)]
@@ -138,6 +143,13 @@ const THOUGHTS_NAMES: &[&str] = &[
 const WEB_NAMES: &[&str] = &["web_fetch", "web_search"];
 
 const REVIEW_NAMES: &[&str] = &["review_diff_snapshot", "review_diff_page", "review_run"];
+
+const WORKSPACE_NAMES: &[&str] = &[
+    "workspace_read",
+    "workspace_todowrite",
+    "workspace_edit",
+    "workspace_apply_patch",
+];
 
 impl AgenticTools {
     /// Build the unified `ToolRegistry` using domain registries.
@@ -224,6 +236,10 @@ impl AgenticTools {
             regs.push(review_tools::build_registry(svc));
         }
 
+        if workspace_tools_enabled(&config.workspace_tools) && domain_wanted(WORKSPACE_NAMES) {
+            regs.push(workspace_tools::build_registry(&config.workspace_tools));
+        }
+
         let merged = ToolRegistry::merge_all(regs);
 
         // Final allowlist filtering at registry level (authoritative)
@@ -250,7 +266,15 @@ impl AgenticTools {
             + THOUGHTS_NAMES.len()
             + WEB_NAMES.len()
             + REVIEW_NAMES.len()
+            + WORKSPACE_NAMES.len()
     }
+}
+
+fn workspace_tools_enabled(config: &WorkspaceToolsConfig) -> bool {
+    config.workspace_read
+        || config.workspace_todowrite
+        || config.workspace_edit
+        || config.workspace_apply_patch
 }
 
 /// Normalize allowlist: lowercase, trim, filter empty strings.
@@ -276,7 +300,7 @@ mod tests {
 
     #[test]
     fn total_tool_count_is_30() {
-        assert_eq!(AgenticTools::total_tool_count(), 30);
+        assert_eq!(AgenticTools::total_tool_count(), 34);
     }
 
     #[test]
@@ -316,7 +340,7 @@ mod tests {
         let reg = AgenticTools::new(AgenticToolsConfig::default());
         let names = reg.list_names();
 
-        // Should have all 27 tools
+        // Workspace tools remain disabled by default.
         assert!(
             names.len() >= 27,
             "expected at least 27 tools, got {}",
@@ -356,6 +380,10 @@ mod tests {
             reg.contains("web_search"),
             "missing web_search from web_retrieval"
         );
+        assert!(!reg.contains("workspace_read"));
+        assert!(!reg.contains("workspace_todowrite"));
+        assert!(!reg.contains("workspace_edit"));
+        assert!(!reg.contains("workspace_apply_patch"));
     }
 
     #[test]
@@ -502,5 +530,43 @@ mod tests {
             reg.contains("ask_reasoning_model"),
             "missing ask_reasoning_model (uses reasoning config)"
         );
+    }
+
+    #[test]
+    fn workspace_tools_require_matching_toggle() {
+        let reg = AgenticTools::new(AgenticToolsConfig {
+            workspace_tools: WorkspaceToolsConfig {
+                workspace_read: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(reg.contains("workspace_read"));
+        assert!(!reg.contains("workspace_todowrite"));
+        assert!(!reg.contains("workspace_edit"));
+        assert!(!reg.contains("workspace_apply_patch"));
+    }
+
+    #[test]
+    fn workspace_tools_respect_allowlist_intersection() {
+        let reg = AgenticTools::new(AgenticToolsConfig {
+            allowlist: Some(HashSet::from([
+                String::from("workspace_read"),
+                String::from("workspace_edit"),
+            ])),
+            workspace_tools: WorkspaceToolsConfig {
+                workspace_read: true,
+                workspace_edit: true,
+                workspace_apply_patch: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(reg.contains("workspace_read"));
+        assert!(reg.contains("workspace_edit"));
+        assert!(!reg.contains("workspace_todowrite"));
+        assert!(!reg.contains("workspace_apply_patch"));
     }
 }

--- a/crates/infra/agentic-config/src/schema.rs
+++ b/crates/infra/agentic-config/src/schema.rs
@@ -64,6 +64,12 @@ mod tests {
                 .is_some()
         );
 
+        let workspace_props = &json["$defs"]["WorkspaceToolsConfig"]["properties"];
+        assert!(workspace_props.get("workspace_read").is_some());
+        assert!(workspace_props.get("workspace_todowrite").is_some());
+        assert!(workspace_props.get("workspace_edit").is_some());
+        assert!(workspace_props.get("workspace_apply_patch").is_some());
+
         let services_properties = &json["$defs"]["ServicesConfig"]["properties"];
         assert!(services_properties.get("linear").is_some());
         assert!(services_properties.get("github").is_some());

--- a/crates/infra/agentic-config/src/types.rs
+++ b/crates/infra/agentic-config/src/types.rs
@@ -44,6 +44,9 @@ pub struct AgenticConfig {
     /// CLI tools (grep, glob, ls) configuration.
     pub cli_tools: CliToolsConfig,
 
+    /// Workspace-local file and todo tools configuration.
+    pub workspace_tools: WorkspaceToolsConfig,
+
     /// Logging and diagnostics configuration.
     pub logging: LoggingConfig,
 }
@@ -308,6 +311,26 @@ impl Default for CliToolsConfig {
 
 //
 // ─────────────────────────────────────────────────────────────────────────────
+// WORKSPACE TOOLS CONFIG
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+/// Configuration for workspace-local file and todo tools.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct WorkspaceToolsConfig {
+    /// Enable the `workspace_read` tool.
+    pub workspace_read: bool,
+    /// Enable the `workspace_todowrite` tool.
+    pub workspace_todowrite: bool,
+    /// Enable the `workspace_edit` tool.
+    pub workspace_edit: bool,
+    /// Enable the `workspace_apply_patch` tool.
+    pub workspace_apply_patch: bool,
+}
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
 // SERVICES CONFIG
 // ─────────────────────────────────────────────────────────────────────────────
 //
@@ -491,6 +514,7 @@ mod tests {
         assert!(toml_str.contains("[orchestrator.agents]"));
         assert!(toml_str.contains("[web_retrieval]"));
         assert!(toml_str.contains("[cli_tools]"));
+        assert!(toml_str.contains("[workspace_tools]"));
         assert!(toml_str.contains("[logging]"));
         // Ensure old sections are NOT present
         assert!(!toml_str.contains("[models]"));
@@ -652,5 +676,15 @@ deny = ["Bash"]
         assert_eq!(cfg.subagents.runtime_timeout_secs, 3600);
         assert_eq!(cfg.review.run_timeout_secs, 1800);
         assert_eq!(cfg.thoughts.add_reference_timeout_secs, 600);
+    }
+
+    #[test]
+    fn test_workspace_tools_defaults_match_plan() {
+        let cfg = AgenticConfig::default();
+
+        assert!(!cfg.workspace_tools.workspace_read);
+        assert!(!cfg.workspace_tools.workspace_todowrite);
+        assert!(!cfg.workspace_tools.workspace_edit);
+        assert!(!cfg.workspace_tools.workspace_apply_patch);
     }
 }

--- a/crates/infra/agentic-config/src/validation.rs
+++ b/crates/infra/agentic-config/src/validation.rs
@@ -83,6 +83,7 @@ const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "orchestrator",
     "web_retrieval",
     "cli_tools",
+    "workspace_tools",
     "review",
     "thoughts",
     "logging",

--- a/crates/tools/workspace-tools/CLAUDE.md
+++ b/crates/tools/workspace-tools/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md - workspace_tools
+
+<!-- BEGIN:xtask:autogen header -->
+- Crate: workspace_tools
+- Path: crates/tools/workspace-tools/
+- Role: tool-lib
+- Family: tools
+- Integrations: mcp=false, logging=false, napi=false
+<!-- END:xtask:autogen -->
+
+## Overview
+
+Briefly describe the purpose of this crate and how to use it.
+
+## Quick Commands
+
+<!-- BEGIN:xtask:autogen commands -->
+```bash
+# Lint & Clippy
+cargo fmt -p workspace_tools -- --check
+cargo clippy -p workspace_tools --all-targets -- -D warnings
+
+# Tests
+cargo test -p workspace_tools
+
+# Build
+cargo build -p workspace_tools
+```
+<!-- END:xtask:autogen -->
+
+## Notes
+
+Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.

--- a/crates/tools/workspace-tools/Cargo.toml
+++ b/crates/tools/workspace-tools/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "workspace_tools"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Workspace-scoped file and todo MCP tools"
+repository = "https://github.com/allisoneer/agentic_auxilary"
+
+[package.metadata.repo]
+role = "tool-lib"
+family = "tools"
+
+[package.metadata.repo.integrations]
+mcp = false
+logging = false
+napi = false
+
+[dependencies]
+agentic-config = { workspace = true }
+agentic-tools-core = { workspace = true }
+anyhow = { workspace = true }
+atomicwrites = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tools/workspace-tools/Cargo.toml
+++ b/crates/tools/workspace-tools/Cargo.toml
@@ -3,7 +3,7 @@ name = "workspace_tools"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-description = "Workspace-scoped file and todo MCP tools"
+description = "Workspace-scoped read/todowrite/edit/apply_patch tools"
 repository = "https://github.com/allisoneer/agentic_auxilary"
 
 [package.metadata.repo]

--- a/crates/tools/workspace-tools/src/lib.rs
+++ b/crates/tools/workspace-tools/src/lib.rs
@@ -1,0 +1,9 @@
+#[cfg(not(unix))]
+compile_error!("workspace_tools only supports Unix-like platforms (Linux/macOS).");
+
+pub mod patch;
+pub mod paths;
+pub mod service;
+pub mod tools;
+
+pub use tools::build_registry;

--- a/crates/tools/workspace-tools/src/patch.rs
+++ b/crates/tools/workspace-tools/src/patch.rs
@@ -1,0 +1,302 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatchOp {
+    Add {
+        path: String,
+        contents: String,
+    },
+    Update {
+        path: String,
+        move_to: Option<String>,
+        chunks: Vec<PatchChunk>,
+    },
+    Delete {
+        path: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchChunk {
+    pub context: Option<String>,
+    pub old_lines: Vec<String>,
+    pub new_lines: Vec<String>,
+    pub end_of_file: bool,
+}
+
+pub fn parse_patch(patch_text: &str) -> Result<Vec<PatchOp>, String> {
+    let lines = normalize_patch_text(patch_text)
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    let begin = lines
+        .iter()
+        .position(|line| line.trim() == "*** Begin Patch")
+        .ok_or_else(|| String::from("Invalid patch format: missing *** Begin Patch marker"))?;
+    let end = lines
+        .iter()
+        .rposition(|line| line.trim() == "*** End Patch")
+        .ok_or_else(|| String::from("Invalid patch format: missing *** End Patch marker"))?;
+
+    if begin >= end {
+        return Err(String::from(
+            "Invalid patch format: patch end marker must come after the begin marker",
+        ));
+    }
+
+    let mut index = begin + 1;
+    let mut operations = Vec::new();
+
+    while index < end {
+        let line = lines[index].trim_end();
+        if line.is_empty() {
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Add File:") {
+            let path = path.trim();
+            if path.is_empty() {
+                return Err(String::from("Add File operation is missing a path"));
+            }
+
+            index += 1;
+            let mut contents = Vec::new();
+            while index < end && !lines[index].starts_with("*** ") {
+                let body = lines[index]
+                    .strip_prefix('+')
+                    .ok_or_else(|| format!("Invalid Add File line: {}", lines[index]))?;
+                contents.push(body.to_string());
+                index += 1;
+            }
+
+            operations.push(PatchOp::Add {
+                path: path.to_string(),
+                contents: contents.join("\n"),
+            });
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Delete File:") {
+            let path = path.trim();
+            if path.is_empty() {
+                return Err(String::from("Delete File operation is missing a path"));
+            }
+
+            operations.push(PatchOp::Delete {
+                path: path.to_string(),
+            });
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Update File:") {
+            let path = path.trim();
+            if path.is_empty() {
+                return Err(String::from("Update File operation is missing a path"));
+            }
+
+            index += 1;
+            let move_to = if index < end {
+                lines[index].strip_prefix("*** Move to:").map(|value| {
+                    index += 1;
+                    value.trim().to_string()
+                })
+            } else {
+                None
+            };
+
+            let mut chunks = Vec::new();
+            while index < end && !lines[index].starts_with("*** ") {
+                let header = lines[index]
+                    .strip_prefix("@@")
+                    .ok_or_else(|| format!("Invalid Update File chunk header: {}", lines[index]))?;
+                index += 1;
+
+                let mut old_lines = Vec::new();
+                let mut new_lines = Vec::new();
+                let mut end_of_file = false;
+
+                while index < end
+                    && !lines[index].starts_with("@@")
+                    && !lines[index].starts_with("*** ")
+                {
+                    let body = &lines[index];
+                    if body == "*** End of File" {
+                        end_of_file = true;
+                        index += 1;
+                        break;
+                    }
+
+                    match body.chars().next() {
+                        Some(' ') => {
+                            let value = body[1..].to_string();
+                            old_lines.push(value.clone());
+                            new_lines.push(value);
+                        }
+                        Some('-') => old_lines.push(body[1..].to_string()),
+                        Some('+') => new_lines.push(body[1..].to_string()),
+                        _ => return Err(format!("Invalid patch line in update chunk: {body}")),
+                    }
+
+                    index += 1;
+                }
+
+                chunks.push(PatchChunk {
+                    context: optional_trimmed(header),
+                    old_lines,
+                    new_lines,
+                    end_of_file,
+                });
+            }
+
+            operations.push(PatchOp::Update {
+                path: path.to_string(),
+                move_to,
+                chunks,
+            });
+            continue;
+        }
+
+        return Err(format!("Unknown patch directive: {line}"));
+    }
+
+    Ok(operations)
+}
+
+pub fn apply_chunks(original_text: &str, chunks: &[PatchChunk]) -> Result<String, String> {
+    let original_had_trailing_newline = original_text.ends_with('\n');
+    let mut lines = split_lines(original_text);
+    let mut cursor = 0_usize;
+
+    for chunk in chunks {
+        let start = locate_chunk(&lines, chunk, cursor)?;
+        let end = start + chunk.old_lines.len();
+        lines.splice(start..end, chunk.new_lines.clone());
+        cursor = start + chunk.new_lines.len();
+    }
+
+    let mut output = lines.join("\n");
+    if original_had_trailing_newline && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn locate_chunk(lines: &[String], chunk: &PatchChunk, cursor: usize) -> Result<usize, String> {
+    if chunk.old_lines.is_empty() {
+        if chunk.end_of_file {
+            return Ok(lines.len());
+        }
+
+        if let Some(context) = &chunk.context {
+            let matches = lines
+                .iter()
+                .enumerate()
+                .skip(cursor)
+                .filter_map(|(index, line)| {
+                    if line == context {
+                        Some(index + 1)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            return unique_match(&matches, "insert location");
+        }
+
+        return Ok(cursor.min(lines.len()));
+    }
+
+    let max = lines.len().saturating_sub(chunk.old_lines.len());
+    let mut matches = Vec::new();
+    for start in cursor..=max {
+        if lines[start..start + chunk.old_lines.len()] == chunk.old_lines[..] {
+            matches.push(start);
+        }
+    }
+    if matches.is_empty() {
+        for start in 0..=max {
+            if lines[start..start + chunk.old_lines.len()] == chunk.old_lines[..] {
+                matches.push(start);
+            }
+        }
+    }
+
+    unique_match(&matches, "update chunk")
+}
+
+fn unique_match(matches: &[usize], label: &str) -> Result<usize, String> {
+    match matches {
+        [index] => Ok(*index),
+        [] => Err(format!("Failed to locate {label} in target file")),
+        _ => Err(format!("Found multiple possible matches for {label}")),
+    }
+}
+
+fn split_lines(text: &str) -> Vec<String> {
+    let mut lines = text.replace("\r\n", "\n").replace('\r', "\n");
+    if lines.ends_with('\n') {
+        lines.pop();
+    }
+
+    if lines.is_empty() {
+        Vec::new()
+    } else {
+        lines.split('\n').map(ToOwned::to_owned).collect()
+    }
+}
+
+fn normalize_patch_text(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn optional_trimmed(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_add_update_delete_and_move_operations() {
+        let patch = r"*** Begin Patch
+*** Add File: new.txt
++hello
+*** Update File: old.txt
+*** Move to: moved.txt
+@@
+-old
++new
+*** Delete File: gone.txt
+*** End Patch";
+
+        let operations = parse_patch(patch).unwrap();
+
+        assert_eq!(operations.len(), 3);
+        assert!(matches!(operations[0], PatchOp::Add { .. }));
+        assert!(matches!(operations[1], PatchOp::Update { .. }));
+        assert!(matches!(operations[2], PatchOp::Delete { .. }));
+    }
+
+    #[test]
+    fn applies_chunks_to_text() {
+        let result = apply_chunks(
+            "before\nold\nafter\n",
+            &[PatchChunk {
+                context: None,
+                old_lines: vec![String::from("old")],
+                new_lines: vec![String::from("new")],
+                end_of_file: false,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(result, "before\nnew\nafter\n");
+    }
+}

--- a/crates/tools/workspace-tools/src/patch.rs
+++ b/crates/tools/workspace-tools/src/patch.rs
@@ -116,14 +116,16 @@ pub fn parse_patch(patch_text: &str) -> Result<Vec<PatchOp>, String> {
                 let mut new_lines = Vec::new();
                 let mut end_of_file = false;
 
-                while index < end
-                    && !lines[index].starts_with("@@")
-                    && !lines[index].starts_with("*** ")
-                {
-                    let body = &lines[index];
+                while index < end && !lines[index].starts_with("@@") {
+                    let body = lines[index].trim_end();
+
                     if body == "*** End of File" {
                         end_of_file = true;
                         index += 1;
+                        break;
+                    }
+
+                    if body.starts_with("*** ") {
                         break;
                     }
 
@@ -165,6 +167,11 @@ pub fn parse_patch(patch_text: &str) -> Result<Vec<PatchOp>, String> {
 
 pub fn apply_chunks(original_text: &str, chunks: &[PatchChunk]) -> Result<String, String> {
     let original_had_trailing_newline = original_text.ends_with('\n');
+    let line_ending = if original_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
     let mut lines = split_lines(original_text);
     let mut cursor = 0_usize;
 
@@ -175,36 +182,44 @@ pub fn apply_chunks(original_text: &str, chunks: &[PatchChunk]) -> Result<String
         cursor = start + chunk.new_lines.len();
     }
 
-    let mut output = lines.join("\n");
+    let mut output = lines.join(line_ending);
     if original_had_trailing_newline && !output.ends_with('\n') {
-        output.push('\n');
+        output.push_str(line_ending);
     }
     Ok(output)
 }
 
 fn locate_chunk(lines: &[String], chunk: &PatchChunk, cursor: usize) -> Result<usize, String> {
+    let mut cursor = cursor;
+
+    if let Some(context) = &chunk.context {
+        let matches = lines
+            .iter()
+            .enumerate()
+            .skip(cursor)
+            .filter_map(|(index, line)| (line == context).then_some(index))
+            .collect::<Vec<_>>();
+        let context_index = unique_match(&matches, "chunk context")?;
+        cursor = context_index + 1;
+    }
+
     if chunk.old_lines.is_empty() {
         if chunk.end_of_file {
             return Ok(lines.len());
         }
 
-        if let Some(context) = &chunk.context {
-            let matches = lines
-                .iter()
-                .enumerate()
-                .skip(cursor)
-                .filter_map(|(index, line)| {
-                    if line == context {
-                        Some(index + 1)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>();
-            return unique_match(&matches, "insert location");
-        }
-
         return Ok(cursor.min(lines.len()));
+    }
+
+    if lines.len() < chunk.old_lines.len() {
+        return Err(String::from("Failed to locate update chunk in target file"));
+    }
+
+    if chunk.end_of_file {
+        let start = lines.len().saturating_sub(chunk.old_lines.len());
+        if start >= cursor && lines[start..start + chunk.old_lines.len()] == chunk.old_lines[..] {
+            return Ok(start);
+        }
     }
 
     let max = lines.len().saturating_sub(chunk.old_lines.len());
@@ -298,5 +313,80 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, "before\nnew\nafter\n");
+    }
+
+    #[test]
+    fn parses_end_of_file_sentinel_in_update_chunk() {
+        let patch = r"*** Begin Patch
+*** Update File: notes.txt
+@@
+-old
++new
+*** End of File
+*** End Patch";
+
+        let operations = parse_patch(patch).unwrap();
+
+        assert_eq!(
+            operations,
+            vec![PatchOp::Update {
+                path: String::from("notes.txt"),
+                move_to: None,
+                chunks: vec![PatchChunk {
+                    context: None,
+                    old_lines: vec![String::from("old")],
+                    new_lines: vec![String::from("new")],
+                    end_of_file: true,
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn apply_chunks_prefers_eof_match_when_end_of_file_is_set() {
+        let result = apply_chunks(
+            "old\nkeep\nold\n",
+            &[PatchChunk {
+                context: None,
+                old_lines: vec![String::from("old")],
+                new_lines: vec![String::from("new")],
+                end_of_file: true,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(result, "old\nkeep\nnew\n");
+    }
+
+    #[test]
+    fn apply_chunks_uses_context_to_disambiguate_replacements() {
+        let result = apply_chunks(
+            "alpha\nold\nseparator\nbeta\nold\n",
+            &[PatchChunk {
+                context: Some(String::from("beta")),
+                old_lines: vec![String::from("old")],
+                new_lines: vec![String::from("new")],
+                end_of_file: false,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(result, "alpha\nold\nseparator\nbeta\nnew\n");
+    }
+
+    #[test]
+    fn apply_chunks_preserves_crlf_line_endings() {
+        let result = apply_chunks(
+            "before\r\nold\r\nafter\r\n",
+            &[PatchChunk {
+                context: None,
+                old_lines: vec![String::from("old")],
+                new_lines: vec![String::from("new")],
+                end_of_file: false,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(result, "before\r\nnew\r\nafter\r\n");
     }
 }

--- a/crates/tools/workspace-tools/src/paths.rs
+++ b/crates/tools/workspace-tools/src/paths.rs
@@ -1,0 +1,205 @@
+use agentic_tools_core::ToolError;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+const RELATIVE_PATH_GUIDANCE: &str = "Use workspace-relative paths such as `src/main.rs`. Absolute paths are only allowed when they resolve inside the current workspace root.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPath {
+    pub absolute_path: PathBuf,
+    pub display_path: String,
+}
+
+pub fn resolve_workspace_path(root: &Path, input: &str) -> Result<ResolvedPath, ToolError> {
+    if input.trim().is_empty() {
+        return Err(ToolError::InvalidInput(format!(
+            "Path is required. {RELATIVE_PATH_GUIDANCE}"
+        )));
+    }
+
+    let canonical_root = std::fs::canonicalize(root).map_err(|error| {
+        ToolError::Internal(format!(
+            "Failed to resolve workspace root {}: {error}",
+            root.display()
+        ))
+    })?;
+
+    let requested = PathBuf::from(input);
+    let combined = if requested.is_absolute() {
+        requested
+    } else {
+        canonical_root.join(requested)
+    };
+    let absolute_path = canonicalize_existing_or_ancestor(&combined)?;
+
+    if !absolute_path.starts_with(&canonical_root) {
+        return Err(ToolError::InvalidInput(format!(
+            "Path `{input}` resolves outside the workspace root. {RELATIVE_PATH_GUIDANCE}"
+        )));
+    }
+
+    Ok(ResolvedPath {
+        display_path: workspace_relative_display(&canonical_root, &absolute_path)?,
+        absolute_path,
+    })
+}
+
+fn canonicalize_existing_or_ancestor(path: &Path) -> Result<PathBuf, ToolError> {
+    if path.exists() {
+        return std::fs::canonicalize(path).map_err(|error| {
+            ToolError::Internal(format!(
+                "Failed to canonicalize {}: {error}",
+                path.display()
+            ))
+        });
+    }
+
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        ancestor = ancestor.parent().ok_or_else(|| {
+            ToolError::InvalidInput(format!(
+                "Path `{}` is invalid. {RELATIVE_PATH_GUIDANCE}",
+                path.display()
+            ))
+        })?;
+    }
+
+    let canonical_ancestor = std::fs::canonicalize(ancestor).map_err(|error| {
+        ToolError::Internal(format!(
+            "Failed to canonicalize {}: {error}",
+            ancestor.display()
+        ))
+    })?;
+    let suffix = path.strip_prefix(ancestor).map_err(|error| {
+        ToolError::Internal(format!("Failed to resolve {}: {error}", path.display()))
+    })?;
+
+    normalize_joined_path(&canonical_ancestor, suffix)
+}
+
+fn normalize_joined_path(base: &Path, suffix: &Path) -> Result<PathBuf, ToolError> {
+    let mut normalized = PathBuf::from(base);
+
+    for component in suffix.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => normalized.push(part),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(ToolError::InvalidInput(format!(
+                        "Path `{}` escapes the workspace root. {RELATIVE_PATH_GUIDANCE}",
+                        suffix.display()
+                    )));
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(ToolError::InvalidInput(
+                    "Use a relative path such as `src/main.rs`. Absolute paths are only allowed when they resolve inside the workspace root.".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn workspace_relative_display(root: &Path, path: &Path) -> Result<String, ToolError> {
+    path.strip_prefix(root)
+        .map_err(|error| ToolError::Internal(error.to_string()))
+        .map(|relative| {
+            let value = relative.to_string_lossy().replace('\\', "/");
+            if value.is_empty() {
+                String::from(".")
+            } else {
+                value
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(prefix: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            path.push(format!("{prefix}{}-{nanos}", std::process::id()));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn relative_path_inside_root_succeeds() {
+        let dir = TestDir::new("workspace-paths-");
+        std::fs::create_dir_all(dir.path.join("src")).unwrap();
+        std::fs::write(dir.path.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let resolved = resolve_workspace_path(&dir.path, "src/main.rs").unwrap();
+
+        assert_eq!(resolved.display_path, "src/main.rs");
+        assert!(resolved.absolute_path.ends_with("src/main.rs"));
+    }
+
+    #[test]
+    fn absolute_path_inside_root_succeeds() {
+        let dir = TestDir::new("workspace-paths-");
+        std::fs::write(dir.path.join("file.txt"), "hello\n").unwrap();
+        let input = dir.path.join("file.txt");
+
+        let resolved = resolve_workspace_path(&dir.path, &input.to_string_lossy()).unwrap();
+
+        assert_eq!(resolved.display_path, "file.txt");
+    }
+
+    #[test]
+    fn dot_dot_traversal_fails() {
+        let dir = TestDir::new("workspace-paths-");
+
+        let error = resolve_workspace_path(&dir.path, "../outside.txt").unwrap_err();
+
+        assert!(error.to_string().contains("outside the workspace root"));
+    }
+
+    #[test]
+    fn absolute_path_outside_root_fails() {
+        let dir = TestDir::new("workspace-paths-");
+        let outside = TestDir::new("workspace-paths-outside-");
+
+        let error = resolve_workspace_path(&dir.path, &outside.path.to_string_lossy()).unwrap_err();
+
+        assert!(error.to_string().contains("outside the workspace root"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_fails() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TestDir::new("workspace-paths-");
+        let outside = TestDir::new("workspace-paths-outside-");
+        symlink(&outside.path, dir.path.join("link")).unwrap();
+
+        let error = resolve_workspace_path(&dir.path, "link/escape.txt").unwrap_err();
+
+        assert!(error.to_string().contains("outside the workspace root"));
+    }
+}

--- a/crates/tools/workspace-tools/src/service.rs
+++ b/crates/tools/workspace-tools/src/service.rs
@@ -1,0 +1,101 @@
+use agentic_tools_core::ToolError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+use tokio::sync::Mutex as AsyncMutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct TodoItem {
+    pub content: String,
+    pub status: String,
+    pub priority: String,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceRuntime {
+    inner: Result<Arc<WorkspaceTools>, Arc<String>>,
+}
+
+impl WorkspaceRuntime {
+    pub fn discover() -> Self {
+        let inner = WorkspaceTools::discover().map(Arc::new).map_err(Arc::new);
+        Self { inner }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_root(root: &Path) -> Result<Self, String> {
+        WorkspaceTools::from_root(root)
+            .map(Arc::new)
+            .map(|tools| Self { inner: Ok(tools) })
+    }
+
+    pub fn tools(&self) -> Result<Arc<WorkspaceTools>, ToolError> {
+        self.inner.clone().map_err(|message| {
+            ToolError::Internal(format!(
+                "workspace tools are unavailable: {message}. Use workspace-relative paths such as `src/main.rs`."
+            ))
+        })
+    }
+}
+
+pub struct WorkspaceTools {
+    root: PathBuf,
+    todos: Arc<RwLock<Vec<TodoItem>>>,
+    file_locks: Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>,
+}
+
+impl WorkspaceTools {
+    fn discover() -> Result<Self, String> {
+        let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+        Self::from_root(&cwd)
+    }
+
+    fn from_root(root: &Path) -> Result<Self, String> {
+        let root = std::fs::canonicalize(root).map_err(|error| error.to_string())?;
+
+        Ok(Self {
+            root,
+            todos: Arc::new(RwLock::new(Vec::new())),
+            file_locks: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn root(&self) -> &PathBuf {
+        &self.root
+    }
+
+    pub fn read_todos(&self) -> Result<Vec<TodoItem>, ToolError> {
+        self.todos
+            .read()
+            .map_err(|error| ToolError::Internal(error.to_string()))
+            .map(|todos| todos.clone())
+    }
+
+    pub fn replace_todos(&self, todos: Vec<TodoItem>) -> Result<Vec<TodoItem>, ToolError> {
+        let mut guard = self
+            .todos
+            .write()
+            .map_err(|error| ToolError::Internal(error.to_string()))?;
+        *guard = todos;
+        Ok(guard.clone())
+    }
+
+    pub fn file_lock(&self, path: &std::path::Path) -> Result<Arc<AsyncMutex<()>>, ToolError> {
+        let mut guard = self
+            .file_locks
+            .lock()
+            .map_err(|error| ToolError::Internal(error.to_string()))?;
+
+        Ok(Arc::clone(
+            guard
+                .entry(path.to_path_buf())
+                .or_insert_with(|| Arc::new(AsyncMutex::new(()))),
+        ))
+    }
+}

--- a/crates/tools/workspace-tools/src/tools.rs
+++ b/crates/tools/workspace-tools/src/tools.rs
@@ -1,0 +1,1069 @@
+use agentic_config::types::WorkspaceToolsConfig;
+use agentic_tools_core::BoxFuture;
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use agentic_tools_core::ToolRegistry;
+use atomicwrites::AtomicFile;
+use atomicwrites::OverwriteBehavior;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::patch::PatchChunk;
+use crate::patch::PatchOp;
+use crate::patch::apply_chunks;
+use crate::patch::parse_patch;
+use crate::paths::resolve_workspace_path;
+use crate::service::TodoItem;
+use crate::service::WorkspaceRuntime;
+
+const DEFAULT_READ_LIMIT: usize = 2000;
+const MAX_LINE_LENGTH: usize = 2000;
+const TRUNCATION_SUFFIX: &str = "... (line truncated to 2000 chars)";
+const BINARY_SAMPLE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct WorkspaceReadInput {
+    #[schemars(description = "Use workspace-relative paths such as `src/main.rs`.")]
+    #[serde(rename = "filePath")]
+    pub file_path: String,
+    #[serde(default)]
+    pub offset: Option<usize>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct WorkspaceTodoWriteInput {
+    pub todos: Vec<TodoItem>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct WorkspaceEditInput {
+    #[schemars(description = "Use workspace-relative paths such as `src/main.rs`.")]
+    #[serde(rename = "filePath")]
+    pub file_path: String,
+    #[serde(rename = "oldString")]
+    pub old_string: String,
+    #[serde(rename = "newString")]
+    pub new_string: String,
+    #[serde(default, rename = "replaceAll")]
+    pub replace_all: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct WorkspaceApplyPatchInput {
+    #[serde(rename = "patchText")]
+    pub patch_text: String,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceReadTool {
+    pub runtime: Arc<WorkspaceRuntime>,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceTodoWriteTool {
+    pub runtime: Arc<WorkspaceRuntime>,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceEditTool {
+    pub runtime: Arc<WorkspaceRuntime>,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceApplyPatchTool {
+    pub runtime: Arc<WorkspaceRuntime>,
+}
+
+impl Tool for WorkspaceReadTool {
+    type Input = WorkspaceReadInput;
+    type Output = String;
+    const NAME: &'static str = "workspace_read";
+    const DESCRIPTION: &'static str = "Read files or directories inside the current workspace. Prefer workspace-relative paths such as `src/main.rs`.";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let runtime = Arc::clone(&self.runtime);
+        Box::pin(async move { workspace_read(runtime.as_ref(), &input) })
+    }
+}
+
+impl Tool for WorkspaceTodoWriteTool {
+    type Input = WorkspaceTodoWriteInput;
+    type Output = String;
+    const NAME: &'static str = "workspace_todowrite";
+    const DESCRIPTION: &'static str = "Replace the in-memory todo list for this MCP process. State resets when the server restarts.";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let runtime = Arc::clone(&self.runtime);
+        Box::pin(async move { workspace_todowrite(runtime.as_ref(), input) })
+    }
+}
+
+impl Tool for WorkspaceEditTool {
+    type Input = WorkspaceEditInput;
+    type Output = String;
+    const NAME: &'static str = "workspace_edit";
+    const DESCRIPTION: &'static str = "Edit a file inside the current workspace using exact string replacement. Prefer workspace-relative paths.";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let runtime = Arc::clone(&self.runtime);
+        Box::pin(async move { workspace_edit(runtime.as_ref(), input).await })
+    }
+}
+
+impl Tool for WorkspaceApplyPatchTool {
+    type Input = WorkspaceApplyPatchInput;
+    type Output = String;
+    const NAME: &'static str = "workspace_apply_patch";
+    const DESCRIPTION: &'static str = "Apply an OpenCode-style patch inside the current workspace. Prefer workspace-relative paths.";
+
+    fn call(
+        &self,
+        input: Self::Input,
+        _ctx: &ToolContext,
+    ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
+        let runtime = Arc::clone(&self.runtime);
+        Box::pin(async move { workspace_apply_patch(runtime.as_ref(), &input) })
+    }
+}
+
+pub fn build_registry(config: &WorkspaceToolsConfig) -> ToolRegistry {
+    let runtime = Arc::new(WorkspaceRuntime::discover());
+    let mut builder = ToolRegistry::builder();
+
+    if config.workspace_read {
+        builder = builder.register::<WorkspaceReadTool, ()>(WorkspaceReadTool {
+            runtime: Arc::clone(&runtime),
+        });
+    }
+    if config.workspace_todowrite {
+        builder = builder.register::<WorkspaceTodoWriteTool, ()>(WorkspaceTodoWriteTool {
+            runtime: Arc::clone(&runtime),
+        });
+    }
+    if config.workspace_edit {
+        builder = builder.register::<WorkspaceEditTool, ()>(WorkspaceEditTool {
+            runtime: Arc::clone(&runtime),
+        });
+    }
+    if config.workspace_apply_patch {
+        builder =
+            builder.register::<WorkspaceApplyPatchTool, ()>(WorkspaceApplyPatchTool { runtime });
+    }
+
+    builder.finish()
+}
+
+fn workspace_read(
+    runtime: &WorkspaceRuntime,
+    input: &WorkspaceReadInput,
+) -> Result<String, ToolError> {
+    let tools = runtime.tools()?;
+    let resolved = resolve_workspace_path(tools.root(), &input.file_path)?;
+    let metadata = fs::metadata(&resolved.absolute_path).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => ToolError::NotFound(format!(
+            "Path `{}` was not found. Use workspace-relative paths such as `src/main.rs`.",
+            resolved.display_path
+        )),
+        _ => ToolError::Internal(format!(
+            "Failed to inspect {}: {error}",
+            resolved.display_path
+        )),
+    })?;
+
+    if metadata.is_dir() {
+        return render_directory(
+            &resolved.absolute_path,
+            &resolved.display_path,
+            input.offset,
+            input.limit,
+        );
+    }
+
+    render_file(
+        &resolved.absolute_path,
+        &resolved.display_path,
+        input.offset,
+        input.limit,
+    )
+}
+
+fn workspace_todowrite(
+    runtime: &WorkspaceRuntime,
+    input: WorkspaceTodoWriteInput,
+) -> Result<String, ToolError> {
+    let tools = runtime.tools()?;
+    let todos = tools.replace_todos(input.todos)?;
+    serde_json::to_string_pretty(&todos).map_err(|error| ToolError::Internal(error.to_string()))
+}
+
+async fn workspace_edit(
+    runtime: &WorkspaceRuntime,
+    input: WorkspaceEditInput,
+) -> Result<String, ToolError> {
+    if input.old_string == input.new_string {
+        return Err(ToolError::InvalidInput(
+            "oldString and newString must be different.".into(),
+        ));
+    }
+
+    let tools = runtime.tools()?;
+    let resolved = resolve_workspace_path(tools.root(), &input.file_path)?;
+    let file_lock = tools.file_lock(&resolved.absolute_path)?;
+    let _guard = file_lock.lock().await;
+
+    if input.old_string.is_empty() {
+        let existing = read_text_file_if_exists(&resolved.absolute_path, &resolved.display_path)?;
+        let (new_bom, new_text) = split_bom(&input.new_string);
+        let desired_bom = existing
+            .as_ref()
+            .map_or(new_bom, |file| file.bom || new_bom);
+        write_text_file(&resolved.absolute_path, &new_text, desired_bom)?;
+        let verb = if existing.is_some() {
+            "Updated"
+        } else {
+            "Created"
+        };
+        return Ok(format!("{verb} {}", resolved.display_path));
+    }
+
+    let source = read_text_file(&resolved.absolute_path, &resolved.display_path)?;
+    let old = normalize_to_line_ending(&input.old_string, source.line_ending);
+    let (new_bom, new_text_raw) = split_bom(&input.new_string);
+    let replacement = normalize_to_line_ending(&new_text_raw, source.line_ending);
+    let matches = source.text.matches(&old).count();
+
+    if matches == 0 {
+        return Err(ToolError::InvalidInput(format!(
+            "oldString did not match any text in {}.",
+            resolved.display_path
+        )));
+    }
+
+    let replace_all = input.replace_all.unwrap_or(false);
+    if matches > 1 && !replace_all {
+        return Err(ToolError::InvalidInput(format!(
+            "oldString matched {} times in {}. Set replaceAll=true or provide a more specific match.",
+            matches, resolved.display_path
+        )));
+    }
+
+    let updated = if replace_all {
+        source.text.replace(&old, &replacement)
+    } else {
+        source.text.replacen(&old, &replacement, 1)
+    };
+    write_text_file(&resolved.absolute_path, &updated, source.bom || new_bom)?;
+
+    Ok(format!("Updated {}", resolved.display_path))
+}
+
+fn workspace_apply_patch(
+    runtime: &WorkspaceRuntime,
+    input: &WorkspaceApplyPatchInput,
+) -> Result<String, ToolError> {
+    let operations = parse_patch(&input.patch_text).map_err(|error| {
+        ToolError::InvalidInput(format!("apply_patch verification failed: {error}"))
+    })?;
+
+    if operations.is_empty() {
+        return Err(ToolError::InvalidInput(String::from(
+            "apply_patch verification failed: patch was empty",
+        )));
+    }
+
+    let tools = runtime.tools()?;
+    let mut planned = Vec::new();
+    let mut touched = HashSet::new();
+
+    for operation in operations {
+        match operation {
+            PatchOp::Add { path, contents } => {
+                let resolved = resolve_workspace_path(tools.root(), &path)?;
+                if resolved.absolute_path.exists() {
+                    return Err(ToolError::InvalidInput(format!(
+                        "apply_patch verification failed: {} already exists",
+                        resolved.display_path
+                    )));
+                }
+                ensure_unique_touch(&mut touched, &resolved.display_path)?;
+
+                let (bom, text) = split_bom(&contents);
+                planned.push(PlannedChange::Add {
+                    path: resolved.absolute_path,
+                    display_path: resolved.display_path,
+                    contents: text,
+                    bom,
+                });
+            }
+            PatchOp::Delete { path } => {
+                let resolved = resolve_workspace_path(tools.root(), &path)?;
+                read_text_file(&resolved.absolute_path, &resolved.display_path)?;
+                ensure_unique_touch(&mut touched, &resolved.display_path)?;
+
+                planned.push(PlannedChange::Delete {
+                    path: resolved.absolute_path,
+                    display_path: resolved.display_path,
+                });
+            }
+            PatchOp::Update {
+                path,
+                move_to,
+                chunks,
+            } => {
+                let resolved = resolve_workspace_path(tools.root(), &path)?;
+                let source = read_text_file(&resolved.absolute_path, &resolved.display_path)?;
+                ensure_unique_touch(&mut touched, &resolved.display_path)?;
+
+                let normalized_chunks = normalize_patch_chunks(&chunks, source.line_ending);
+                let updated = if normalized_chunks.is_empty() {
+                    source.text.clone()
+                } else {
+                    apply_chunks(&source.text, &normalized_chunks).map_err(|error| {
+                        ToolError::InvalidInput(format!(
+                            "apply_patch verification failed for {}: {error}",
+                            resolved.display_path
+                        ))
+                    })?
+                };
+
+                if let Some(move_to) = move_to {
+                    let destination = resolve_workspace_path(tools.root(), &move_to)?;
+                    if destination.absolute_path != resolved.absolute_path
+                        && destination.absolute_path.exists()
+                    {
+                        return Err(ToolError::InvalidInput(format!(
+                            "apply_patch verification failed: destination {} already exists",
+                            destination.display_path
+                        )));
+                    }
+                    ensure_unique_touch(&mut touched, &destination.display_path)?;
+
+                    planned.push(PlannedChange::Move {
+                        source_path: resolved.absolute_path,
+                        destination_path: destination.absolute_path,
+                        destination_display_path: destination.display_path,
+                        contents: updated,
+                        bom: source.bom,
+                    });
+                } else {
+                    planned.push(PlannedChange::Update {
+                        path: resolved.absolute_path,
+                        display_path: resolved.display_path,
+                        contents: updated,
+                        bom: source.bom,
+                    });
+                }
+            }
+        }
+    }
+
+    let mut summary = Vec::new();
+    for change in &planned {
+        match change {
+            PlannedChange::Add {
+                path,
+                display_path,
+                contents,
+                bom,
+            } => {
+                write_text_file(path, contents, *bom)?;
+                summary.push(format!("A {display_path}"));
+            }
+            PlannedChange::Update {
+                path,
+                display_path,
+                contents,
+                bom,
+            } => {
+                write_text_file(path, contents, *bom)?;
+                summary.push(format!("M {display_path}"));
+            }
+            PlannedChange::Move {
+                source_path,
+                destination_path,
+                destination_display_path,
+                contents,
+                bom,
+                ..
+            } => {
+                write_text_file(destination_path, contents, *bom)?;
+                fs::remove_file(source_path).map_err(|error| {
+                    ToolError::Internal(format!(
+                        "Failed to remove {}: {error}",
+                        source_path.display()
+                    ))
+                })?;
+                summary.push(format!("M {destination_display_path}"));
+            }
+            PlannedChange::Delete {
+                path, display_path, ..
+            } => {
+                fs::remove_file(path).map_err(|error| {
+                    ToolError::Internal(format!("Failed to remove {}: {error}", path.display()))
+                })?;
+                summary.push(format!("D {display_path}"));
+            }
+        }
+    }
+
+    Ok(format!(
+        "Success. Updated the following files:\n{}",
+        summary.join("\n")
+    ))
+}
+
+fn render_directory(
+    path: &Path,
+    display_path: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<String, ToolError> {
+    let mut entries = fs::read_dir(path)
+        .map_err(|error| ToolError::Internal(format!("Failed to read {display_path}: {error}")))?
+        .map(|entry| entry.map_err(|error| ToolError::Internal(error.to_string())))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    entries.sort_by_key(|entry| entry.file_name().to_string_lossy().to_lowercase());
+
+    let mut names = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let entry_type = entry
+            .file_type()
+            .map_err(|error| ToolError::Internal(error.to_string()))?;
+        let is_dir = if entry_type.is_symlink() {
+            fs::metadata(entry.path())
+                .map(|meta| meta.is_dir())
+                .unwrap_or(false)
+        } else {
+            entry_type.is_dir()
+        };
+        names.push(if is_dir { format!("{name}/") } else { name });
+    }
+
+    let offset = offset.unwrap_or(1).max(1);
+    let limit = limit.unwrap_or(DEFAULT_READ_LIMIT);
+    let start = offset.saturating_sub(1);
+    let sliced = names
+        .iter()
+        .skip(start)
+        .take(limit)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(format!(
+        "<path>{display_path}</path>\n<type>directory</type>\n<entries>\n{}\n</entries>",
+        sliced.join("\n")
+    ))
+}
+
+fn render_file(
+    path: &Path,
+    display_path: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<String, ToolError> {
+    let bytes = fs::read(path)
+        .map_err(|error| ToolError::Internal(format!("Failed to read {display_path}: {error}")))?;
+
+    if is_binary(&bytes) {
+        return Err(ToolError::InvalidInput(format!(
+            "`{display_path}` appears to be a binary file. Use workspace-relative paths such as `src/main.rs` for text files."
+        )));
+    }
+
+    let text = String::from_utf8(bytes).map_err(|_| {
+        ToolError::InvalidInput(format!("`{display_path}` is not valid UTF-8 text."))
+    })?;
+    let offset = offset.unwrap_or(1).max(1);
+    let limit = limit.unwrap_or(DEFAULT_READ_LIMIT);
+    let start = offset.saturating_sub(1);
+
+    let numbered_lines = text
+        .lines()
+        .enumerate()
+        .skip(start)
+        .take(limit)
+        .map(|(index, line)| format!("{}: {}", index + 1, truncate_line(line)))
+        .collect::<Vec<_>>();
+
+    Ok(format!(
+        "<path>{display_path}</path>\n<type>file</type>\n<content>\n{}\n</content>",
+        numbered_lines.join("\n")
+    ))
+}
+
+fn truncate_line(line: &str) -> String {
+    let count = line.chars().count();
+    if count <= MAX_LINE_LENGTH {
+        return line.to_string();
+    }
+
+    let truncated = line.chars().take(MAX_LINE_LENGTH).collect::<String>();
+    format!("{truncated}{TRUNCATION_SUFFIX}")
+}
+
+fn is_binary(bytes: &[u8]) -> bool {
+    let sample = &bytes[..bytes.len().min(BINARY_SAMPLE_BYTES)];
+    if sample.contains(&0) {
+        return true;
+    }
+
+    let non_printable = sample
+        .iter()
+        .filter(|byte| **byte < 9 || (**byte > 13 && **byte < 32))
+        .count();
+
+    !sample.is_empty() && non_printable * 10 > sample.len() * 3
+}
+
+#[derive(Debug, Clone)]
+struct TextFile {
+    text: String,
+    bom: bool,
+    line_ending: &'static str,
+}
+
+fn read_text_file(path: &Path, display_path: &str) -> Result<TextFile, ToolError> {
+    let bytes = fs::read(path).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => ToolError::NotFound(format!(
+            "File `{display_path}` was not found. Use workspace-relative paths such as `src/main.rs`."
+        )),
+        _ => ToolError::Internal(format!("Failed to read {display_path}: {error}")),
+    })?;
+
+    decode_text_file(&bytes, display_path)
+}
+
+fn read_text_file_if_exists(
+    path: &Path,
+    display_path: &str,
+) -> Result<Option<TextFile>, ToolError> {
+    match fs::read(path) {
+        Ok(bytes) => decode_text_file(&bytes, display_path).map(Some),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ToolError::Internal(format!(
+            "Failed to read {display_path}: {error}"
+        ))),
+    }
+}
+
+fn decode_text_file(bytes: &[u8], display_path: &str) -> Result<TextFile, ToolError> {
+    if is_binary(bytes) {
+        return Err(ToolError::InvalidInput(format!(
+            "`{display_path}` appears to be a binary file."
+        )));
+    }
+
+    let bom = bytes.starts_with(&[0xEF, 0xBB, 0xBF]);
+    let text_bytes = if bom { &bytes[3..] } else { bytes };
+    let text = String::from_utf8(text_bytes.to_vec()).map_err(|_| {
+        ToolError::InvalidInput(format!("`{display_path}` is not valid UTF-8 text."))
+    })?;
+
+    Ok(TextFile {
+        line_ending: detect_line_ending(&text),
+        text,
+        bom,
+    })
+}
+
+fn detect_line_ending(text: &str) -> &'static str {
+    if text.contains("\r\n") { "\r\n" } else { "\n" }
+}
+
+fn normalize_to_line_ending(text: &str, line_ending: &str) -> String {
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    if line_ending == "\r\n" {
+        normalized.replace('\n', "\r\n")
+    } else {
+        normalized
+    }
+}
+
+fn split_bom(text: &str) -> (bool, String) {
+    if let Some(stripped) = text.strip_prefix('\u{feff}') {
+        (true, stripped.to_string())
+    } else {
+        (false, text.to_string())
+    }
+}
+
+fn write_text_file(path: &Path, text: &str, bom: bool) -> Result<(), ToolError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            ToolError::Internal(format!("Failed to create {}: {error}", parent.display()))
+        })?;
+    }
+
+    let mut contents = Vec::new();
+    if bom {
+        contents.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
+    }
+    contents.extend_from_slice(text.as_bytes());
+
+    AtomicFile::new(path, OverwriteBehavior::AllowOverwrite)
+        .write(|file| file.write_all(&contents))
+        .map_err(|error| {
+            ToolError::Internal(format!("Failed to write {}: {error}", path.display()))
+        })
+}
+
+fn normalize_patch_chunks(chunks: &[PatchChunk], line_ending: &str) -> Vec<PatchChunk> {
+    chunks
+        .iter()
+        .map(|chunk| PatchChunk {
+            context: chunk
+                .context
+                .as_ref()
+                .map(|value| normalize_to_line_ending(value, line_ending)),
+            old_lines: chunk
+                .old_lines
+                .iter()
+                .map(|value| normalize_to_line_ending(value, line_ending))
+                .collect(),
+            new_lines: chunk
+                .new_lines
+                .iter()
+                .map(|value| normalize_to_line_ending(value, line_ending))
+                .collect(),
+            end_of_file: chunk.end_of_file,
+        })
+        .collect()
+}
+
+fn ensure_unique_touch(touched: &mut HashSet<String>, display_path: &str) -> Result<(), ToolError> {
+    if touched.insert(display_path.to_string()) {
+        Ok(())
+    } else {
+        Err(ToolError::InvalidInput(format!(
+            "apply_patch verification failed: duplicate operation for {display_path}"
+        )))
+    }
+}
+
+enum PlannedChange {
+    Add {
+        path: std::path::PathBuf,
+        display_path: String,
+        contents: String,
+        bom: bool,
+    },
+    Update {
+        path: std::path::PathBuf,
+        display_path: String,
+        contents: String,
+        bom: bool,
+    },
+    Move {
+        source_path: std::path::PathBuf,
+        destination_path: std::path::PathBuf,
+        destination_display_path: String,
+        contents: String,
+        bom: bool,
+    },
+    Delete {
+        path: std::path::PathBuf,
+        display_path: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(prefix: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            path.push(format!("{prefix}{}-{nanos}", std::process::id()));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn runtime_for(dir: &TestDir) -> WorkspaceRuntime {
+        WorkspaceRuntime::from_root(&dir.path).unwrap()
+    }
+
+    #[test]
+    fn workspace_read_pages_and_numbers_lines() {
+        let dir = TestDir::new("workspace-read-");
+        std::fs::write(dir.path.join("notes.txt"), "a\nb\nc\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let output = workspace_read(
+            &runtime,
+            &WorkspaceReadInput {
+                file_path: String::from("notes.txt"),
+                offset: Some(2),
+                limit: Some(1),
+            },
+        )
+        .unwrap();
+
+        assert!(output.contains("<path>notes.txt</path>"));
+        assert!(output.contains("2: b"));
+        assert!(!output.contains("1: a"));
+    }
+
+    #[test]
+    fn workspace_read_lists_directories() {
+        let dir = TestDir::new("workspace-read-");
+        std::fs::create_dir_all(dir.path.join("src")).unwrap();
+        std::fs::write(dir.path.join("Cargo.toml"), "[package]\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let output = workspace_read(
+            &runtime,
+            &WorkspaceReadInput {
+                file_path: String::from("."),
+                offset: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+        assert!(output.contains("<type>directory</type>"));
+        assert!(output.contains("Cargo.toml"));
+        assert!(output.contains("src/"));
+    }
+
+    #[test]
+    fn workspace_read_truncates_long_lines() {
+        let dir = TestDir::new("workspace-read-");
+        let long_line = "x".repeat(2100);
+        std::fs::write(dir.path.join("long.txt"), format!("{long_line}\n")).unwrap();
+        let runtime = runtime_for(&dir);
+
+        let output = workspace_read(
+            &runtime,
+            &WorkspaceReadInput {
+                file_path: String::from("long.txt"),
+                offset: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+        assert!(output.contains(TRUNCATION_SUFFIX));
+    }
+
+    #[test]
+    fn workspace_read_rejects_binary_files() {
+        let dir = TestDir::new("workspace-read-");
+        std::fs::write(dir.path.join("data.bin"), [0_u8, 159, 146, 150]).unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_read(
+            &runtime,
+            &WorkspaceReadInput {
+                file_path: String::from("data.bin"),
+                offset: None,
+                limit: None,
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("binary file"));
+    }
+
+    #[test]
+    fn workspace_todowrite_replaces_entire_list() {
+        let dir = TestDir::new("workspace-todo-");
+        let runtime = runtime_for(&dir);
+
+        let first = workspace_todowrite(
+            &runtime,
+            WorkspaceTodoWriteInput {
+                todos: vec![TodoItem {
+                    content: String::from("one"),
+                    status: String::from("pending"),
+                    priority: String::from("high"),
+                }],
+            },
+        )
+        .unwrap();
+        assert!(first.contains("one"));
+
+        let second = workspace_todowrite(
+            &runtime,
+            WorkspaceTodoWriteInput {
+                todos: vec![TodoItem {
+                    content: String::from("two"),
+                    status: String::from("completed"),
+                    priority: String::from("low"),
+                }],
+            },
+        )
+        .unwrap();
+        assert!(second.contains("two"));
+        assert!(!second.contains("one"));
+
+        let stored = runtime.tools().unwrap().read_todos().unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].content, "two");
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_replaces_single_match() {
+        let dir = TestDir::new("workspace-edit-");
+        std::fs::write(dir.path.join("file.txt"), "hello world\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let result = workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("file.txt"),
+                old_string: String::from("world"),
+                new_string: String::from("mars"),
+                replace_all: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("Updated file.txt"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("file.txt")).unwrap(),
+            "hello mars\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_fails_when_no_match_exists() {
+        let dir = TestDir::new("workspace-edit-");
+        std::fs::write(dir.path.join("file.txt"), "hello\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("file.txt"),
+                old_string: String::from("missing"),
+                new_string: String::from("mars"),
+                replace_all: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("did not match any text"));
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_fails_on_ambiguous_match_without_replace_all() {
+        let dir = TestDir::new("workspace-edit-");
+        std::fs::write(dir.path.join("file.txt"), "dup dup\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("file.txt"),
+                old_string: String::from("dup"),
+                new_string: String::from("ok"),
+                replace_all: Some(false),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("matched 2 times"));
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_replace_all_updates_every_match() {
+        let dir = TestDir::new("workspace-edit-");
+        std::fs::write(dir.path.join("file.txt"), "dup dup\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("file.txt"),
+                old_string: String::from("dup"),
+                new_string: String::from("ok"),
+                replace_all: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("file.txt")).unwrap(),
+            "ok ok\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_create_file_mode_writes_new_file() {
+        let dir = TestDir::new("workspace-edit-");
+        let runtime = runtime_for(&dir);
+
+        let result = workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("src/new.txt"),
+                old_string: String::new(),
+                new_string: String::from("created\n"),
+                replace_all: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("Created src/new.txt"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("src/new.txt")).unwrap(),
+            "created\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_preserves_existing_line_endings() {
+        let dir = TestDir::new("workspace-edit-");
+        std::fs::write(dir.path.join("file.txt"), b"hello\r\nworld\r\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("file.txt"),
+                old_string: String::from("hello\nworld\n"),
+                new_string: String::from("hi\nplanet\n"),
+                replace_all: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(dir.path.join("file.txt")).unwrap(),
+            b"hi\r\nplanet\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_apply_patch_supports_add_update_delete_and_move() {
+        let dir = TestDir::new("workspace-patch-");
+        std::fs::write(dir.path.join("update.txt"), "old\n").unwrap();
+        std::fs::write(dir.path.join("delete.txt"), "gone\n").unwrap();
+        std::fs::write(dir.path.join("move.txt"), "move-me\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let patch_text = r"*** Begin Patch
+*** Add File: add.txt
++new
+*** Update File: update.txt
+@@
+-old
++updated
+*** Delete File: delete.txt
+*** Update File: move.txt
+*** Move to: moved.txt
+@@
+-move-me
++moved
+*** End Patch";
+
+        let result = workspace_apply_patch(
+            &runtime,
+            &WorkspaceApplyPatchInput {
+                patch_text: patch_text.to_string(),
+            },
+        )
+        .unwrap();
+
+        assert!(result.contains("A add.txt"));
+        assert!(result.contains("M update.txt"));
+        assert!(result.contains("D delete.txt"));
+        assert!(result.contains("M moved.txt"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("add.txt")).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("update.txt")).unwrap(),
+            "updated\n"
+        );
+        assert!(!dir.path.join("delete.txt").exists());
+        assert!(!dir.path.join("move.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("moved.txt")).unwrap(),
+            "moved\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_apply_patch_verification_failure_leaves_files_unchanged() {
+        let dir = TestDir::new("workspace-patch-");
+        let file_path = dir.path.join("update.txt");
+        std::fs::write(&file_path, "original\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_apply_patch(
+            &runtime,
+            &WorkspaceApplyPatchInput {
+                patch_text: String::from(
+                    "*** Begin Patch\n*** Update File: update.txt\n@@\n-missing\n+updated\n*** End Patch",
+                ),
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("verification failed"));
+        assert_eq!(std::fs::read_to_string(file_path).unwrap(), "original\n");
+    }
+
+    #[test]
+    fn build_registry_registers_only_enabled_workspace_tools() {
+        let registry = build_registry(&WorkspaceToolsConfig {
+            workspace_read: true,
+            workspace_edit: true,
+            ..Default::default()
+        });
+
+        assert!(registry.contains("workspace_read"));
+        assert!(registry.contains("workspace_edit"));
+        assert!(!registry.contains("workspace_todowrite"));
+        assert!(!registry.contains("workspace_apply_patch"));
+    }
+}

--- a/crates/tools/workspace-tools/src/tools.rs
+++ b/crates/tools/workspace-tools/src/tools.rs
@@ -10,7 +10,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs;
+use std::io::BufRead;
+use std::io::BufReader;
 use std::io::ErrorKind;
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
@@ -143,7 +146,7 @@ impl Tool for WorkspaceApplyPatchTool {
         _ctx: &ToolContext,
     ) -> BoxFuture<'static, Result<Self::Output, ToolError>> {
         let runtime = Arc::clone(&self.runtime);
-        Box::pin(async move { workspace_apply_patch(runtime.as_ref(), &input) })
+        Box::pin(async move { workspace_apply_patch(runtime.as_ref(), &input).await })
     }
 }
 
@@ -233,18 +236,16 @@ async fn workspace_edit(
     let _guard = file_lock.lock().await;
 
     if input.old_string.is_empty() {
-        let existing = read_text_file_if_exists(&resolved.absolute_path, &resolved.display_path)?;
+        if resolved.absolute_path.exists() {
+            return Err(ToolError::InvalidInput(format!(
+                "File `{}` already exists; create mode (oldString=\"\") cannot overwrite. Provide oldString to update it.",
+                resolved.display_path
+            )));
+        }
+
         let (new_bom, new_text) = split_bom(&input.new_string);
-        let desired_bom = existing
-            .as_ref()
-            .map_or(new_bom, |file| file.bom || new_bom);
-        write_text_file(&resolved.absolute_path, &new_text, desired_bom)?;
-        let verb = if existing.is_some() {
-            "Updated"
-        } else {
-            "Created"
-        };
-        return Ok(format!("{verb} {}", resolved.display_path));
+        write_text_file(&resolved.absolute_path, &new_text, new_bom)?;
+        return Ok(format!("Created {}", resolved.display_path));
     }
 
     let source = read_text_file(&resolved.absolute_path, &resolved.display_path)?;
@@ -278,7 +279,7 @@ async fn workspace_edit(
     Ok(format!("Updated {}", resolved.display_path))
 }
 
-fn workspace_apply_patch(
+async fn workspace_apply_patch(
     runtime: &WorkspaceRuntime,
     input: &WorkspaceApplyPatchInput,
 ) -> Result<String, ToolError> {
@@ -293,6 +294,35 @@ fn workspace_apply_patch(
     }
 
     let tools = runtime.tools()?;
+    let mut lock_paths = HashSet::new();
+    for operation in &operations {
+        match operation {
+            PatchOp::Add { path, .. } | PatchOp::Delete { path } => {
+                let resolved = resolve_workspace_path(tools.root(), path)?;
+                lock_paths.insert(resolved.absolute_path);
+            }
+            PatchOp::Update { path, move_to, .. } => {
+                let resolved = resolve_workspace_path(tools.root(), path)?;
+                lock_paths.insert(resolved.absolute_path);
+
+                if let Some(move_to) = move_to {
+                    let destination = resolve_workspace_path(tools.root(), move_to)?;
+                    lock_paths.insert(destination.absolute_path);
+                }
+            }
+        }
+    }
+
+    let mut lock_paths = lock_paths.into_iter().collect::<Vec<_>>();
+    lock_paths.sort_by(|a, b| a.as_os_str().cmp(b.as_os_str()));
+
+    let mut guards = Vec::with_capacity(lock_paths.len());
+    for path in &lock_paths {
+        let lock = tools.file_lock(path)?;
+        guards.push(lock.lock_owned().await);
+    }
+    let _ = guards.len();
+
     let mut planned = Vec::new();
     let mut touched = HashSet::new();
 
@@ -484,29 +514,52 @@ fn render_file(
     offset: Option<usize>,
     limit: Option<usize>,
 ) -> Result<String, ToolError> {
-    let bytes = fs::read(path)
+    let mut file = std::fs::File::open(path)
         .map_err(|error| ToolError::Internal(format!("Failed to read {display_path}: {error}")))?;
 
-    if is_binary(&bytes) {
+    let mut sample = vec![0_u8; BINARY_SAMPLE_BYTES];
+    let read = file
+        .read(&mut sample)
+        .map_err(|error| ToolError::Internal(format!("Failed to read {display_path}: {error}")))?;
+    sample.truncate(read);
+
+    if is_binary(&sample) {
         return Err(ToolError::InvalidInput(format!(
             "`{display_path}` appears to be a binary file. Use workspace-relative paths such as `src/main.rs` for text files."
         )));
     }
 
-    let text = String::from_utf8(bytes).map_err(|_| {
-        ToolError::InvalidInput(format!("`{display_path}` is not valid UTF-8 text."))
-    })?;
+    let cursor = std::io::Cursor::new(sample);
+    let mut reader = BufReader::new(cursor.chain(file));
     let offset = offset.unwrap_or(1).max(1);
     let limit = limit.unwrap_or(DEFAULT_READ_LIMIT);
     let start = offset.saturating_sub(1);
+    let end = start.saturating_add(limit);
+    let mut numbered_lines = Vec::new();
+    let mut buf = String::new();
+    let mut line_no = 0_usize;
 
-    let numbered_lines = text
-        .lines()
-        .enumerate()
-        .skip(start)
-        .take(limit)
-        .map(|(index, line)| format!("{}: {}", index + 1, truncate_line(line)))
-        .collect::<Vec<_>>();
+    loop {
+        buf.clear();
+        let read = reader.read_line(&mut buf).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::InvalidData {
+                ToolError::InvalidInput(format!("`{display_path}` is not valid UTF-8 text."))
+            } else {
+                ToolError::Internal(format!("Failed to read {display_path}: {error}"))
+            }
+        })?;
+        if read == 0 {
+            break;
+        }
+
+        line_no += 1;
+        let line = buf.strip_suffix('\n').unwrap_or(&buf);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        if (start..end).contains(&(line_no - 1)) {
+            numbered_lines.push(format!("{}: {}", line_no, truncate_line(line)));
+        }
+    }
 
     Ok(format!(
         "<path>{display_path}</path>\n<type>file</type>\n<content>\n{}\n</content>",
@@ -554,19 +607,6 @@ fn read_text_file(path: &Path, display_path: &str) -> Result<TextFile, ToolError
     })?;
 
     decode_text_file(&bytes, display_path)
-}
-
-fn read_text_file_if_exists(
-    path: &Path,
-    display_path: &str,
-) -> Result<Option<TextFile>, ToolError> {
-    match fs::read(path) {
-        Ok(bytes) => decode_text_file(&bytes, display_path).map(Some),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(ToolError::Internal(format!(
-            "Failed to read {display_path}: {error}"
-        ))),
-    }
 }
 
 fn decode_text_file(bytes: &[u8], display_path: &str) -> Result<TextFile, ToolError> {
@@ -806,6 +846,25 @@ mod tests {
     }
 
     #[test]
+    fn workspace_read_rejects_invalid_utf8_even_outside_requested_page() {
+        let dir = TestDir::new("workspace-read-");
+        std::fs::write(dir.path.join("notes.txt"), b"ok\n\xFFtail").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_read(
+            &runtime,
+            &WorkspaceReadInput {
+                file_path: String::from("notes.txt"),
+                offset: Some(1),
+                limit: Some(1),
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("not valid UTF-8 text"));
+    }
+
+    #[test]
     fn workspace_todowrite_replaces_entire_list() {
         let dir = TestDir::new("workspace-todo-");
         let runtime = runtime_for(&dir);
@@ -958,6 +1017,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workspace_edit_create_mode_rejects_overwrite_existing_file() {
+        let dir = TestDir::new("workspace-edit-");
+        let file_path = dir.path.join("src/existing.txt");
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, "original\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        let error = workspace_edit(
+            &runtime,
+            WorkspaceEditInput {
+                file_path: String::from("src/existing.txt"),
+                old_string: String::new(),
+                new_string: String::from("replacement\n"),
+                replace_all: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cannot overwrite"));
+        assert_eq!(std::fs::read_to_string(file_path).unwrap(), "original\n");
+    }
+
+    #[tokio::test]
     async fn workspace_edit_preserves_existing_line_endings() {
         let dir = TestDir::new("workspace-edit-");
         std::fs::write(dir.path.join("file.txt"), b"hello\r\nworld\r\n").unwrap();
@@ -1010,6 +1093,7 @@ mod tests {
                 patch_text: patch_text.to_string(),
             },
         )
+        .await
         .unwrap();
 
         assert!(result.contains("A add.txt"));
@@ -1047,10 +1131,81 @@ mod tests {
                 ),
             },
         )
+        .await
         .unwrap_err();
 
         assert!(error.to_string().contains("verification failed"));
         assert_eq!(std::fs::read_to_string(file_path).unwrap(), "original\n");
+    }
+
+    #[tokio::test]
+    async fn workspace_apply_patch_acquires_sorted_locks_before_verification() {
+        let dir = TestDir::new("workspace-patch-");
+        std::fs::write(dir.path.join("a.txt"), "old-a\n").unwrap();
+        std::fs::write(dir.path.join("z.txt"), "old-z\n").unwrap();
+        let runtime = runtime_for(&dir);
+        let tools = runtime.tools().unwrap();
+
+        let first_lock = tools.file_lock(&dir.path.join("a.txt")).unwrap();
+        let second_lock = tools.file_lock(&dir.path.join("z.txt")).unwrap();
+        let first_guard = first_lock.lock_owned().await;
+
+        let patch_text = String::from(
+            "*** Begin Patch\n*** Update File: z.txt\n@@\n-old-z\n+new-z\n*** Update File: a.txt\n@@\n-old-a\n+new-a\n*** End Patch",
+        );
+        let runtime_clone = runtime.clone();
+        let input = WorkspaceApplyPatchInput { patch_text };
+        let task = tokio::spawn(async move { workspace_apply_patch(&runtime_clone, &input).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let second_guard = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            second_lock.lock_owned(),
+        )
+        .await
+        .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!task.is_finished());
+
+        drop(first_guard);
+        drop(second_guard);
+
+        let result = task.await.unwrap().unwrap();
+        assert!(result.contains("M z.txt"));
+        assert!(result.contains("M a.txt"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("a.txt")).unwrap(),
+            "new-a\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path.join("z.txt")).unwrap(),
+            "new-z\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_apply_patch_preserves_existing_line_endings() {
+        let dir = TestDir::new("workspace-patch-");
+        std::fs::write(dir.path.join("file.txt"), b"hello\r\nworld\r\n").unwrap();
+        let runtime = runtime_for(&dir);
+
+        workspace_apply_patch(
+            &runtime,
+            &WorkspaceApplyPatchInput {
+                patch_text: String::from(
+                    "*** Begin Patch\n*** Update File: file.txt\n@@\n-hello\n+hi\n*** End Patch",
+                ),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(dir.path.join("file.txt")).unwrap(),
+            b"hi\r\nworld\r\n"
+        );
     }
 
     #[test]

--- a/crates/tools/workspace-tools/src/tools.rs
+++ b/crates/tools/workspace-tools/src/tools.rs
@@ -1149,8 +1149,8 @@ mod tests {
         let runtime = runtime_for(&dir);
         let tools = runtime.tools().unwrap();
 
-        let first_lock = tools.file_lock(&dir.path.join("a.txt")).unwrap();
-        let second_lock = tools.file_lock(&dir.path.join("z.txt")).unwrap();
+        let first_lock = tools.file_lock(&tools.root().join("a.txt")).unwrap();
+        let second_lock = tools.file_lock(&tools.root().join("z.txt")).unwrap();
         let first_guard = first_lock.lock_owned().await;
 
         let patch_text = String::from(

--- a/crates/tools/workspace-tools/src/tools.rs
+++ b/crates/tools/workspace-tools/src/tools.rs
@@ -321,146 +321,149 @@ async fn workspace_apply_patch(
         let lock = tools.file_lock(path)?;
         guards.push(lock.lock_owned().await);
     }
-    let _ = guards.len();
+    let result = (|| {
+        let mut planned = Vec::new();
+        let mut touched = HashSet::new();
 
-    let mut planned = Vec::new();
-    let mut touched = HashSet::new();
-
-    for operation in operations {
-        match operation {
-            PatchOp::Add { path, contents } => {
-                let resolved = resolve_workspace_path(tools.root(), &path)?;
-                if resolved.absolute_path.exists() {
-                    return Err(ToolError::InvalidInput(format!(
-                        "apply_patch verification failed: {} already exists",
-                        resolved.display_path
-                    )));
-                }
-                ensure_unique_touch(&mut touched, &resolved.display_path)?;
-
-                let (bom, text) = split_bom(&contents);
-                planned.push(PlannedChange::Add {
-                    path: resolved.absolute_path,
-                    display_path: resolved.display_path,
-                    contents: text,
-                    bom,
-                });
-            }
-            PatchOp::Delete { path } => {
-                let resolved = resolve_workspace_path(tools.root(), &path)?;
-                read_text_file(&resolved.absolute_path, &resolved.display_path)?;
-                ensure_unique_touch(&mut touched, &resolved.display_path)?;
-
-                planned.push(PlannedChange::Delete {
-                    path: resolved.absolute_path,
-                    display_path: resolved.display_path,
-                });
-            }
-            PatchOp::Update {
-                path,
-                move_to,
-                chunks,
-            } => {
-                let resolved = resolve_workspace_path(tools.root(), &path)?;
-                let source = read_text_file(&resolved.absolute_path, &resolved.display_path)?;
-                ensure_unique_touch(&mut touched, &resolved.display_path)?;
-
-                let normalized_chunks = normalize_patch_chunks(&chunks, source.line_ending);
-                let updated = if normalized_chunks.is_empty() {
-                    source.text.clone()
-                } else {
-                    apply_chunks(&source.text, &normalized_chunks).map_err(|error| {
-                        ToolError::InvalidInput(format!(
-                            "apply_patch verification failed for {}: {error}",
-                            resolved.display_path
-                        ))
-                    })?
-                };
-
-                if let Some(move_to) = move_to {
-                    let destination = resolve_workspace_path(tools.root(), &move_to)?;
-                    if destination.absolute_path != resolved.absolute_path
-                        && destination.absolute_path.exists()
-                    {
+        for operation in operations {
+            match operation {
+                PatchOp::Add { path, contents } => {
+                    let resolved = resolve_workspace_path(tools.root(), &path)?;
+                    if resolved.absolute_path.exists() {
                         return Err(ToolError::InvalidInput(format!(
-                            "apply_patch verification failed: destination {} already exists",
-                            destination.display_path
+                            "apply_patch verification failed: {} already exists",
+                            resolved.display_path
                         )));
                     }
-                    ensure_unique_touch(&mut touched, &destination.display_path)?;
+                    ensure_unique_touch(&mut touched, &resolved.display_path)?;
 
-                    planned.push(PlannedChange::Move {
-                        source_path: resolved.absolute_path,
-                        destination_path: destination.absolute_path,
-                        destination_display_path: destination.display_path,
-                        contents: updated,
-                        bom: source.bom,
-                    });
-                } else {
-                    planned.push(PlannedChange::Update {
+                    let (bom, text) = split_bom(&contents);
+                    planned.push(PlannedChange::Add {
                         path: resolved.absolute_path,
                         display_path: resolved.display_path,
-                        contents: updated,
-                        bom: source.bom,
+                        contents: text,
+                        bom,
                     });
+                }
+                PatchOp::Delete { path } => {
+                    let resolved = resolve_workspace_path(tools.root(), &path)?;
+                    read_text_file(&resolved.absolute_path, &resolved.display_path)?;
+                    ensure_unique_touch(&mut touched, &resolved.display_path)?;
+
+                    planned.push(PlannedChange::Delete {
+                        path: resolved.absolute_path,
+                        display_path: resolved.display_path,
+                    });
+                }
+                PatchOp::Update {
+                    path,
+                    move_to,
+                    chunks,
+                } => {
+                    let resolved = resolve_workspace_path(tools.root(), &path)?;
+                    let source = read_text_file(&resolved.absolute_path, &resolved.display_path)?;
+                    ensure_unique_touch(&mut touched, &resolved.display_path)?;
+
+                    let normalized_chunks = normalize_patch_chunks(&chunks, source.line_ending);
+                    let updated = if normalized_chunks.is_empty() {
+                        source.text.clone()
+                    } else {
+                        apply_chunks(&source.text, &normalized_chunks).map_err(|error| {
+                            ToolError::InvalidInput(format!(
+                                "apply_patch verification failed for {}: {error}",
+                                resolved.display_path
+                            ))
+                        })?
+                    };
+
+                    if let Some(move_to) = move_to {
+                        let destination = resolve_workspace_path(tools.root(), &move_to)?;
+                        if destination.absolute_path != resolved.absolute_path
+                            && destination.absolute_path.exists()
+                        {
+                            return Err(ToolError::InvalidInput(format!(
+                                "apply_patch verification failed: destination {} already exists",
+                                destination.display_path
+                            )));
+                        }
+                        ensure_unique_touch(&mut touched, &destination.display_path)?;
+
+                        planned.push(PlannedChange::Move {
+                            source_path: resolved.absolute_path,
+                            destination_path: destination.absolute_path,
+                            destination_display_path: destination.display_path,
+                            contents: updated,
+                            bom: source.bom,
+                        });
+                    } else {
+                        planned.push(PlannedChange::Update {
+                            path: resolved.absolute_path,
+                            display_path: resolved.display_path,
+                            contents: updated,
+                            bom: source.bom,
+                        });
+                    }
                 }
             }
         }
-    }
 
-    let mut summary = Vec::new();
-    for change in &planned {
-        match change {
-            PlannedChange::Add {
-                path,
-                display_path,
-                contents,
-                bom,
-            } => {
-                write_text_file(path, contents, *bom)?;
-                summary.push(format!("A {display_path}"));
-            }
-            PlannedChange::Update {
-                path,
-                display_path,
-                contents,
-                bom,
-            } => {
-                write_text_file(path, contents, *bom)?;
-                summary.push(format!("M {display_path}"));
-            }
-            PlannedChange::Move {
-                source_path,
-                destination_path,
-                destination_display_path,
-                contents,
-                bom,
-                ..
-            } => {
-                write_text_file(destination_path, contents, *bom)?;
-                fs::remove_file(source_path).map_err(|error| {
-                    ToolError::Internal(format!(
-                        "Failed to remove {}: {error}",
-                        source_path.display()
-                    ))
-                })?;
-                summary.push(format!("M {destination_display_path}"));
-            }
-            PlannedChange::Delete {
-                path, display_path, ..
-            } => {
-                fs::remove_file(path).map_err(|error| {
-                    ToolError::Internal(format!("Failed to remove {}: {error}", path.display()))
-                })?;
-                summary.push(format!("D {display_path}"));
+        let mut summary = Vec::new();
+        for change in &planned {
+            match change {
+                PlannedChange::Add {
+                    path,
+                    display_path,
+                    contents,
+                    bom,
+                } => {
+                    write_text_file(path, contents, *bom)?;
+                    summary.push(format!("A {display_path}"));
+                }
+                PlannedChange::Update {
+                    path,
+                    display_path,
+                    contents,
+                    bom,
+                } => {
+                    write_text_file(path, contents, *bom)?;
+                    summary.push(format!("M {display_path}"));
+                }
+                PlannedChange::Move {
+                    source_path,
+                    destination_path,
+                    destination_display_path,
+                    contents,
+                    bom,
+                    ..
+                } => {
+                    write_text_file(destination_path, contents, *bom)?;
+                    fs::remove_file(source_path).map_err(|error| {
+                        ToolError::Internal(format!(
+                            "Failed to remove {}: {error}",
+                            source_path.display()
+                        ))
+                    })?;
+                    summary.push(format!("M {destination_display_path}"));
+                }
+                PlannedChange::Delete {
+                    path, display_path, ..
+                } => {
+                    fs::remove_file(path).map_err(|error| {
+                        ToolError::Internal(format!("Failed to remove {}: {error}", path.display()))
+                    })?;
+                    summary.push(format!("D {display_path}"));
+                }
             }
         }
-    }
 
-    Ok(format!(
-        "Success. Updated the following files:\n{}",
-        summary.join("\n")
-    ))
+        Ok(format!(
+            "Success. Updated the following files:\n{}",
+            summary.join("\n")
+        ))
+    })();
+
+    drop(guards);
+    result
 }
 
 fn render_directory(

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -213,6 +213,13 @@ git_tag_enable = false
 release = true
 
 [[package]]
+name = "workspace_tools"
+changelog_path = "crates/tools/workspace-tools/CHANGELOG.md"
+git_tag_name = "workspace_tools-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
 name = "message-optimizer-bin"
 changelog_path = "apps/message-optimizer/CHANGELOG.md"
 git_tag_name = "message-optimizer-bin-v{{ version }}"


### PR DESCRIPTION
## My Notes (preserved)

<!-- Add any scratch notes, todos, and observations here. This section is preserved when /describe_pr runs. -->

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

Agentic MCP exposed search, review, web, and thoughts tools, but it did not have any built-in local workspace mutation tools with explicit config gating and workspace-root confinement. That left a gap for safe, OpenCode-style local file workflows such as paged reads, in-process todo state, exact string edits, and structured patch application.

This PR adds that missing workspace-local tool domain while keeping the initial rollout conservative:
- all four new tools are disabled by default behind explicit `[workspace_tools]` booleans
- file access is restricted to the current workspace / repo root
- path UX strongly prefers workspace-relative paths such as `src/main.rs`
- `workspace_todowrite` is process-local and in-memory only for v1
- patch application verifies the full patch plan before writing any files

It also wires the new domain into the existing config, registry, schema, example config, release metadata, and generated repository documentation so the feature behaves like a first-class Agentic MCP capability.

## What user-facing changes did I ship?

- Added four new MCP tools under a dedicated workspace namespace:
  - `workspace_read`
  - `workspace_todowrite`
  - `workspace_edit`
  - `workspace_apply_patch`
- Added a new top-level config section in `agentic.toml`:
  - `workspace_read = false`
  - `workspace_todowrite = false`
  - `workspace_edit = false`
  - `workspace_apply_patch = false`
- Kept the new tools absent by default unless their specific toggles are enabled.
- Enforced a root-scoped local path policy for file tools:
  - workspace-relative paths are the preferred UX
  - absolute paths are only accepted if they still resolve inside the workspace root
  - traversal / symlink escapes outside the workspace root are rejected
- Implemented user-visible tool behavior aligned with the approved plan:
  - `workspace_read`: paged, line-numbered file reads and directory listings
  - `workspace_todowrite`: full-list in-memory todo replacement for the running MCP process
  - `workspace_edit`: exact-match replacement with ambiguity failures unless `replaceAll=true`
  - `workspace_apply_patch`: OpenCode-style `*** Begin Patch` envelope with Add / Update / Delete / optional Move to support

## How I implemented it

- Added `WorkspaceToolsConfig` to `AgenticConfig`, included it in validation/schema coverage, and updated config-init expectations and the human example config.
- Threaded `workspace_tools` from merged config loading in `agentic-mcp` into `AgenticToolsConfig` before registry construction.
- Extended `agentic-tools-registry` with:
  - a `workspace_tools` config field
  - `WORKSPACE_NAMES`
  - default-off registration logic that only includes the new domain when at least one workspace tool toggle is enabled
  - registry tests for toggle behavior and allowlist intersection
- Added a new tool crate at `crates/tools/workspace-tools/` containing:
  - shared runtime state with the canonical workspace root, in-memory todo storage, and per-file async locks
  - root-constrained path resolution and user-facing relative display paths
  - a patch parser / chunk applier for the OpenCode-style envelope
  - the four concrete tool wrappers and focused crate-local tests
- Regenerated and updated repository metadata / generated artifacts so the new crate and config surface appear in schema and repo docs.
- Performed an additional post-description manual verification pass using a temporary workspace at `/tmp/workspace_tools_manual`.
- Used the repository’s supported MCP harness via `@modelcontextprotocol/inspector` / `just mcp-inspector` for end-to-end tool calls.
- The PR consists of commit `5919dfb8`:
  - `feat(workspace_tools): add workspace-scoped mcp file and todo tools`

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] I ran `just xtask-sync-check` and it passed
- [x] Manual: `agentic-mcp --help` confirmed `--list-tools` support
- [x] Manual: a temporary `/tmp/workspace_tools_manual/agentic.toml` enabled all four `[workspace_tools]` toggles
- [x] Manual: running `agentic-mcp --list-tools` from the temporary workspace listed 34 tools including `workspace_apply_patch`, `workspace_edit`, `workspace_read`, and `workspace_todowrite`
- [x] Manual: existing supported harness confirmed via `@modelcontextprotocol/inspector` / `just mcp-inspector`
- [x] Manual: `workspace_read` succeeded end-to-end via inspector with a relative file path and returned paged, line-numbered output
- [x] Manual: `workspace_todowrite` succeeded end-to-end via inspector for a tool call in the temporary workspace
- [ ] Manual: `workspace_todowrite` persistence across repeated calls in a single long-lived MCP process was not manually verified because the inspector CLI is one-shot; automated coverage covers the in-process state behavior
- [x] Manual: `workspace_edit` succeeded end-to-end via inspector on a unique exact match and updated the temporary file atomically
- [x] Manual: `workspace_apply_patch` succeeded end-to-end via inspector and exercised Add File, Update File, Delete File, and Move to in a single patch
- [x] Manual: final `git status --short` remained clean after the verification pass

## Description for the changelog

Add a new default-off `workspace_tools` domain to Agentic MCP with root-scoped local file and todo tools: `workspace_read`, `workspace_todowrite`, `workspace_edit`, and `workspace_apply_patch`. The new tools are gated by explicit config toggles, prefer workspace-relative paths, reject out-of-root access, and include OpenCode-style patch application with verify-before-write semantics.
<!-- END:describe_pr:autogen -->

