### PR TITLE
ENG-938: Add orchestrator-facing agent descriptions

### DIFF
--- a/.claude/orchestrator_sysprompt.md
+++ b/.claude/orchestrator_sysprompt.md
@@ -22,7 +22,7 @@ Use the orchestrator MCP to:
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__orchestrator__run` | Start a new session, or continue an existing session by `session_id` (`resume`). |
+| `mcp__orchestrator__run` | Start a new session or resume an existing one. Supports command workflows, or raw prompts via `agent=<name>`; do not combine `agent` with `command`. |
 | `mcp__orchestrator__list_sessions` | List available sessions and their status. |
 | `mcp__orchestrator__get_session_state` | Inspect a session's current state, tool calls, and pending work. |
 | `mcp__orchestrator__list_commands` | List available command-style entry points. |
@@ -38,7 +38,7 @@ Use the orchestrator MCP to:
 
 At the start of a new user task, before choosing a route, session, command, or agent, call `mcp__orchestrator__list_commands` and `mcp__orchestrator__list_agents`. Treat their policy-filtered results and descriptions as the current truth; static command names in prompts or docs are examples, not authority. Re-run discovery if config/repo context may have changed, if an expected route is missing, or if routing is uncertain.
 
-Use command descriptions and, when present, agent descriptions as routing metadata. Richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
+Use command and agent descriptions as routing metadata. Descriptions are written as first-line routing summaries in text-mode discovery output.
 
 Normal spawned sessions have structured repo tools such as Just recipes and sub-agents, not ambient shell. Prefer Just for repo-defined checks/tests/builds/sync/read-only git recipes, after asking the session to search recipes first and pass `dir` when non-root or ambiguous. Use bash-capable commands for arbitrary shell, exact CLI transcripts, and shell-only workflows.
 

--- a/.opencode/orchestrator_sysprompt.md
+++ b/.opencode/orchestrator_sysprompt.md
@@ -16,7 +16,7 @@ You have access to these orchestrator tools:
 
 | Tool | Purpose |
 |------|---------|
-| `orchestrator_run` | Start or resume a session. Accepts optional `command`, `message`, and `session_id` parameters. |
+| `orchestrator_run` | Start or resume a session. Accepts optional `command`, optional `agent` for raw-prompt execution, `message`, and `session_id`. Do not combine `agent` with `command`. |
 | `orchestrator_list_sessions` | List available sessions with IDs and descriptions. |
 | `orchestrator_get_session_state` | Inspect one session's status, pending messages, recent tool calls, and last activity. |
 | `orchestrator_list_commands` | List available commands that can be run. |
@@ -43,7 +43,7 @@ Sessions do not have shell access by default. Shell access is available through 
 
 At the start of a new user task, before choosing a route, session, command, or agent, call `orchestrator_list_commands` and `orchestrator_list_agents`. Treat the policy-filtered runtime results and their descriptions as the current truth. Static command lists in this prompt are examples and context only, not authority.
 
-Re-run discovery if configuration or repository context may have changed, if an expected command or agent is missing, or if routing is uncertain. Use command descriptions and, when present, agent descriptions as routing metadata; richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
+Re-run discovery if configuration or repository context may have changed, if an expected command or agent is missing, or if routing is uncertain. Use command and agent descriptions as routing metadata. Runtime discovery is authoritative, and text output is optimized around first-line routing summaries.
 
 </capabilities>
 

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -2,6 +2,7 @@
 orchestrator_run: Start or resume a session.
   Parameters:
     command: Optional command name. Use orchestrator_list_commands to discover the current policy-filtered set before routing; examples in this prompt are not authoritative.
+    agent: Optional agent name for raw-prompt execution only; invalid with command
     message: The prompt or arguments for the command
     session_id: Optional session ID to resume instead of creating new
 
@@ -29,7 +30,7 @@ orchestrator_respond_question: Respond to question requests from sessions.
 </tool_definitions>
 
 <available_commands>
-This static list is example/context only. At the start of a new user task, call orchestrator_list_commands and orchestrator_list_agents before choosing a route, session, command, or agent. Treat the policy-filtered runtime results and first-line descriptions as current truth; re-run discovery if config/repo context may have changed, if an expected route is missing, or if routing is uncertain. Use command descriptions and, when present, agent descriptions as routing metadata; richer agent descriptions are a follow-up/ENG-938-compatible design and may not exist yet.
+This static list is example/context only. At the start of a new user task, call orchestrator_list_commands and orchestrator_list_agents before choosing a route, session, command, or agent. Treat the policy-filtered runtime results and first-line descriptions as current truth; re-run discovery if config/repo context may have changed, if an expected route is missing, or if routing is uncertain. Use command and agent descriptions as routing metadata.
 
 bash: Grants shell access with pre-approved patterns for ls, cat, grep, find, head, tail, tree, jq, pwd, which, git operations, cargo, just, make, aws (read-only), gh.
 linear: Grants 9 Linear tools for issue management (read, search, create, archive, comment, metadata, get_issue_comments, update_issue, set_relation).

--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -745,4 +745,18 @@ mod tests {
         assert!(text.contains("orchestrator_run"));
         assert!(text.contains("agent=<name>"));
     }
+
+    #[test]
+    fn list_agents_text_format_omits_dash_when_description_missing() {
+        let out = ListAgentsOutput {
+            agents: vec![AgentInfo {
+                name: "NoDesc".into(),
+                description: None,
+            }],
+        };
+
+        let text = out.fmt_text(&TextOptions::default());
+        assert!(text.contains("  NoDesc\n"));
+        assert!(!text.contains("NoDesc -"));
+    }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -23,15 +23,18 @@
   },
   "agent": {
     "Normal": {
+      "description": "General-purpose primary session for repo coding and research with the standard non-shell toolset.",
       "prompt": "{file:./.opencode/sysprompt.md}",
       "mode": "primary"
     },
     "NormalOpenAI": {
+      "description": "OpenAI-backed general-purpose primary session for repo research, planning, and implementation workflows.",
       "prompt": "{file:./.opencode/sysprompt_gpt54.md}",
       "model": "openai/gpt-5.4",
       "mode": "primary"
     },
     "OrchestratorClaude": {
+      "description": "Claude orchestration-only agent for routing, coordination, and todowrite/read state management without direct code execution.",
       "prompt": "{file:./.opencode/orchestrator_sysprompt.md}",
       "model": "anthropic/claude-opus-4-5",
       "mode": "primary",
@@ -43,6 +46,7 @@
       }
     },
     "OrchestratorOpenAI": {
+      "description": "OpenAI orchestration-only agent for routing, coordination, and todowrite/read state management without direct code execution.",
       "prompt": "{file:./.opencode/orchestrator_sysprompt_gpt54.md}",
       "model": "openai/gpt-5.5",
       "mode": "primary",
@@ -54,6 +58,7 @@
       }
     },
     "ReviewClaude": {
+      "description": "Claude adversarial review agent for evidence-grounded change review using review tools and read-only discovery surfaces.",
       "prompt": "{file:./.opencode/review_sysprompt.md}",
       "model": "anthropic/claude-opus-4-5",
       "mode": "primary",
@@ -70,6 +75,7 @@
       }
     },
     "ReviewOpenAI": {
+      "description": "OpenAI adversarial review agent for evidence-grounded change review using review tools and read-only discovery surfaces.",
       "prompt": "{file:./.opencode/review_sysprompt_gpt54.md}",
       "model": "openai/gpt-5.5",
       "mode": "primary",
@@ -86,6 +92,7 @@
       }
     },
     "Bash": {
+      "description": "Shell-enabled session for exact CLI work, git/build/test commands, and command-output-driven tasks; prefer Just recipes when suitable.",
       "mode": "primary",
       "permission": {
         "bash": {
@@ -141,6 +148,7 @@
       }
     },
     "Playwright": {
+      "description": "Browser automation session for navigation, interaction, screenshots, and Playwright-style UI workflows.",
       "prompt": "{file:./.opencode/sysprompt.md}",
       "mode": "primary",
       "permission": {
@@ -148,6 +156,7 @@
       }
     },
     "Linear": {
+      "description": "Linear issue-management session for reading, searching, updating, commenting on, and creating Linear work items.",
       "permission": {
         "tools_linear_*": "allow"
       }

--- a/workflow.md
+++ b/workflow.md
@@ -10,6 +10,12 @@
 
 First is orchestration level, allowing full management of opencode sessions.
 
+### Runtime discovery notes
+
+- `orchestrator_list_agents` and `orchestrator_list_commands` show the policy-filtered runtime inventory.
+- In text output, only the first line of each description is shown; treat line 1 as the routing summary.
+- After editing `opencode.json` or other agent/command metadata, restart OpenCode/orchestrator or reopen the repo/worktree before trusting refreshed discovery output.
+
 ```
 LEVEL 0: ORCHESTRATOR (Parent Agent)
 ├── orchestrator_run              - Spawn/resume sessions


### PR DESCRIPTION
## What problem(s) was I solving?

`orchestrator_list_agents` already exposed runtime agent descriptions, but the repo-owned visible agents did not define any descriptions in `opencode.json`, which made agent discovery much less useful for routing. The orchestrator prompt surfaces also still implied that agent descriptions might not exist yet and did not consistently document the already-supported `agent` parameter for raw-prompt `orchestrator_run` usage.

## What user-facing changes did I ship?

- Added first-line routing descriptions for the repo-owned visible agents in `opencode.json`: `Normal`, `NormalOpenAI`, `OrchestratorClaude`, `OrchestratorOpenAI`, `ReviewClaude`, `ReviewOpenAI`, `Bash`, `Playwright`, and `Linear`
- Updated the OpenCode and Claude orchestrator prompts to treat runtime-discovered agent descriptions as authoritative routing metadata
- Documented that `orchestrator_run(..., agent=...)` is supported for raw-prompt execution and must not be combined with `command`
- Added a workflow note that text-mode discovery only shows the first description line and that refreshed config-provided descriptions may require restart/reopen to appear in running orchestrator/OpenCode processes

## How I implemented it

- Populated the repo-owned agent entries in `opencode.json` with concise, first-line-friendly descriptions so `orchestrator_list_agents` can surface routing metadata without any transport or schema changes
- Updated `.opencode/orchestrator_sysprompt.md`, `.opencode/orchestrator_sysprompt_gpt54.md`, and `.claude/orchestrator_sysprompt.md` to remove stale ENG-938 hedge wording, align on runtime discovery authority, and describe the `agent` parameter correctly
- Added a compact runtime-discovery note to `workflow.md` covering policy-filtered inventory, first-line rendering behavior, and the restart/reopen caveat
- Added a focused unit test in `apps/opencode-orchestrator-mcp/src/types.rs` to confirm agent text formatting omits a dangling dash when an agent description is missing
- Kept the change scoped to config, prompt/docs, and test coverage only; thoughts documents are not part of the code changes in this PR

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [ ] Manually restart or reopen the relevant orchestrator/OpenCode process and confirm `orchestrator_list_agents` shows the refreshed config-provided descriptions for the repo-owned agents

Manual verification note: current running orchestrator/OpenCode processes may need restart/reopen before `orchestrator_list_agents` shows the refreshed descriptions.

## Description for the changelog

Add first-line agent descriptions and align orchestrator routing docs with runtime agent discovery.
