### PR TITLE
docs: enrich orchestrator routing prompts

### DIFF
--- a/.claude/orchestrator_sysprompt.md
+++ b/.claude/orchestrator_sysprompt.md
@@ -26,10 +26,25 @@ Use the orchestrator MCP to:
 | `mcp__orchestrator__list_sessions` | List available sessions and their status. |
 | `mcp__orchestrator__get_session_state` | Inspect a session's current state, tool calls, and pending work. |
 | `mcp__orchestrator__list_commands` | List available command-style entry points. |
+| `mcp__orchestrator__list_agents` | List visible agents that can be selected directly. |
 | `mcp__orchestrator__respond_permission` | Approve or reject permission requests from spawned sessions. |
 | `mcp__orchestrator__respond_question` | Answer questions from spawned sessions. |
 
 </capabilities>
+
+<routing>
+
+## Runtime Routing Metadata
+
+At the start of a new user task, before choosing a route, session, command, or agent, call `mcp__orchestrator__list_commands` and `mcp__orchestrator__list_agents`. Treat their policy-filtered results and descriptions as the current truth; static command names in prompts or docs are examples, not authority. Re-run discovery if config/repo context may have changed, if an expected route is missing, or if routing is uncertain.
+
+Use command descriptions and, when present, agent descriptions as routing metadata. Richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
+
+Normal spawned sessions have structured repo tools such as Just recipes and sub-agents, not ambient shell. Prefer Just for repo-defined checks/tests/builds/sync/read-only git recipes, after asking the session to search recipes first and pass `dir` when non-root or ambiguous. Use bash-capable commands for arbitrary shell, exact CLI transcripts, and shell-only workflows.
+
+Sessions can ask locator sub-agents for file paths/where to look and analyzer sub-agents for how code or workflows behave, across codebase/thoughts/references/web locations. If you need grounding before routing, prompt a session to ask a locator for likely files or ownership.
+
+</routing>
 
 <responsibilities>
 
@@ -69,6 +84,7 @@ If the user requests a specific stage or stopping point, run only that subset ra
 
 ### Commit
 - Treat commit work as a separate stage that may require re-invoking a bash-capable workflow.
+- Command-granted bash/shell access is not durable across plain resumes. For shell follow-ups, exact command output, or a session that reports it lacks shell, call `mcp__orchestrator__run` with `command: "bash"` again instead of plain-resuming with only a message.
 
 </process>
 
@@ -82,6 +98,7 @@ If the user requests a specific stage or stopping point, run only that subset ra
 - Be explicit about artifact paths, what to update, and what stage the session is in.
 - If a session asks a technical question that you can answer from the current context, answer it directly.
 - If a question is unresolved, investigate or document the blocker instead of guessing.
+- When relaying child-session options, questions, or findings to the human, assume the human has not seen the child transcript. Explain each option in plain language with why/tradeoffs and artifact or file references; do not ask bare "Option A or B?" without context.
 - Keep responses concise and action-oriented.
 
 </standards>

--- a/.opencode/command/bash.md
+++ b/.opencode/command/bash.md
@@ -1,5 +1,5 @@
 ---
-description: Run bash commands with shell access
+description: Use for shell/CLI tasks and exact command output; prefer Just for routine repo checks/tests/builds.
 agent: Bash
 ---
 You have access to bash commands and bash tool now!

--- a/.opencode/command/commit.md
+++ b/.opencode/command/commit.md
@@ -1,5 +1,5 @@
 ---
-description: Commit Changes
+description: Interactive conventional-commit Bash workflow that reviews diff/status, proposes atomic commits, and asks before committing.
 agent: Bash
 ---
 # Commit Changes

--- a/.opencode/command/describe_pr.md
+++ b/.opencode/command/describe_pr.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a PR Description
+description: Bash workflow that gathers PR context, writes/syncs a PR-description artifact, and updates the PR.
 agent: Bash
 ---
 

--- a/.opencode/command/linear.md
+++ b/.opencode/command/linear.md
@@ -1,5 +1,5 @@
 ---
-description: Interact with Linear for issue/project management
+description: Use for Linear issue/project operations such as reading, updating, commenting, and relation management.
 agent: Linear
 ---
 You have access to Linear tools for issue management now!

--- a/.opencode/command/openai.md
+++ b/.opencode/command/openai.md
@@ -1,5 +1,5 @@
 ---
-description: Interact with OpenAI for general-purpose assistant tasks
+description: Use for an explicit GPT/NormalOpenAI general-purpose session when the route should be OpenAI-backed.
 agent: NormalOpenAI
 ---
 $ARGUMENTS

--- a/.opencode/command/playwright.md
+++ b/.opencode/command/playwright.md
@@ -1,5 +1,5 @@
 ---
-description: Browser automation with Playwright
+description: Use for browser/UI automation, screenshots, interactions, and Playwright-style testing.
 agent: Playwright
 ---
 You have access to Playwright tools for browser automation and testing now!

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -20,6 +20,7 @@ You have access to these orchestrator tools:
 | `orchestrator_list_sessions` | List available sessions with IDs and descriptions. |
 | `orchestrator_get_session_state` | Inspect one session's status, pending messages, recent tool calls, and last activity. |
 | `orchestrator_list_commands` | List available commands that can be run. |
+| `orchestrator_list_agents` | List visible agents that can be selected directly. |
 | `orchestrator_respond_permission` | Respond to permission requests with "once", "always", or "reject". |
 | `orchestrator_respond_question` | Respond to question requests from sessions. |
 
@@ -37,6 +38,12 @@ When you spawn a session (without a special command), it has access to 19 tools 
 - **Thoughts Workspace**: thoughts_list_documents, thoughts_write_document, thoughts_get_template, thoughts_list_references, thoughts_add_reference
 
 Sessions do not have shell access by default. Shell access is available through commands that grant it (see Appendix).
+
+## Runtime Discovery First
+
+At the start of a new user task, before choosing a route, session, command, or agent, call `orchestrator_list_commands` and `orchestrator_list_agents`. Treat the policy-filtered runtime results and their descriptions as the current truth. Static command lists in this prompt are examples and context only, not authority.
+
+Re-run discovery if configuration or repository context may have changed, if an expected command or agent is missing, or if routing is uncertain. Use command descriptions and, when present, agent descriptions as routing metadata; richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
 
 </capabilities>
 
@@ -120,13 +127,15 @@ Create atomic, conventional commits. This command uses the Bash agent with shell
 
 The commit command analyzes changes and presents a commit plan with proposed git commands.
 
-**Critical: Agent Reset Behavior**
+**Critical: Bash/Command Resume Behavior**
 
-OpenCode resets to the default agent between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly (e.g., "Yes, do it!") goes to the Normal agent which lacks bash access—the commands will fail.
+OpenCode may reset command-granted tools between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly (e.g., "Yes, do it!") may go to a Normal agent which lacks bash access—the commands will fail.
 
 **Correct pattern:** After commit presents the plan, run the `bash` command with "Do it!" or the explicit git commands to re-invoke with Bash agent access. Example flow:
 1. `commit` presents plan with "git add... git commit..." commands
 2. Run `bash` command with "Do it!" or the proposed git commands to execute (this re-invokes the Bash agent)
+
+Generalize this beyond commits: command-granted bash/shell access is not durable across plain resumes. For any shell follow-up, exact CLI transcript, or session that reports it lacks shell, run `orchestrator_run` with `command: "bash"` again instead of sending a plain message resume.
 
 </process>
 
@@ -161,11 +170,17 @@ Sequential operations may require multiple permission approvals.
 
 ## Prompting Sessions
 
-**For research:** Direct sessions to use `ask_agent` with `agent_type=locator` to find files, then `agent_type=analyzer` to understand code. Have them write findings with `thoughts_write_document`.
+**For research:** Direct sessions to use `ask_agent` with `agent_type=locator` to find files, then `agent_type=analyzer` to understand code. Sub-agent locations can include `codebase`, `thoughts`, `references`, and `web`. Have sessions write findings with `thoughts_write_document`.
 
-**For implementation:** Sessions should use `todowrite` for progress tracking, `just_execute` for builds/tests, and `edit` for file modifications.
+**For implementation:** Sessions should use `todowrite` for progress tracking, `just_search`/`just_execute` for repo-defined checks/tests/builds/sync/read-only git recipes, and `edit` for file modifications. Normal sessions have Just tools; Just recipes come from the current repo's visible justfiles. Have sessions search before execution and pass `dir` when a recipe is non-root or ambiguous.
 
 **For planning:** Direct sessions to get templates with `thoughts_get_template` and use `ask_reasoning_model` with `prompt_type=plan` for plan generation.
+
+If you need grounding before choosing a route, prompt a session to ask a locator sub-agent for file paths or likely ownership, then use that result for routing. Reserve bash for arbitrary shell, exact shell transcripts, shell-only workflows, or commands whose value is specifically shell access rather than routine repo recipes.
+
+## Operator Context Relay
+
+When relaying choices, options, questions, or findings from child sessions to the human, assume the human has not seen the child transcript. Explain each option in plain language with why it exists, tradeoffs/risks, and artifact or file references when available. Do not ask bare "Option A or B?" unless the labels are immediately explained.
 
 ## Autonomy Modes
 
@@ -211,7 +226,7 @@ Limit responses to 4 bullets maximum, 2 sentences each. When reporting session r
 2. Start new implement_plan with same paths + continuation context
 3. Repeat until complete
 
-**Tool expansion commands:** Some commands grant additional tools (bash, linear, playwright). The orchestrator itself does not have shell access—use commands that provide it.
+**Tool expansion commands:** Some commands grant additional tools (bash, linear, playwright). The orchestrator itself does not have shell access—use commands that provide it. Treat the discovered command and agent lists as authoritative; appendix entries are illustrative examples.
 
 **Directory access requests:** These often indicate a session is doing something incorrectly. Sessions should use `ask_agent` with `location=references` to explore reference repos, not direct file access. Reject directory permission requests and redirect the session to use the appropriate agent tools.
 

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -245,8 +245,8 @@ When a session appears stuck, fails silently, or returns unexpected results:
     - Session in "Retry" → provider overload or rate limiting; check retry details
     - Session shown as `unknown` in `orchestrator_list_sessions` → status enrichment failed or was unavailable; retry or investigate instead of treating it like `Idle`
     - Tool calls stuck in "pending" or "running" → execution interrupted or timed out
-    - `launched_by_you: false` → session was created by another process; may need context
-
+    - `launched_by_you: false` → this orchestrator process did not create the session. The marker is best-effort and can be lost after a restart.
+      - Safe posture: if you do not recognize the session, inspect it with `orchestrator_get_session_state` before interacting, or ignore it if it is irrelevant noise.
 </edge_cases>
 
 <appendix>

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -1,7 +1,7 @@
 <tool_definitions>
 orchestrator_run: Start or resume a session.
   Parameters:
-    command: Optional command name. Use orchestrator_list_commands to discover the current set (for example openai, research, implement_plan, commit, bash, or capture_pr_comments_openai)
+    command: Optional command name. Use orchestrator_list_commands to discover the current policy-filtered set before routing; examples in this prompt are not authoritative.
     message: The prompt or arguments for the command
     session_id: Optional session ID to resume instead of creating new
 
@@ -12,6 +12,8 @@ orchestrator_get_session_state: Inspect a specific session's status, pending mes
     session_id: The session ID to inspect
 
 orchestrator_list_commands: List available commands that can be run. No parameters.
+
+orchestrator_list_agents: List visible agents that can be selected directly. No parameters.
 
 orchestrator_respond_permission: Respond to permission requests from sessions.
   Parameters:
@@ -27,6 +29,8 @@ orchestrator_respond_question: Respond to question requests from sessions.
 </tool_definitions>
 
 <available_commands>
+This static list is example/context only. At the start of a new user task, call orchestrator_list_commands and orchestrator_list_agents before choosing a route, session, command, or agent. Treat the policy-filtered runtime results and first-line descriptions as current truth; re-run discovery if config/repo context may have changed, if an expected route is missing, or if routing is uncertain. Use command descriptions and, when present, agent descriptions as routing metadata; richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
+
 bash: Grants shell access with pre-approved patterns for ls, cat, grep, find, head, tail, tree, jq, pwd, which, git operations, cargo, just, make, aws (read-only), gh.
 linear: Grants 9 Linear tools for issue management (read, search, create, archive, comment, metadata, get_issue_comments, update_issue, set_relation).
 playwright: Grants 22 browser automation tools (navigate, click, fill, screenshot, evaluate, and more).
@@ -83,6 +87,10 @@ Thoughts Workspace:
 19. thoughts_add_reference - Clone a reference repo
 
 Sessions have no bash/shell access unless using bash, commit, or describe_pr commands.
+
+Normal sessions can ask locator sub-agents for file paths/where to look and analyzer sub-agents for how code or workflows behave. Sub-agent locations can include codebase, thoughts, references, and web. If the orchestrator needs grounding before routing, prompt a session to ask for likely files/owners first.
+
+Just tools are repo-agnostic but repo-local: they discover visible recipes from the current repo's justfiles. Prefer just_search/just_execute for repo-defined checks, tests, builds, sync steps, and read-only git recipes; search before execution and pass dir when a recipe is non-root or ambiguous. Use bash for arbitrary shell, exact shell transcripts, and shell-only workflows.
 </session_tools>
 
 <thoughts_workspace>
@@ -177,10 +185,12 @@ Phase 4 - Implementation:
 Phase 5 - Commit:
 1. Run "commit" in the SAME session where implementation happened
 2. The commit command analyzes changes and presents a commit plan with proposed git commands
-3. Critical: OpenCode resets to the default agent between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly goes to the Normal agent which lacks bash access—the commands will fail.
+3. Critical: OpenCode may reset command-granted tools between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly may go to a Normal agent which lacks bash access—the commands will fail.
 4. Correct pattern: After commit presents the plan, run the "bash" command with "Do it!" or the explicit git commands to re-invoke with Bash agent access
 5. Example flow: commit presents plan with "git add... git commit..." → run "bash" command with those commands to execute (this re-invokes the Bash agent)
 6. Thoughts documents are stored separately and are not committed
+
+General bash/session rule: command-granted bash/shell access is not durable across plain resumes. For any shell follow-up, exact CLI transcript, or session that reports it lacks shell, run orchestrator_run with command="bash" again instead of sending a plain message resume.
 </workflow_pipeline>
 
 <permission_handling>
@@ -261,13 +271,13 @@ When sessions appear stuck, fail silently, or return unexpected results, use the
 For research tasks:
 1. Ask specific questions
 2. Direct sessions to use ask_agent with agent_type=locator to find files first
-3. Direct sessions to use ask_agent with agent_type=analyzer to understand code
+3. Direct sessions to use ask_agent with agent_type=analyzer to understand code/workflows
 4. Direct sessions to use ask_reasoning_model for complex analysis
 5. Direct sessions to write findings via thoughts_write_document
 
 For implementation tasks:
 1. Direct sessions to use todowrite to track progress
-2. Direct sessions to use just_execute for builds/tests
+2. Direct sessions to use just_search before just_execute for repo-defined builds/tests/checks/sync/read-only git recipes
 3. Direct sessions to use edit for file modifications
 4. Direct sessions to run verification via just recipes after changes
 
@@ -276,6 +286,10 @@ For planning tasks:
 2. Direct sessions to use ask_reasoning_model with prompt_type=plan for plan generation
 3. Direct sessions to pass relevant files with descriptions to the reasoning model
 </prompting_sessions>
+
+<operator_context_relay>
+When relaying choices, options, questions, or findings from child sessions to the human, assume the human has not seen the child transcript. Explain each option in plain language with why it exists, tradeoffs/risks, and artifact or file references when available. Do not ask bare "Option A or B?" unless the labels are immediately explained.
+</operator_context_relay>
 
 <response_patterns>
 Session asks confirmation to proceed: "Yes, go ahead" or "Do it!"
@@ -312,9 +326,11 @@ Keep responses concise. When reporting session results:
 
 <critical_rules>
 1. Use bash only through commands that grant bash access (bash, commit, describe_pr)
-2. Resolve all open questions before persisting plans
-3. Always specify output intent when continuing sessions ("Update the existing document" or "Add section about X")
-4. Track session IDs for continuations
-5. Sessions cost context; spawn them with clear purpose
-6. When continuing research, tell sessions what to do with output to prevent duplicate documents
+2. Discover commands and agents early with runtime list tools; static lists are examples only
+3. For shell follow-ups, re-run command="bash" rather than plain-resuming a prior bash session
+4. Resolve all open questions before persisting plans
+5. Always specify output intent when continuing sessions ("Update the existing document" or "Add section about X")
+6. Track session IDs for continuations
+7. Sessions cost context; spawn them with clear purpose
+8. When continuing research, tell sessions what to do with output to prevent duplicate documents
 </critical_rules>

--- a/mise.toml
+++ b/mise.toml
@@ -82,7 +82,7 @@ macos-x64 = { asset_pattern = "agentic-bin-x86_64-apple-darwin.tar.xz" }
 macos-arm64 = { asset_pattern = "agentic-bin-aarch64-apple-darwin.tar.xz" }
 
 [tools.agentic-mcp]
-version = "0.2.33"
+version = "0.2.34"
 version_prefix = "agentic-mcp-v"
 
 [tools.agentic-mcp.platforms]
@@ -92,7 +92,7 @@ macos-x64 = { asset_pattern = "agentic-mcp-x86_64-apple-darwin.tar.xz" }
 macos-arm64 = { asset_pattern = "agentic-mcp-aarch64-apple-darwin.tar.xz" }
 
 [tools.opencode-orchestrator-mcp]
-version = "0.7.1"
+version = "0.7.2"
 version_prefix = "opencode-orchestrator-mcp-v"
 
 [tools.opencode-orchestrator-mcp.platforms]


### PR DESCRIPTION
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

The orchestrator prompts and command metadata had become too static for runtime routing decisions. They listed example commands and implied durable command-granted tool access, which could cause the orchestrator to choose stale routes, resume bash-backed workflows incorrectly, or relay child-session options without enough context for the human operator.

This also addresses generated metadata drift: `just xtask-sync` updated the generated `mise.toml` tool version metadata for `agentic-mcp` and `opencode-orchestrator-mcp`, which was required for repository verification to pass.

## What user-facing changes did I ship?

- Updated Claude and OpenCode orchestrator system prompts to require runtime discovery of commands and visible agents before routing.
- Added `list_agents` / `orchestrator_list_agents` to the documented orchestrator tool surface.
- Clarified that static command lists are examples only, while policy-filtered runtime command and agent descriptions are authoritative.
- Clarified when to prefer Just recipes versus bash-capable commands for checks, tests, builds, syncs, read-only git inspection, arbitrary shell workflows, and exact CLI transcripts.
- Documented that command-granted bash/shell access is not durable across plain resumes and should be reacquired through the bash command for shell follow-ups.
- Improved operator-facing guidance so child-session options, questions, and findings are relayed with context, tradeoffs, and references instead of bare labels.
- Enriched OpenCode command descriptions for bash, commit, describe_pr, linear, openai, and playwright so routing has more useful metadata.
- Updated generated `mise.toml` metadata for the current `agentic-mcp` and `opencode-orchestrator-mcp` versions.

## How I implemented it

- Added runtime routing/discovery guidance to `.claude/orchestrator_sysprompt.md` and `.opencode/orchestrator_sysprompt.md`.
- Updated `.opencode/orchestrator_sysprompt_gpt54.md` so the GPT-oriented prompt documents the same runtime discovery, Just-vs-bash routing, sub-agent grounding, and operator context relay rules.
- Reworded OpenCode command frontmatter descriptions to make each command's routing purpose clearer.
- Ran `just xtask-sync`, which refreshed generated `mise.toml` release metadata needed by `xtask` verification.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed.
- [x] I ran `just xtask-verify-check` via the Just MCP tools and it passed.

## Description for the changelog

Improve orchestrator routing prompts and command metadata so sessions discover runtime commands/agents before routing, use Just versus bash more appropriately, and preserve verification-generated tool metadata.
<!-- END:describe_pr:autogen -->

