### PR TITLE
ENG-992: Build outer DAG automation

### DIFF
--- a/.opencode/command/linear_ticket_2_pr.md
+++ b/.opencode/command/linear_ticket_2_pr.md
@@ -180,10 +180,12 @@ $ARGUMENTS
 1. Once implementation is verified, run `commit` to prepare the commit plan.
 2. Respect the agent-reset caveat: after `commit`, re-enter a bash-capable child session to perform the actual git commands.
 3. In the bash-capable phase:
-   - confirm the working tree state
-   - create the commit or commits
-   - push the branch
-   - use `gh` tooling to create the PR if none exists, or update the existing PR if one already exists for the branch
+    - confirm the working tree state
+    - create the commit or commits
+    - push the branch
+    - use `gh` tooling to create the PR if none exists, or update the existing PR if one already exists for the branch
+    - the PR must be ready for review, never draft; do not create a draft PR
+    - if a created or discovered PR is draft for any reason, run `gh pr ready` before returning control to the orchestrator and verify the PR is no longer draft
 4. After the PR exists, run `describe_pr` so the PR description is generated from the actual diff and verification state.
 5. If needed, use a follow-up bash-capable child session to apply any final `gh` update steps after `describe_pr` completes.
 6. Capture the commit hash or hashes and the final PR URL for the orchestrator summary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ Guidance for Claude Code when working with this repository.
 
 - `agentic-tools-utils` (lib) - `crates/agentic-tools/utils/`
 - `agentic-tools-core` (lib) - `crates/agentic-tools/core/`
-- `agentic-mcp` (app) - `apps/agentic-mcp/`
 - `agentic-tools-mcp` (lib) - `crates/agentic-tools/mcp/`
+- `agentic-mcp` (app) - `apps/agentic-mcp/`
 - `agentic-tools-registry` (lib) - `crates/agentic-tools/registry/`
 - `opencode-orchestrator-mcp` (app) - `apps/opencode-orchestrator-mcp/`
 - `agentic-tools-napi` (binding) - `bindings/node/agentic-tools-napi/`
@@ -19,9 +19,9 @@ Guidance for Claude Code when working with this repository.
 ### infra
 
 - `agentic-config` (lib) - `crates/infra/agentic-config/`
-- `thoughts-tool` (lib) - `crates/infra/thoughts-core/`
-- `agentic_logging` (lib) - `crates/infra/agentic-logging/`
 - `gwt-worktree` (lib) - `crates/infra/gwt-worktree/`
+- `agentic_logging` (lib) - `crates/infra/agentic-logging/`
+- `thoughts-tool` (lib) - `crates/infra/thoughts-core/`
 
 ### legacy
 
@@ -41,18 +41,19 @@ Guidance for Claude Code when working with this repository.
 
 ### services
 
+- `opencode_rs` (lib) - `crates/services/opencode-rs/`
 - `claudecode` (lib) - `crates/services/claudecode-rs/`
 - `anthropic-async` (lib) - `crates/services/anthropic-async/`
 - `exa-async` (lib) - `crates/services/exa-async/`
-- `opencode_rs` (lib) - `crates/services/opencode-rs/`
 
 ### tools
 
 - `agentic-bin` (app) - `apps/agentic/`
+- `agentic-outer-dag-bin` (app) - `apps/agentic-outer-dag/`
+- `pr_comments` (tool-lib) - `crates/tools/pr-comments/`
 - `thoughts-bin` (app) - `apps/thoughts/`
 - `coding_agent_tools` (tool-lib) - `crates/tools/coding-agent-tools/`
 - `gpt5_reasoner` (tool-lib) - `crates/tools/gpt5-reasoner/`
-- `pr_comments` (tool-lib) - `crates/tools/pr-comments/`
 - `review_tools` (tool-lib) - `crates/tools/review-tools/`
 - `thoughts-mcp-tools` (tool-lib) - `crates/tools/thoughts-mcp-tools/`
 - `web-retrieval` (tool-lib) - `crates/tools/web-retrieval/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentic-outer-dag-bin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "git2",
+ "gwt-worktree",
+ "linear-tools",
+ "opencode_rs",
+ "pr_comments",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thoughts-tool",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wiremock",
+]
+
+[[package]]
 name = "agentic-tools-core"
 version = "0.4.0"
 dependencies = [
@@ -4795,6 +4818,7 @@ dependencies = [
  "git2",
  "mockito",
  "octocrab",
+ "reqwest 0.12.28",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "linear-tools",
  "opencode_rs",
  "pr_comments",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,6 +4819,7 @@ dependencies = [
  "mockito",
  "octocrab",
  "reqwest 0.12.28",
+ "rustls",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   # Apps
   "apps/agentic",
+  "apps/agentic-outer-dag",
   "apps/thoughts",
   "apps/agentic-mcp",
   "apps/message-optimizer",
@@ -87,6 +88,7 @@ agentic-tools-utils = { version = "0.1.5", path = "crates/agentic-tools/utils" }
 agentic-tools-registry = { version = "0.5.0", path = "crates/agentic-tools/registry" }
 agentic_logging = { version = "0.2.0", path = "crates/infra/agentic-logging" }
 thoughts-tool = { version = "0.12.1", path = "crates/infra/thoughts-core" }
+gwt-worktree = { version = "0.1.1", path = "crates/infra/gwt-worktree" }
 thoughts-mcp-tools = { version = "0.3.3", path = "crates/tools/thoughts-mcp-tools" }
 workspace_tools = { package = "agentic-workspace-tools", version = "0.1.0", path = "crates/tools/workspace-tools" }
 coding_agent_tools = { version = "0.5.3", path = "crates/tools/coding-agent-tools" }

--- a/TODO.md
+++ b/TODO.md
@@ -70,6 +70,9 @@ These items have dependencies and should be done in order.
 
 ## To classify/investigate:
 
+- TODO(2): Extract shared OpenCode session monitoring/completion detection helper used by both
+  `apps/opencode-orchestrator-mcp` and `apps/agentic-outer-dag` (dispatch-confirmed idle grace gating, bounded transcript settling,
+  conservative unresolved tool-state handling) to reduce drift.
 - TODO(2): ENG-762 follow-up — add Node/NAPI abort-signal propagation so JS callers can drive `ToolContext` cancellation instead of always using `ToolContext::default()`.
 - TODO(2): ENG-762 follow-up — define mutation-tool cancellation semantics beyond local post-commit monitoring, including whether/when remote rollback is possible.
 - TODO(2): ENG-762 follow-up — have orchestrator monitoring call OpenCode `sessions().abort()` once the API contract and side effects are clearly defined.

--- a/apps/agentic-mcp/CLAUDE.md
+++ b/apps/agentic-mcp/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-mcp -- --check
-cargo clippy -p agentic-mcp --all-targets -- -D warnings
+just crate-check agentic-mcp
 
 # Tests
-cargo test -p agentic-mcp
+just crate-test agentic-mcp
 
 # Build
-cargo build -p agentic-mcp
+just crate-build agentic-mcp
 ```
 <!-- END:xtask:autogen -->
 

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -36,6 +36,9 @@ Add any human-authored notes below. Content outside autogen blocks is preserved 
 - OpenCode session monitoring/completion detection in `src/opencode/supervisor.rs` is intentionally kept in behavioral parity with
   `apps/opencode-orchestrator-mcp/src/tools.rs` (OrchestratorRunTool). If changing idle gating or transcript settling, update the
   outer-DAG regression tests for ENG-929/ENG-972 and cross-check orchestrator behavior.
+- OpenCode v1.17.x `POST /session/{id}/command` is completion-coupled rather than enqueue-and-return. Treat that HTTP call as
+  dispatch initiation only: once session start is confirmed via SSE, `/session/status`, or bounded transcript evidence, outer-DAG
+  must keep supervising via SSE + `/session/status` and treat later `/command` transport failures as non-terminal warnings.
 
 ## Phase 1 live-test ladder (conservative)
 

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -10,7 +10,9 @@
 
 ## Overview
 
-Briefly describe the purpose of this crate and how to use it.
+`agentic-outer-dag` drives the outer workflow around a feature worktree: it resolves or creates the target worktree, persists run state under `thoughts/<branch>/artifacts/`, runs the ticket-to-PR and PR-comment-resolution phases through the embedded OpenCode supervisor, waits for CodeRabbit review completion, and stops when human input or review is required.
+
+Use `agentic-outer-dag start --ticket <LINEAR-KEY>` to begin a run, `resume` to continue a paused run in the current worktree, and `status` to inspect the persisted state. Use `respond-permission`, `respond-question`, `handoff`, and `reset` to drive the workflow when the supervised agent pauses for operator input.
 
 ## Quick Commands
 

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -38,6 +38,7 @@ Add any human-authored notes below. Content outside autogen blocks is preserved 
 
 Goals: exercise worktree selection/creation, state persistence, and existing-PR observation without:
 - creating a PR,
+- running `linear_ticket_2_pr`,
 - running `resolve_pr_comments`,
 - posting Linear handoff comments.
 
@@ -58,7 +59,7 @@ Steps:
    ```
 3. Existing-PR guard validation without eager OpenCode startup:
    ```bash
-   agentic-outer-dag start --ticket ENG-992 --branch <branch> --stop-after dispatching_ticket_to_pr --force
+   agentic-outer-dag start --ticket ENG-992 --branch <branch> --stop-after dispatching_ticket_to_pr --no-opencode-dispatch --force
    ```
 4. Safety-test dirty/conflict freshness stops without posting Linear comments:
    ```bash
@@ -66,7 +67,7 @@ Steps:
    ```
 5. Stop before `resolve_pr_comments`:
    ```bash
-   agentic-outer-dag resume --stop-after waiting_for_coderabbit --no-linear-handoff
+   agentic-outer-dag resume --stop-after waiting_for_coderabbit --no-linear-handoff --no-opencode-dispatch
    ```
 
-Compact `status` output includes both `linear_handoff_enabled` and `linear_handoff_posted` so live tests can confirm whether safety suppression was active and whether a handoff comment was actually posted.
+Compact `status` output includes `opencode_dispatch_enabled`, `linear_handoff_enabled`, and `linear_handoff_posted`, plus `pr_lookup` diagnostics, so live tests can confirm whether safety suppression was active and recover branch/repo lookup context when PR detection returns no match.

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -19,14 +19,13 @@ Use `agentic-outer-dag start --ticket <LINEAR-KEY>` to begin a run, `resume` to 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-outer-dag-bin -- --check
-cargo clippy -p agentic-outer-dag-bin --all-targets -- -D warnings
+just crate-check agentic-outer-dag-bin
 
 # Tests
-cargo test -p agentic-outer-dag-bin
+just crate-test agentic-outer-dag-bin
 
 # Build
-cargo build -p agentic-outer-dag-bin
+just crate-build agentic-outer-dag-bin
 ```
 <!-- END:xtask:autogen -->
 
@@ -50,22 +49,31 @@ Do not proceed past `dispatching_resolve_pr_comments` in Phase 1.
 
 Steps:
 1. Preview only:
+
    ```bash
    agentic-outer-dag --dry-run start --ticket ENG-992 --branch <branch>
    ```
+
 2. Force OpenCode startup failure only when a dispatch actually needs OpenCode:
+
    ```bash
    OPENCODE_BINARY=/does-not-exist agentic-outer-dag start --ticket ENG-992 --branch <branch> --force
    ```
+
 3. Existing-PR guard validation without eager OpenCode startup:
+
    ```bash
    agentic-outer-dag start --ticket ENG-992 --branch <branch> --stop-after dispatching_ticket_to_pr --no-opencode-dispatch --force
    ```
+
 4. Safety-test dirty/conflict freshness stops without posting Linear comments:
+
    ```bash
    agentic-outer-dag start --ticket ENG-992 --branch <branch> --no-linear-handoff --force
    ```
+
 5. Stop before `resolve_pr_comments`:
+
    ```bash
    agentic-outer-dag resume --stop-after waiting_for_coderabbit --no-linear-handoff --no-opencode-dispatch
    ```

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -33,6 +33,10 @@ just crate-build agentic-outer-dag-bin
 
 Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.
 
+- OpenCode session monitoring/completion detection in `src/opencode/supervisor.rs` is intentionally kept in behavioral parity with
+  `apps/opencode-orchestrator-mcp/src/tools.rs` (OrchestratorRunTool). If changing idle gating or transcript settling, update the
+  outer-DAG regression tests for ENG-929/ENG-972 and cross-check orchestrator behavior.
+
 ## Phase 1 live-test ladder (conservative)
 
 Goals: exercise worktree selection/creation, state persistence, and existing-PR observation without:

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md - agentic-outer-dag-bin
+
+<!-- BEGIN:xtask:autogen header -->
+- Crate: agentic-outer-dag-bin
+- Path: apps/agentic-outer-dag/
+- Role: app
+- Family: tools
+- Integrations: mcp=false, logging=false, napi=false
+<!-- END:xtask:autogen -->
+
+## Overview
+
+Briefly describe the purpose of this crate and how to use it.
+
+## Quick Commands
+
+<!-- BEGIN:xtask:autogen commands -->
+```bash
+# Lint & Clippy
+cargo fmt -p agentic-outer-dag-bin -- --check
+cargo clippy -p agentic-outer-dag-bin --all-targets -- -D warnings
+
+# Tests
+cargo test -p agentic-outer-dag-bin
+
+# Build
+cargo build -p agentic-outer-dag-bin
+```
+<!-- END:xtask:autogen -->
+
+## Notes
+
+Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -33,3 +33,40 @@ cargo build -p agentic-outer-dag-bin
 ## Notes
 
 Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.
+
+## Phase 1 live-test ladder (conservative)
+
+Goals: exercise worktree selection/creation, state persistence, and existing-PR observation without:
+- creating a PR,
+- running `resolve_pr_comments`,
+- posting Linear handoff comments.
+
+Safe stop-after values for Phase 1:
+- `dispatching_ticket_to_pr` — validate the existing-PR guard before any `linear_ticket_2_pr` dispatch.
+- `waiting_for_coderabbit` — stop before `dispatching_resolve_pr_comments`.
+
+Do not proceed past `dispatching_resolve_pr_comments` in Phase 1.
+
+Steps:
+1. Preview only:
+   ```bash
+   agentic-outer-dag --dry-run start --ticket ENG-992 --branch <branch>
+   ```
+2. Force OpenCode startup failure only when a dispatch actually needs OpenCode:
+   ```bash
+   OPENCODE_BINARY=/does-not-exist agentic-outer-dag start --ticket ENG-992 --branch <branch> --force
+   ```
+3. Existing-PR guard validation without eager OpenCode startup:
+   ```bash
+   agentic-outer-dag start --ticket ENG-992 --branch <branch> --stop-after dispatching_ticket_to_pr --force
+   ```
+4. Safety-test dirty/conflict freshness stops without posting Linear comments:
+   ```bash
+   agentic-outer-dag start --ticket ENG-992 --branch <branch> --no-linear-handoff --force
+   ```
+5. Stop before `resolve_pr_comments`:
+   ```bash
+   agentic-outer-dag resume --stop-after waiting_for_coderabbit --no-linear-handoff
+   ```
+
+Compact `status` output includes both `linear_handoff_enabled` and `linear_handoff_posted` so live tests can confirm whether safety suppression was active and whether a handoff comment was actually posted.

--- a/apps/agentic-outer-dag/Cargo.toml
+++ b/apps/agentic-outer-dag/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "agentic-outer-dag-bin"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+repository = "https://github.com/allisoneer/agentic_auxilary"
+description = "External outer-DAG driver for worktree→PR→CodeRabbit loops"
+publish = true
+
+[package.metadata.repo]
+role = "app"
+family = "tools"
+
+[package.metadata.repo.integrations]
+mcp = false
+logging = false
+napi = false
+
+[[bin]]
+name = "agentic-outer-dag"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["env"] }
+git2 = { version = "0.20", features = ["vendored-openssl", "ssh", "https"] }
+gwt-worktree = { workspace = true }
+linear-tools = { workspace = true }
+opencode_rs = { workspace = true, features = ["server"] }
+pr_comments = { workspace = true }
+sha2 = "0.10"
+thoughts-tool = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+tempfile = "3"
+wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/apps/agentic-outer-dag/Cargo.toml
+++ b/apps/agentic-outer-dag/Cargo.toml
@@ -37,6 +37,13 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
+# TLS backend - explicit dependency for CryptoProvider initialization
+# Required because rustls 0.23+ panics if both ring and aws-lc-rs are compiled
+# in without explicit provider selection (due to Cargo's additive features)
+rustls = { version = "0.23", default-features = false, features = [
+  "aws_lc_rs",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -146,4 +146,28 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn start_accepts_top_level_dry_run_flag() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "--dry-run",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--branch",
+            "feature/eng-992",
+        ])
+        .expect("dry-run start should parse");
+
+        assert!(cli.dry_run);
+        assert!(matches!(
+            cli.command,
+            Commands::Start {
+                ticket,
+                branch: Some(branch),
+                ..
+            } if ticket == "ENG-992" && branch == "feature/eng-992"
+        ));
+    }
 }

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -53,6 +53,12 @@ pub enum Commands {
 
         #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
         coderabbit_timeout_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        opencode_session_deadline_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        opencode_inactivity_timeout_seconds: Option<u64>,
     },
     Resume {
         #[arg(long)]
@@ -75,6 +81,12 @@ pub enum Commands {
 
         #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
         coderabbit_timeout_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        opencode_session_deadline_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        opencode_inactivity_timeout_seconds: Option<u64>,
     },
     Status {
         #[arg(long)]
@@ -203,6 +215,8 @@ mod tests {
                 stop_after: None,
                 poll_interval_seconds: None,
                 coderabbit_timeout_seconds: None,
+                opencode_session_deadline_seconds: None,
+                opencode_inactivity_timeout_seconds: None,
                 ..
             } if ticket == "ENG-992" && branch == "feature/eng-992"
         ));
@@ -228,6 +242,8 @@ mod tests {
                 stop_after: Some(StageKind::WaitingForCoderabbit),
                 poll_interval_seconds: None,
                 coderabbit_timeout_seconds: None,
+                opencode_session_deadline_seconds: None,
+                opencode_inactivity_timeout_seconds: None,
                 ..
             }
         ));
@@ -251,6 +267,8 @@ mod tests {
                 stop_after: Some(StageKind::DispatchingTicketToPr),
                 poll_interval_seconds: None,
                 coderabbit_timeout_seconds: None,
+                opencode_session_deadline_seconds: None,
+                opencode_inactivity_timeout_seconds: None,
                 ..
             }
         ));
@@ -283,6 +301,8 @@ mod tests {
         assert!(help.contains("--stop-after"));
         assert!(help.contains("--poll-interval-seconds"));
         assert!(help.contains("--coderabbit-timeout-seconds"));
+        assert!(help.contains("--opencode-session-deadline-seconds"));
+        assert!(help.contains("--opencode-inactivity-timeout-seconds"));
         assert!(help.contains("--no-linear-handoff"));
         assert!(help.contains("--no-opencode-dispatch"));
         assert!(help.contains("waiting_for_coderabbit"));
@@ -300,6 +320,10 @@ mod tests {
             "5",
             "--coderabbit-timeout-seconds",
             "120",
+            "--opencode-session-deadline-seconds",
+            "28800",
+            "--opencode-inactivity-timeout-seconds",
+            "900",
         ])
         .expect("start timing overrides should parse");
 
@@ -308,6 +332,8 @@ mod tests {
             Commands::Start {
                 poll_interval_seconds: Some(5),
                 coderabbit_timeout_seconds: Some(120),
+                opencode_session_deadline_seconds: Some(28800),
+                opencode_inactivity_timeout_seconds: Some(900),
                 ..
             }
         ));
@@ -322,6 +348,10 @@ mod tests {
             "2",
             "--coderabbit-timeout-seconds",
             "45",
+            "--opencode-session-deadline-seconds",
+            "14400",
+            "--opencode-inactivity-timeout-seconds",
+            "600",
         ])
         .expect("resume timing overrides should parse");
 
@@ -330,6 +360,8 @@ mod tests {
             Commands::Resume {
                 poll_interval_seconds: Some(2),
                 coderabbit_timeout_seconds: Some(45),
+                opencode_session_deadline_seconds: Some(14400),
+                opencode_inactivity_timeout_seconds: Some(600),
                 ..
             }
         ));
@@ -359,6 +391,34 @@ mod tests {
             "0",
         ])
         .expect_err("zero timeout should fail");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn start_rejects_zero_opencode_session_deadline() {
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--opencode-session-deadline-seconds",
+            "0",
+        ])
+        .expect_err("zero deadline should fail");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn resume_rejects_zero_opencode_inactivity_timeout() {
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "resume",
+            "--opencode-inactivity-timeout-seconds",
+            "0",
+        ])
+        .expect_err("zero inactivity timeout should fail");
 
         assert_eq!(err.kind(), ErrorKind::ValueValidation);
     }

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::state::StageKind;
 use clap::ArgGroup;
 use clap::Parser;
 use clap::Subcommand;
@@ -37,6 +38,12 @@ pub enum Commands {
 
         #[arg(long)]
         force: bool,
+
+        #[arg(long)]
+        no_linear_handoff: bool,
+
+        #[arg(long, value_enum)]
+        stop_after: Option<StageKind>,
     },
     Resume {
         #[arg(long)]
@@ -44,6 +51,12 @@ pub enum Commands {
 
         #[arg(long)]
         worktree: Option<PathBuf>,
+
+        #[arg(long)]
+        no_linear_handoff: bool,
+
+        #[arg(long, value_enum)]
+        stop_after: Option<StageKind>,
     },
     Status {
         #[arg(long)]
@@ -80,6 +93,7 @@ pub enum Commands {
 mod tests {
     use super::Cli;
     use super::Commands;
+    use crate::state::StageKind;
     use clap::CommandFactory;
     use clap::Parser;
     use clap::error::ErrorKind;
@@ -166,8 +180,116 @@ mod tests {
             Commands::Start {
                 ticket,
                 branch: Some(branch),
+                no_linear_handoff: false,
+                stop_after: None,
                 ..
             } if ticket == "ENG-992" && branch == "feature/eng-992"
+        ));
+    }
+
+    #[test]
+    fn start_accepts_valid_stop_after_stage() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--stop-after",
+            "waiting_for_coderabbit",
+        ])
+        .expect("valid stop-after should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Start {
+                no_linear_handoff: false,
+                stop_after: Some(StageKind::WaitingForCoderabbit),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_accepts_valid_stop_after_stage() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "resume",
+            "--stop-after",
+            "dispatching_ticket_to_pr",
+        ])
+        .expect("valid stop-after should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Resume {
+                no_linear_handoff: false,
+                stop_after: Some(StageKind::DispatchingTicketToPr),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn stop_after_rejects_invalid_stage_name() {
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--stop-after",
+            "not_a_stage",
+        ])
+        .expect_err("invalid stop-after stage should fail");
+
+        assert_eq!(err.kind(), ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn start_help_lists_stop_after_flag_and_stage_values() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("start")
+            .expect("start subcommand exists")
+            .render_long_help()
+            .to_string();
+
+        assert!(help.contains("--stop-after"));
+        assert!(help.contains("--no-linear-handoff"));
+        assert!(help.contains("waiting_for_coderabbit"));
+        assert!(help.contains("dispatching_resolve_pr_comments"));
+    }
+
+    #[test]
+    fn start_accepts_no_linear_handoff_flag() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--no-linear-handoff",
+        ])
+        .expect("start no-linear-handoff should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Start {
+                no_linear_handoff: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_accepts_no_linear_handoff_flag() {
+        let cli = Cli::try_parse_from(["agentic-outer-dag", "resume", "--no-linear-handoff"])
+            .expect("resume no-linear-handoff should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Resume {
+                no_linear_handoff: true,
+                ..
+            }
         ));
     }
 }

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -1,0 +1,97 @@
+use clap::Parser;
+use clap::Subcommand;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "agentic-outer-dag")]
+#[command(version)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+
+    /// Increase logging verbosity (-v, -vv, -vvv)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Suppress output except errors
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Do not run side-effecting operations.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    Start {
+        #[arg(long)]
+        ticket: String,
+
+        #[arg(long)]
+        branch: Option<String>,
+
+        #[arg(long)]
+        worktree: Option<PathBuf>,
+
+        #[arg(long)]
+        force: bool,
+    },
+    Resume {
+        #[arg(long)]
+        branch: Option<String>,
+
+        #[arg(long)]
+        worktree: Option<PathBuf>,
+    },
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+    RespondPermission {
+        #[arg(long)]
+        allow: bool,
+
+        #[arg(long)]
+        deny: bool,
+    },
+    RespondQuestion {
+        #[arg(long)]
+        answer: String,
+    },
+    Handoff {
+        #[arg(long)]
+        message: Option<String>,
+    },
+    Reset {
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory;
+
+    #[test]
+    fn generated_help_includes_expected_subcommands_and_flags() {
+        let mut command = Cli::command();
+        let help = command.render_long_help().to_string();
+
+        for expected in [
+            "start",
+            "resume",
+            "status",
+            "respond-permission",
+            "respond-question",
+            "handoff",
+            "reset",
+            "--dry-run",
+            "--quiet",
+            "--verbose",
+        ] {
+            assert!(help.contains(expected), "missing help entry: {expected}");
+        }
+    }
+}

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -47,6 +47,12 @@ pub enum Commands {
 
         #[arg(long, value_enum)]
         stop_after: Option<StageKind>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        poll_interval_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        coderabbit_timeout_seconds: Option<u64>,
     },
     Resume {
         #[arg(long)]
@@ -63,6 +69,12 @@ pub enum Commands {
 
         #[arg(long, value_enum)]
         stop_after: Option<StageKind>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        poll_interval_seconds: Option<u64>,
+
+        #[arg(long, value_name = "u64", value_parser = clap::value_parser!(u64).range(1..))]
+        coderabbit_timeout_seconds: Option<u64>,
     },
     Status {
         #[arg(long)]
@@ -189,6 +201,8 @@ mod tests {
                 no_linear_handoff: false,
                 no_opencode_dispatch: false,
                 stop_after: None,
+                poll_interval_seconds: None,
+                coderabbit_timeout_seconds: None,
                 ..
             } if ticket == "ENG-992" && branch == "feature/eng-992"
         ));
@@ -212,6 +226,8 @@ mod tests {
                 no_linear_handoff: false,
                 no_opencode_dispatch: false,
                 stop_after: Some(StageKind::WaitingForCoderabbit),
+                poll_interval_seconds: None,
+                coderabbit_timeout_seconds: None,
                 ..
             }
         ));
@@ -233,6 +249,8 @@ mod tests {
                 no_linear_handoff: false,
                 no_opencode_dispatch: false,
                 stop_after: Some(StageKind::DispatchingTicketToPr),
+                poll_interval_seconds: None,
+                coderabbit_timeout_seconds: None,
                 ..
             }
         ));
@@ -263,10 +281,86 @@ mod tests {
             .to_string();
 
         assert!(help.contains("--stop-after"));
+        assert!(help.contains("--poll-interval-seconds"));
+        assert!(help.contains("--coderabbit-timeout-seconds"));
         assert!(help.contains("--no-linear-handoff"));
         assert!(help.contains("--no-opencode-dispatch"));
         assert!(help.contains("waiting_for_coderabbit"));
         assert!(help.contains("dispatching_resolve_pr_comments"));
+    }
+
+    #[test]
+    fn start_accepts_timing_override_flags() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--poll-interval-seconds",
+            "5",
+            "--coderabbit-timeout-seconds",
+            "120",
+        ])
+        .expect("start timing overrides should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Start {
+                poll_interval_seconds: Some(5),
+                coderabbit_timeout_seconds: Some(120),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_accepts_timing_override_flags() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "resume",
+            "--poll-interval-seconds",
+            "2",
+            "--coderabbit-timeout-seconds",
+            "45",
+        ])
+        .expect("resume timing overrides should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Resume {
+                poll_interval_seconds: Some(2),
+                coderabbit_timeout_seconds: Some(45),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn start_rejects_zero_poll_interval() {
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--poll-interval-seconds",
+            "0",
+        ])
+        .expect_err("zero poll interval should fail");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn resume_rejects_zero_coderabbit_timeout() {
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "resume",
+            "--coderabbit-timeout-seconds",
+            "0",
+        ])
+        .expect_err("zero timeout should fail");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -1,3 +1,4 @@
+use clap::ArgGroup;
 use clap::Parser;
 use clap::Subcommand;
 use std::path::PathBuf;
@@ -48,6 +49,12 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    #[command(group(
+        ArgGroup::new("decision")
+            .required(true)
+            .multiple(false)
+            .args(["allow", "deny"])
+    ))]
     RespondPermission {
         #[arg(long)]
         allow: bool,
@@ -72,7 +79,10 @@ pub enum Commands {
 #[cfg(test)]
 mod tests {
     use super::Cli;
+    use super::Commands;
     use clap::CommandFactory;
+    use clap::Parser;
+    use clap::error::ErrorKind;
 
     #[test]
     fn generated_help_includes_expected_subcommands_and_flags() {
@@ -93,5 +103,47 @@ mod tests {
         ] {
             assert!(help.contains(expected), "missing help entry: {expected}");
         }
+    }
+
+    #[test]
+    fn respond_permission_requires_exactly_one_flag() {
+        let err = Cli::try_parse_from(["agentic-outer-dag", "respond-permission"])
+            .expect_err("missing decision flag should fail");
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+
+        let err = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "respond-permission",
+            "--allow",
+            "--deny",
+        ])
+        .expect_err("both decision flags should fail");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn respond_permission_accepts_allow_flag() {
+        let cli = Cli::try_parse_from(["agentic-outer-dag", "respond-permission", "--allow"])
+            .expect("allow should parse");
+        assert!(matches!(
+            cli.command,
+            Commands::RespondPermission {
+                allow: true,
+                deny: false,
+            }
+        ));
+    }
+
+    #[test]
+    fn respond_permission_accepts_deny_flag() {
+        let cli = Cli::try_parse_from(["agentic-outer-dag", "respond-permission", "--deny"])
+            .expect("deny should parse");
+        assert!(matches!(
+            cli.command,
+            Commands::RespondPermission {
+                allow: false,
+                deny: true,
+            }
+        ));
     }
 }

--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -42,6 +42,9 @@ pub enum Commands {
         #[arg(long)]
         no_linear_handoff: bool,
 
+        #[arg(long)]
+        no_opencode_dispatch: bool,
+
         #[arg(long, value_enum)]
         stop_after: Option<StageKind>,
     },
@@ -54,6 +57,9 @@ pub enum Commands {
 
         #[arg(long)]
         no_linear_handoff: bool,
+
+        #[arg(long)]
+        no_opencode_dispatch: bool,
 
         #[arg(long, value_enum)]
         stop_after: Option<StageKind>,
@@ -181,6 +187,7 @@ mod tests {
                 ticket,
                 branch: Some(branch),
                 no_linear_handoff: false,
+                no_opencode_dispatch: false,
                 stop_after: None,
                 ..
             } if ticket == "ENG-992" && branch == "feature/eng-992"
@@ -203,6 +210,7 @@ mod tests {
             cli.command,
             Commands::Start {
                 no_linear_handoff: false,
+                no_opencode_dispatch: false,
                 stop_after: Some(StageKind::WaitingForCoderabbit),
                 ..
             }
@@ -223,6 +231,7 @@ mod tests {
             cli.command,
             Commands::Resume {
                 no_linear_handoff: false,
+                no_opencode_dispatch: false,
                 stop_after: Some(StageKind::DispatchingTicketToPr),
                 ..
             }
@@ -255,6 +264,7 @@ mod tests {
 
         assert!(help.contains("--stop-after"));
         assert!(help.contains("--no-linear-handoff"));
+        assert!(help.contains("--no-opencode-dispatch"));
         assert!(help.contains("waiting_for_coderabbit"));
         assert!(help.contains("dispatching_resolve_pr_comments"));
     }
@@ -274,6 +284,7 @@ mod tests {
             cli.command,
             Commands::Start {
                 no_linear_handoff: true,
+                no_opencode_dispatch: false,
                 ..
             }
         ));
@@ -288,6 +299,41 @@ mod tests {
             cli.command,
             Commands::Resume {
                 no_linear_handoff: true,
+                no_opencode_dispatch: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn start_accepts_no_opencode_dispatch_flag() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "start",
+            "--ticket",
+            "ENG-992",
+            "--no-opencode-dispatch",
+        ])
+        .expect("start no-opencode-dispatch should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Start {
+                no_opencode_dispatch: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_accepts_no_opencode_dispatch_flag() {
+        let cli = Cli::try_parse_from(["agentic-outer-dag", "resume", "--no-opencode-dispatch"])
+            .expect("resume no-opencode-dispatch should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Resume {
+                no_opencode_dispatch: true,
                 ..
             }
         ));

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -1,6 +1,7 @@
 use crate::dag::stages;
 use crate::github::coderabbit::CodeRabbitClient;
 use crate::github::coderabbit::CodeRabbitPoll;
+use crate::github::coderabbit::skip_reason_indicates_draft;
 use crate::github::pr::DetectedPrLookup;
 use crate::github::pr::GitHubPrClient;
 use crate::linear;
@@ -106,6 +107,8 @@ fn record_pr_lookup(state: &mut RunState, stage_kind: StageKind, lookup: &Detect
         repo_name: lookup.repo_name.clone(),
         token_source: lookup.token_source.clone(),
         empty_result_reason: lookup.empty_result_reason.clone(),
+        pr_number: lookup.pr.as_ref().map(|pr| pr.number),
+        pr_is_draft: lookup.pr.as_ref().map(|pr| pr.is_draft),
         outcome: if lookup.pr.is_some() {
             "found".to_string()
         } else {
@@ -174,6 +177,97 @@ fn stage_kind_label(kind: &StageKind) -> String {
         .unwrap_or_else(|| format!("{kind:?}"))
 }
 
+fn persist_detected_pr(state: &mut RunState, pr: &pr_comments::models::PrRef) {
+    state.pr.number = Some(pr.number);
+    state.pr.url = Some(pr.url.clone());
+    state.pr.head_sha = Some(pr.head_sha.clone());
+    state.pr.last_observed_head_sha = Some(pr.head_sha.clone());
+    state.pr.is_draft = Some(pr.is_draft);
+}
+
+async fn ensure_pr_ready_for_review<MarkReady, MarkReadyFut>(
+    state: &mut RunState,
+    pr: &pr_comments::models::PrRef,
+    context: &str,
+    mark_ready: MarkReady,
+) -> Result<pr_comments::models::PrRef>
+where
+    MarkReady: FnOnce(pr_comments::models::PrRef) -> MarkReadyFut,
+    MarkReadyFut: Future<Output = Result<pr_comments::models::PrRef>>,
+{
+    persist_detected_pr(state, pr);
+    if !pr.is_draft {
+        state.pr.ready_for_review.last_result = Some(format!("already_ready:{context}"));
+        return Ok(pr.clone());
+    }
+
+    state.pr.ready_for_review.attempts += 1;
+    state.pr.ready_for_review.last_attempted_at = Some(chrono::Utc::now().to_rfc3339());
+    let updated_pr = mark_ready(pr.clone()).await.map_err(|error| {
+        anyhow::anyhow!(
+            "draft PR #{} must be ready for review before proceeding ({context}): {error}",
+            pr.number
+        )
+    })?;
+    persist_detected_pr(state, &updated_pr);
+    state.pr.is_draft = Some(false);
+    state.pr.ready_for_review.last_result = Some(format!("marked_ready:{context}"));
+    Ok(updated_pr)
+}
+
+enum DraftSkipRecovery {
+    ContinueWaiting,
+    TerminalStop { message: String },
+}
+
+async fn recover_from_draft_review_skip<DetectPr, DetectPrFut, MarkReady, MarkReadyFut>(
+    state: &mut RunState,
+    reason: &str,
+    detect_pr: DetectPr,
+    mark_ready: MarkReady,
+) -> Result<DraftSkipRecovery>
+where
+    DetectPr: FnOnce() -> DetectPrFut,
+    DetectPrFut: Future<Output = Result<DetectedPrLookup>>,
+    MarkReady: FnOnce(pr_comments::models::PrRef) -> MarkReadyFut,
+    MarkReadyFut: Future<Output = Result<pr_comments::models::PrRef>>,
+{
+    if !skip_reason_indicates_draft(reason) {
+        return Ok(DraftSkipRecovery::TerminalStop {
+            message: reason.to_string(),
+        });
+    }
+
+    if state.pr.ready_for_review.coderabbit_draft_skip_recovered {
+        state.stage.kind = StageKind::WaitingForCoderabbit;
+        state.stage.details = Some(
+            "CodeRabbit still reports the earlier draft-skip comment after recovery; treating it as stale and continuing to wait"
+                .to_string(),
+        );
+        return Ok(DraftSkipRecovery::ContinueWaiting);
+    }
+
+    let lookup = detect_pr().await?;
+    record_pr_lookup(state, StageKind::WaitingForCoderabbit, &lookup);
+    let Some(pr) = lookup.pr else {
+        return Ok(DraftSkipRecovery::TerminalStop {
+            message: format!(
+                "CodeRabbit reported draft-detected skip, but no open PR could be re-detected for branch '{}'",
+                state.worktree.branch
+            ),
+        });
+    };
+
+    ensure_pr_ready_for_review(state, &pr, "coderabbit_draft_skip_recovery", mark_ready).await?;
+    state.pr.ready_for_review.coderabbit_draft_skip_recovered = true;
+    state.stage.kind = StageKind::WaitingForCoderabbit;
+    state.stage.details = Some(
+        "CodeRabbit skipped review because the PR was draft; marked ready for review and continuing to wait"
+            .to_string(),
+    );
+    Ok(DraftSkipRecovery::ContinueWaiting)
+}
+
 impl DagEngine {
     pub fn for_current_dir() -> Result<Self> {
         Ok(Self {
@@ -215,10 +309,14 @@ impl DagEngine {
                         .await?;
                     record_pr_lookup(&mut state, StageKind::DispatchingTicketToPr, &lookup);
                     if let Some(pr) = lookup.pr {
-                        state.pr.number = Some(pr.number);
-                        state.pr.url = Some(pr.url);
-                        state.pr.head_sha = Some(pr.head_sha.clone());
-                        state.pr.last_observed_head_sha = Some(pr.head_sha);
+                        let github = &self.github;
+                        ensure_pr_ready_for_review(
+                            &mut state,
+                            &pr,
+                            "existing_pr_guard",
+                            |pr| async move { github.mark_ready_for_review(&pr).await },
+                        )
+                        .await?;
                         state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
                         state.stage.details = None;
                         ThoughtsStateStore::save(&state)?;
@@ -260,10 +358,14 @@ impl DagEngine {
                     .await?;
                     record_pr_lookup(&mut state, StageKind::DetectingPr, &lookup);
                     if let Some(pr) = lookup.pr {
-                        state.pr.number = Some(pr.number);
-                        state.pr.url = Some(pr.url);
-                        state.pr.head_sha = Some(pr.head_sha.clone());
-                        state.pr.last_observed_head_sha = Some(pr.head_sha);
+                        let github = &self.github;
+                        ensure_pr_ready_for_review(
+                            &mut state,
+                            &pr,
+                            "post_ticket_to_pr_detection",
+                            |pr| async move { github.mark_ready_for_review(&pr).await },
+                        )
+                        .await?;
                         state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
                         state.stage.details = None;
                     } else {
@@ -305,10 +407,30 @@ impl DagEngine {
                                 break;
                             }
                             CodeRabbitPoll::Skipped { reason } => {
-                                state.stage.kind = StageKind::StoppedReviewSkipped;
-                                state.stage.details = Some(reason);
-                                ThoughtsStateStore::save(&state)?;
-                                return Ok(());
+                                let branch = state.worktree.branch.clone();
+                                let github = &self.github;
+                                match recover_from_draft_review_skip(
+                                    &mut state,
+                                    &reason,
+                                    || github.detect_open_pr_from_branch(&branch),
+                                    |pr| async move { github.mark_ready_for_review(&pr).await },
+                                )
+                                .await?
+                                {
+                                    DraftSkipRecovery::ContinueWaiting => {
+                                        ThoughtsStateStore::save(&state)?;
+                                        tokio::time::sleep(poll_interval_sleep_duration(
+                                            state.settings.poll_interval_seconds,
+                                        ))
+                                        .await;
+                                    }
+                                    DraftSkipRecovery::TerminalStop { message } => {
+                                        state.stage.kind = StageKind::StoppedReviewSkipped;
+                                        state.stage.details = Some(message);
+                                        ThoughtsStateStore::save(&state)?;
+                                        return Ok(());
+                                    }
+                                }
                             }
                             CodeRabbitPoll::Waiting => {
                                 if (chrono::Utc::now() - started_at).num_seconds()
@@ -523,9 +645,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::DagEngine;
+    use super::DraftSkipRecovery;
+    use super::ensure_pr_ready_for_review;
     use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
     use super::record_pr_lookup;
+    use super::recover_from_draft_review_skip;
     use super::stage_kind_label;
     use super::transition_to_dispatch_disabled;
     use super::transition_to_missing_pr_after_lookup;
@@ -534,11 +659,22 @@ mod tests {
     use crate::state::RunState;
     use crate::state::StageKind;
     use crate::worktree::TargetWorktree;
+    use pr_comments::models::PrRef;
     use std::sync::Mutex;
     use std::sync::OnceLock;
     use std::time::Duration;
 
     static OPENCODE_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn sample_pr(is_draft: bool) -> PrRef {
+        PrRef {
+            number: 258,
+            url: "https://example.invalid/pr/258".to_string(),
+            head_sha: "abc123".to_string(),
+            node_id: "PR_258".to_string(),
+            is_draft,
+        }
+    }
 
     fn sample_state() -> RunState {
         RunState::for_start(
@@ -637,6 +773,31 @@ mod tests {
             lookup.empty_result_reason.as_deref(),
             Some("no_open_pull_requests_matched_branch")
         );
+        assert_eq!(lookup.pr_number, None);
+        assert_eq!(lookup.pr_is_draft, None);
+    }
+
+    #[test]
+    fn record_pr_lookup_persists_detected_draft_state() {
+        let mut state = sample_state();
+
+        record_pr_lookup(
+            &mut state,
+            StageKind::DetectingPr,
+            &DetectedPrLookup {
+                requested_branch: "feature/eng-992".to_string(),
+                current_branch: Some("feature/eng-992".to_string()),
+                repo_owner: "allisoneer".to_string(),
+                repo_name: "agentic_auxilary".to_string(),
+                token_source: Some("GH_TOKEN".to_string()),
+                empty_result_reason: None,
+                pr: Some(sample_pr(true)),
+            },
+        );
+
+        let lookup = state.pr.last_lookup.as_ref().expect("lookup stored");
+        assert_eq!(lookup.pr_number, Some(258));
+        assert_eq!(lookup.pr_is_draft, Some(true));
     }
 
     #[test]
@@ -774,11 +935,7 @@ mod tests {
                         token_source: Some("GH_TOKEN".to_string()),
                         empty_result_reason: (attempt < 1)
                             .then_some("no_open_pull_requests_matched_branch".to_string()),
-                        pr: (attempt >= 1).then_some(pr_comments::models::PrRef {
-                            number: 258,
-                            url: "https://example.invalid/pr/258".to_string(),
-                            head_sha: "abc123".to_string(),
-                        }),
+                        pr: (attempt >= 1).then_some(sample_pr(false)),
                     })
                 }
             },
@@ -838,6 +995,92 @@ mod tests {
                 Duration::from_secs(4),
                 Duration::from_secs(8)
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_pr_ready_for_review_marks_draft_before_coderabbit_wait() {
+        let mut state = sample_state();
+
+        let updated = ensure_pr_ready_for_review(
+            &mut state,
+            &sample_pr(true),
+            "existing_pr_guard",
+            |_| async { Ok(sample_pr(false)) },
+        )
+        .await
+        .expect("draft PR should be marked ready");
+
+        assert!(!updated.is_draft);
+        assert_eq!(state.pr.number, Some(258));
+        assert_eq!(state.pr.is_draft, Some(false));
+        assert_eq!(
+            state.pr.ready_for_review.last_result.as_deref(),
+            Some("marked_ready:existing_pr_guard")
+        );
+        assert_eq!(state.pr.ready_for_review.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn recover_from_draft_review_skip_continues_waiting_after_readying_pr() {
+        let mut state = sample_state();
+
+        let recovery = recover_from_draft_review_skip(
+            &mut state,
+            "Review skipped. Draft detected.",
+            || async {
+                Ok(DetectedPrLookup {
+                    requested_branch: "feature/eng-992".to_string(),
+                    current_branch: Some("feature/eng-992".to_string()),
+                    repo_owner: "allisoneer".to_string(),
+                    repo_name: "agentic_auxilary".to_string(),
+                    token_source: Some("GH_TOKEN".to_string()),
+                    empty_result_reason: None,
+                    pr: Some(sample_pr(true)),
+                })
+            },
+            |_| async { Ok(sample_pr(false)) },
+        )
+        .await
+        .expect("recovery should succeed");
+
+        assert!(matches!(recovery, DraftSkipRecovery::ContinueWaiting));
+        assert_eq!(state.stage.kind, StageKind::WaitingForCoderabbit);
+        assert!(
+            state
+                .stage
+                .details
+                .as_deref()
+                .expect("recovery detail")
+                .contains("marked ready for review")
+        );
+        assert!(state.pr.ready_for_review.coderabbit_draft_skip_recovered);
+        assert_eq!(state.pr.is_draft, Some(false));
+    }
+
+    #[tokio::test]
+    async fn recover_from_draft_review_skip_treats_repeat_draft_skip_as_stale() {
+        let mut state = sample_state();
+        state.pr.ready_for_review.coderabbit_draft_skip_recovered = true;
+
+        let recovery = recover_from_draft_review_skip(
+            &mut state,
+            "Review skipped. Draft detected.",
+            || async { panic!("repeat draft skip should not trigger another PR lookup") },
+            |_| async { panic!("repeat draft skip should not try to ready the PR again") },
+        )
+        .await
+        .expect("repeat draft skip should continue waiting");
+
+        assert!(matches!(recovery, DraftSkipRecovery::ContinueWaiting));
+        assert_eq!(state.stage.kind, StageKind::WaitingForCoderabbit);
+        assert!(
+            state
+                .stage
+                .details
+                .as_deref()
+                .expect("stale detail")
+                .contains("treating it as stale")
         );
     }
 

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -408,7 +408,7 @@ impl DagEngine {
             return ThoughtsStateStore::save(state);
         }
 
-        self.supervisor()
+        self.supervisor(&state.settings)
             .await?
             .ensure_commands_present(&[command_name, "linear_ticket_2_pr", "resolve_pr_comments"])
             .await?;
@@ -418,7 +418,7 @@ impl DagEngine {
         ThoughtsStateStore::save(state)?;
 
         let outcome = self
-            .supervisor()
+            .supervisor(&state.settings)
             .await?
             .run_command_supervised(
                 state.opencode.active_session_id.as_deref(),
@@ -475,9 +475,17 @@ impl DagEngine {
         ThoughtsStateStore::save(state)
     }
 
-    async fn supervisor(&mut self) -> Result<&OpenCodeSupervisor> {
+    async fn supervisor(&mut self, settings: &state::Settings) -> Result<&OpenCodeSupervisor> {
         if self.supervisor.is_none() {
-            self.supervisor = Some(OpenCodeSupervisor::start(std::path::Path::new(".")).await?);
+            self.supervisor = Some(
+                OpenCodeSupervisor::start(
+                    std::path::Path::new("."),
+                    crate::opencode::supervisor::OpenCodeSupervisorTimeouts::from_settings(
+                        settings,
+                    ),
+                )
+                .await?,
+            );
         }
 
         self.supervisor

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -90,6 +90,10 @@ fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Durati
     std::time::Duration::from_secs(poll_interval_seconds.max(1))
 }
 
+fn should_reset_coderabbit_timeout_baseline(was_recovered: bool, now_recovered: bool) -> bool {
+    !was_recovered && now_recovered
+}
+
 fn transition_to_stopped_failed(state: &mut RunState, message: impl Into<String>) {
     let message = message.into();
     state.last_error = Some(message.clone());
@@ -268,6 +272,19 @@ where
     Ok(DraftSkipRecovery::ContinueWaiting)
 }
 
+fn persist_stop_state_before_handoff<Save>(state: &RunState, save: Save) -> Result<String>
+where
+    Save: FnMut(&RunState) -> Result<()>,
+{
+    let mut save = save;
+    save(state)?;
+    state
+        .stage
+        .details
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("missing stop detail before Linear handoff"))
+}
+
 impl DagEngine {
     pub fn for_current_dir() -> Result<Self> {
         Ok(Self {
@@ -394,7 +411,7 @@ impl DagEngine {
                         .head_sha
                         .clone()
                         .ok_or_else(|| anyhow::anyhow!("missing PR head SHA in state"))?;
-                    let started_at = chrono::Utc::now();
+                    let mut started_at = chrono::Utc::now();
                     let timeout_seconds = i64::try_from(state.settings.coderabbit_timeout_seconds)
                         .map_err(|_| anyhow::anyhow!("coderabbit timeout exceeds i64 range"))?;
                     loop {
@@ -409,6 +426,8 @@ impl DagEngine {
                             CodeRabbitPoll::Skipped { reason } => {
                                 let branch = state.worktree.branch.clone();
                                 let github = &self.github;
+                                let recovered_before =
+                                    state.pr.ready_for_review.coderabbit_draft_skip_recovered;
                                 match recover_from_draft_review_skip(
                                     &mut state,
                                     &reason,
@@ -418,6 +437,15 @@ impl DagEngine {
                                 .await?
                                 {
                                     DraftSkipRecovery::ContinueWaiting => {
+                                        if should_reset_coderabbit_timeout_baseline(
+                                            recovered_before,
+                                            state
+                                                .pr
+                                                .ready_for_review
+                                                .coderabbit_draft_skip_recovered,
+                                        ) {
+                                            started_at = chrono::Utc::now();
+                                        }
                                         ThoughtsStateStore::save(&state)?;
                                         tokio::time::sleep(poll_interval_sleep_duration(
                                             state.settings.poll_interval_seconds,
@@ -502,17 +530,19 @@ impl DagEngine {
             }
             freshness::FreshnessOutcome::Conflict => {
                 let message = "rebase conflict requires manual handoff".to_string();
-                linear::post_handoff_once(state, &message).await?;
                 state.freshness.last_result = Some("conflict".to_string());
                 state.stage.kind = StageKind::StoppedRebaseConflict;
                 state.stage.details = Some(message);
+                let message = persist_stop_state_before_handoff(state, ThoughtsStateStore::save)?;
+                linear::post_handoff_once(state, &message).await?;
             }
             freshness::FreshnessOutcome::DirtyTree => {
                 let message = "dirty worktree blocks freshness gate".to_string();
-                linear::post_handoff_once(state, &message).await?;
                 state.freshness.last_result = Some("dirty_tree".to_string());
                 state.stage.kind = StageKind::StoppedDirtyTree;
                 state.stage.details = Some(message);
+                let message = persist_stop_state_before_handoff(state, ThoughtsStateStore::save)?;
+                linear::post_handoff_once(state, &message).await?;
             }
         }
         ThoughtsStateStore::save(state)
@@ -647,10 +677,12 @@ mod tests {
     use super::DagEngine;
     use super::DraftSkipRecovery;
     use super::ensure_pr_ready_for_review;
+    use super::persist_stop_state_before_handoff;
     use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
     use super::record_pr_lookup;
     use super::recover_from_draft_review_skip;
+    use super::should_reset_coderabbit_timeout_baseline;
     use super::stage_kind_label;
     use super::transition_to_dispatch_disabled;
     use super::transition_to_missing_pr_after_lookup;
@@ -658,13 +690,11 @@ mod tests {
     use crate::github::pr::DetectedPrLookup;
     use crate::state::RunState;
     use crate::state::StageKind;
+    use crate::test_support::process_state_lock;
     use crate::worktree::TargetWorktree;
     use pr_comments::models::PrRef;
     use std::sync::Mutex;
-    use std::sync::OnceLock;
     use std::time::Duration;
-
-    static OPENCODE_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn sample_pr(is_draft: bool) -> PrRef {
         PrRef {
@@ -694,6 +724,14 @@ mod tests {
         assert_eq!(poll_interval_sleep_duration(0), Duration::from_secs(1));
         assert_eq!(poll_interval_sleep_duration(1), Duration::from_secs(1));
         assert_eq!(poll_interval_sleep_duration(5), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn should_reset_coderabbit_timeout_baseline_only_on_false_to_true_transition() {
+        assert!(should_reset_coderabbit_timeout_baseline(false, true));
+        assert!(!should_reset_coderabbit_timeout_baseline(false, false));
+        assert!(!should_reset_coderabbit_timeout_baseline(true, true));
+        assert!(!should_reset_coderabbit_timeout_baseline(true, false));
     }
 
     #[test]
@@ -892,7 +930,7 @@ mod tests {
 
     #[test]
     fn for_current_dir_does_not_start_opencode_eagerly() {
-        let _guard = opencode_env_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let previous = std::env::var_os("OPENCODE_BINARY");
 
         // SAFETY: this test serializes OPENCODE_BINARY mutation with a process-wide mutex.
@@ -1084,7 +1122,36 @@ mod tests {
         );
     }
 
-    fn opencode_env_lock() -> &'static Mutex<()> {
-        OPENCODE_ENV_LOCK.get_or_init(|| Mutex::new(()))
+    #[tokio::test]
+    async fn persist_stop_state_before_handoff_saves_before_posting() {
+        let mut state = sample_state();
+        state.stage.kind = StageKind::StoppedDirtyTree;
+        state.stage.details = Some("dirty worktree blocks freshness gate".to_string());
+
+        let events = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let message = persist_stop_state_before_handoff(&state, {
+            let events = std::sync::Arc::clone(&events);
+            move |saved_state| {
+                events
+                    .lock()
+                    .unwrap()
+                    .push(format!("save:{:?}", saved_state.stage.kind));
+                Ok(())
+            }
+        })
+        .expect("save-before-post helper should succeed");
+
+        events
+            .lock()
+            .unwrap()
+            .push(format!("post:{:?}:{}", state.stage.kind, message));
+
+        assert_eq!(
+            events.lock().unwrap().as_slice(),
+            &[
+                "save:StoppedDirtyTree".to_string(),
+                "post:StoppedDirtyTree:dirty worktree blocks freshness gate".to_string(),
+            ]
+        );
     }
 }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -155,10 +155,10 @@ fn transition_to_dispatch_disabled(
     transition_to_stopped_failed(state, message);
 }
 
-fn transition_to_missing_pr_after_lookup(state: &mut RunState, context: &str) {
+fn transition_to_ticket_to_pr_no_pr_handoff(state: &mut RunState, context: &str) {
     let message = if let Some(lookup) = state.pr.last_lookup.as_ref() {
         let mut message = format!(
-            "no open PR found for branch '{}' in {}/{} {context}",
+            "ticket_to_pr completed but no open PR found for branch '{}' in {}/{} {context}; stopping for human handoff. Inspect status.pr_lookup for lookup context",
             lookup.requested_branch, lookup.repo_owner, lookup.repo_name,
         );
         if let Some(current_branch) = lookup.current_branch.as_deref() {
@@ -172,10 +172,11 @@ fn transition_to_missing_pr_after_lookup(state: &mut RunState, context: &str) {
         }
         message
     } else {
-        format!("no open PR found {context}")
+        format!("ticket_to_pr completed but no open PR found {context}; stopping for human handoff")
     };
 
-    transition_to_stopped_failed(state, message);
+    state.stage.kind = StageKind::StoppedTicketToPrNoPrHandoff;
+    state.stage.details = Some(message);
 }
 
 fn stage_kind_label(kind: &StageKind) -> String {
@@ -390,9 +391,9 @@ impl DagEngine {
                         state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
                         state.stage.details = None;
                     } else {
-                        transition_to_missing_pr_after_lookup(
+                        transition_to_ticket_to_pr_no_pr_handoff(
                             &mut state,
-                            "after ticket_to_pr run; inspect status.pr_lookup for lookup context",
+                            "after ticket_to_pr run",
                         );
                     }
                     ThoughtsStateStore::save(&state)?;
@@ -512,6 +513,7 @@ impl DagEngine {
                 | StageKind::StoppedReviewSkipped
                 | StageKind::StoppedTimedOut
                 | StageKind::StoppedReadyForHumanReview
+                | StageKind::StoppedTicketToPrNoPrHandoff
                 | StageKind::StoppedFailed => return Ok(()),
             }
         }
@@ -703,8 +705,8 @@ mod tests {
     use super::should_reset_coderabbit_timeout_baseline;
     use super::stage_kind_label;
     use super::transition_to_dispatch_disabled;
-    use super::transition_to_missing_pr_after_lookup;
     use super::transition_to_stopped_failed;
+    use super::transition_to_ticket_to_pr_no_pr_handoff;
     use crate::github::pr::DetectedPrLookup;
     use crate::state::RunState;
     use crate::state::StageKind;
@@ -913,7 +915,7 @@ mod tests {
     }
 
     #[test]
-    fn transition_to_missing_pr_after_lookup_uses_lookup_context() {
+    fn transition_to_ticket_to_pr_no_pr_handoff_uses_lookup_context_and_does_not_set_last_error() {
         let mut state = sample_state();
         record_pr_lookup(
             &mut state,
@@ -929,18 +931,24 @@ mod tests {
             },
         );
 
-        transition_to_missing_pr_after_lookup(&mut state, "after ticket_to_pr run");
+        transition_to_ticket_to_pr_no_pr_handoff(&mut state, "after ticket_to_pr run");
 
-        assert!(state
-            .last_error
-            .as_deref()
-            .expect("last error should exist")
-            .contains("no open PR found for branch 'feature/eng-992' in allisoneer/agentic_auxilary after ticket_to_pr run"));
+        assert_eq!(state.stage.kind, StageKind::StoppedTicketToPrNoPrHandoff);
+        assert_eq!(state.last_error, None);
         assert!(
             state
-                .last_error
+                .stage
+                .details
                 .as_deref()
-                .expect("last error should exist")
+                .expect("stage details should exist")
+                .contains("ticket_to_pr completed but no open PR found for branch 'feature/eng-992' in allisoneer/agentic_auxilary after ticket_to_pr run")
+        );
+        assert!(
+            state
+                .stage
+                .details
+                .as_deref()
+                .expect("stage details should exist")
                 .contains("diagnostic=no_open_pull_requests_matched_branch")
         );
     }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -1,0 +1,289 @@
+use crate::dag::stages;
+use crate::github::coderabbit::CodeRabbitClient;
+use crate::github::coderabbit::CodeRabbitPoll;
+use crate::github::pr::GitHubPrClient;
+use crate::linear;
+use crate::opencode::supervisor::OpenCodeSupervisor;
+use crate::opencode::supervisor::SupervisedOutcome;
+use crate::state;
+use crate::state::RunState;
+use crate::state::StageKind;
+use crate::state::store::ThoughtsStateStore;
+use crate::worktree::freshness;
+use anyhow::Result;
+use std::path::Path;
+
+pub struct DagEngine {
+    supervisor: OpenCodeSupervisor,
+    github: GitHubPrClient,
+    coderabbit: CodeRabbitClient,
+}
+
+impl DagEngine {
+    pub async fn for_current_dir() -> Result<Self> {
+        let supervisor = OpenCodeSupervisor::start(Path::new(".")).await?;
+        Ok(Self {
+            supervisor,
+            github: GitHubPrClient::new()?,
+            coderabbit: CodeRabbitClient::new()?,
+        })
+    }
+
+    pub async fn run_until_stop(&self) -> Result<()> {
+        loop {
+            let mut state = ThoughtsStateStore::load()?
+                .ok_or_else(|| anyhow::anyhow!("no state; run start first"))?;
+
+            if stages::is_terminal(&state.stage.kind) || stages::is_paused(&state.stage.kind) {
+                return Ok(());
+            }
+
+            match state.stage.kind.clone() {
+                StageKind::FreshnessBeforeTicketToPr => {
+                    self.advance_freshness(
+                        &mut state,
+                        StageKind::DispatchingTicketToPr,
+                        StageKind::FreshnessBeforeTicketToPr,
+                    )
+                    .await?;
+                }
+                StageKind::DispatchingTicketToPr => {
+                    if let Some(pr) = self
+                        .github
+                        .detect_open_pr_from_branch(&state.worktree.branch)
+                        .await?
+                    {
+                        state.pr.number = Some(pr.number);
+                        state.pr.url = Some(pr.url);
+                        state.pr.head_sha = Some(pr.head_sha.clone());
+                        state.pr.last_observed_head_sha = Some(pr.head_sha);
+                        state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
+                        state.stage.details = None;
+                        ThoughtsStateStore::save(&state)?;
+                        continue;
+                    }
+
+                    let ticket_key = state.ticket.linear_key.clone();
+                    self.run_supervised_command(
+                        &mut state,
+                        StageKind::DispatchingTicketToPr,
+                        "linear_ticket_2_pr",
+                        Some(ticket_key.as_str()),
+                    )
+                    .await?;
+                    if stages::is_paused(&state.stage.kind)
+                        || matches!(state.stage.kind, StageKind::StoppedFailed)
+                    {
+                        return Ok(());
+                    }
+                    state.stage.kind = StageKind::DetectingPr;
+                    state.stage.details = None;
+                    state.counters.ticket_to_pr_runs += 1;
+                    ThoughtsStateStore::save(&state)?;
+                }
+                StageKind::DetectingPr => {
+                    if let Some(pr) = self
+                        .github
+                        .detect_open_pr_from_branch(&state.worktree.branch)
+                        .await?
+                    {
+                        state.pr.number = Some(pr.number);
+                        state.pr.url = Some(pr.url);
+                        state.pr.head_sha = Some(pr.head_sha.clone());
+                        state.pr.last_observed_head_sha = Some(pr.head_sha);
+                        state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
+                        state.stage.details = None;
+                    } else {
+                        state.stage.kind = StageKind::StoppedFailed;
+                        state.stage.details =
+                            Some("no open PR found for branch after ticket_to_pr run".to_string());
+                    }
+                    ThoughtsStateStore::save(&state)?;
+                }
+                StageKind::FreshnessBeforeCoderabbitWait => {
+                    self.advance_freshness(
+                        &mut state,
+                        StageKind::WaitingForCoderabbit,
+                        StageKind::FreshnessBeforeCoderabbitWait,
+                    )
+                    .await?;
+                }
+                StageKind::WaitingForCoderabbit => {
+                    let pr_number = state
+                        .pr
+                        .number
+                        .ok_or_else(|| anyhow::anyhow!("missing PR number in state"))?;
+                    let head_sha = state
+                        .pr
+                        .head_sha
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("missing PR head SHA in state"))?;
+                    let started_at = chrono::Utc::now();
+                    let timeout_seconds = i64::try_from(state.settings.coderabbit_timeout_seconds)
+                        .map_err(|_| anyhow::anyhow!("coderabbit timeout exceeds i64 range"))?;
+                    loop {
+                        match self.coderabbit.poll_once(pr_number, &head_sha).await? {
+                            CodeRabbitPoll::Completed => {
+                                state.coderabbit.current_cycle += 1;
+                                state.stage.kind = StageKind::DispatchingResolvePrComments;
+                                state.stage.details = None;
+                                ThoughtsStateStore::save(&state)?;
+                                break;
+                            }
+                            CodeRabbitPoll::Skipped { reason } => {
+                                state.stage.kind = StageKind::StoppedReviewSkipped;
+                                state.stage.details = Some(reason);
+                                ThoughtsStateStore::save(&state)?;
+                                return Ok(());
+                            }
+                            CodeRabbitPoll::Waiting => {
+                                if (chrono::Utc::now() - started_at).num_seconds()
+                                    >= timeout_seconds
+                                {
+                                    state.stage.kind = StageKind::StoppedTimedOut;
+                                    state.stage.details = Some(
+                                        "timed out waiting for CodeRabbit completion".to_string(),
+                                    );
+                                    ThoughtsStateStore::save(&state)?;
+                                    return Ok(());
+                                }
+                                tokio::time::sleep(std::time::Duration::from_secs(
+                                    state.settings.poll_interval_seconds,
+                                ))
+                                .await;
+                            }
+                        }
+                    }
+                }
+                StageKind::DispatchingResolvePrComments => {
+                    self.run_supervised_command(
+                        &mut state,
+                        StageKind::DispatchingResolvePrComments,
+                        "resolve_pr_comments",
+                        None,
+                    )
+                    .await?;
+                    if stages::is_paused(&state.stage.kind)
+                        || matches!(state.stage.kind, StageKind::StoppedFailed)
+                    {
+                        return Ok(());
+                    }
+                    state.counters.resolve_comments_runs += 1;
+                    state.stage.kind = StageKind::StoppedReadyForHumanReview;
+                    state.stage.details =
+                        Some("completed one CodeRabbit resolve cycle".to_string());
+                    ThoughtsStateStore::save(&state)?;
+                    return Ok(());
+                }
+                _ => return Ok(()),
+            }
+        }
+    }
+
+    async fn advance_freshness(
+        &self,
+        state: &mut RunState,
+        next_stage: StageKind,
+        resume_stage: StageKind,
+    ) -> Result<()> {
+        let outcome = freshness::run(&state.worktree.base_ref, state.settings.dry_run)?;
+        state.freshness.last_checked_at = Some(chrono::Utc::now().to_rfc3339());
+        state.opencode.resume_stage = Some(resume_stage);
+        match outcome {
+            freshness::FreshnessOutcome::UpToDate => {
+                state.freshness.last_result = Some("up_to_date".to_string());
+                state.stage.kind = next_stage;
+                state.stage.details = None;
+            }
+            freshness::FreshnessOutcome::Rebases { old_head, new_head } => {
+                state.freshness.last_result = Some(format!("rebased:{old_head}->{new_head}"));
+                state.stage.kind = next_stage;
+                state.stage.details = Some("rebased onto base ref".to_string());
+                if state.pr.head_sha.is_some() {
+                    state.pr.head_sha = Some(new_head.clone());
+                    state.pr.last_observed_head_sha = Some(new_head);
+                }
+            }
+            freshness::FreshnessOutcome::Conflict => {
+                let message = "rebase conflict requires manual handoff".to_string();
+                linear::post_handoff_once(state, &message).await?;
+                state.freshness.last_result = Some("conflict".to_string());
+                state.stage.kind = StageKind::StoppedRebaseConflict;
+                state.stage.details = Some(message);
+            }
+            freshness::FreshnessOutcome::DirtyTree => {
+                let message = "dirty worktree blocks freshness gate".to_string();
+                linear::post_handoff_once(state, &message).await?;
+                state.freshness.last_result = Some("dirty_tree".to_string());
+                state.stage.kind = StageKind::StoppedDirtyTree;
+                state.stage.details = Some(message);
+            }
+        }
+        ThoughtsStateStore::save(state)
+    }
+
+    async fn run_supervised_command(
+        &self,
+        state: &mut RunState,
+        resume_stage: StageKind,
+        command_name: &str,
+        message: Option<&str>,
+    ) -> Result<()> {
+        self.supervisor
+            .ensure_commands_present(&[command_name, "linear_ticket_2_pr", "resolve_pr_comments"])
+            .await?;
+        state.opencode.resume_stage = Some(resume_stage.clone());
+        state.opencode.dispatch_attempt += 1;
+        state.opencode.last_command = Some(command_name.to_string());
+        ThoughtsStateStore::save(state)?;
+
+        let outcome = self
+            .supervisor
+            .run_command_supervised(
+                state.opencode.active_session_id.as_deref(),
+                command_name,
+                message,
+            )
+            .await?;
+        match outcome {
+            SupervisedOutcome::Completed { session_id } => {
+                state.opencode.active_session_id = Some(session_id);
+                state.opencode.pending_permission = None;
+                state.opencode.pending_question = None;
+                state.stage.kind = resume_stage;
+                state.stage.details = None;
+            }
+            SupervisedOutcome::PermissionRequired {
+                session_id,
+                request_id,
+                permission_type,
+            } => {
+                state.opencode.active_session_id = Some(session_id);
+                state.opencode.pending_permission = Some(state::PendingPermission {
+                    request_id,
+                    permission_type,
+                });
+                state.stage.kind = StageKind::StoppedPermissionRequired;
+                state.stage.details = Some("OpenCode permission response required".to_string());
+            }
+            SupervisedOutcome::QuestionRequired {
+                session_id,
+                request_id,
+                prompt,
+            } => {
+                state.opencode.active_session_id = Some(session_id);
+                state.opencode.pending_question =
+                    Some(state::PendingQuestion { request_id, prompt });
+                state.stage.kind = StageKind::StoppedQuestionRequired;
+                state.stage.details = Some("OpenCode question response required".to_string());
+            }
+            SupervisedOutcome::Failed { session_id, error } => {
+                state.opencode.active_session_id = session_id;
+                state.last_error = Some(error.clone());
+                state.stage.kind = StageKind::StoppedFailed;
+                state.stage.details = Some(error);
+            }
+        }
+        ThoughtsStateStore::save(state)
+    }
+}

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -11,10 +11,9 @@ use crate::state::StageKind;
 use crate::state::store::ThoughtsStateStore;
 use crate::worktree::freshness;
 use anyhow::Result;
-use std::path::Path;
 
 pub struct DagEngine {
-    supervisor: OpenCodeSupervisor,
+    supervisor: Option<OpenCodeSupervisor>,
     github: GitHubPrClient,
     coderabbit: CodeRabbitClient,
 }
@@ -40,10 +39,6 @@ pub fn planned_actions_for_start() -> Vec<PlannedAction> {
             summary: "Persist initial outer DAG run state",
         },
         PlannedAction {
-            id: "opencode.start",
-            summary: "Start embedded OpenCode server",
-        },
-        PlannedAction {
             id: "freshness.before_ticket_to_pr",
             summary: "Freshness gate before ticket_to_pr (fetch/rebase)",
         },
@@ -53,7 +48,7 @@ pub fn planned_actions_for_start() -> Vec<PlannedAction> {
         },
         PlannedAction {
             id: "opencode.run.linear_ticket_2_pr",
-            summary: "If no PR, run OpenCode command linear_ticket_2_pr",
+            summary: "If no PR, lazily start OpenCode and run linear_ticket_2_pr",
         },
         PlannedAction {
             id: "github.pr.detect_after_ticket_to_pr",
@@ -69,7 +64,7 @@ pub fn planned_actions_for_start() -> Vec<PlannedAction> {
         },
         PlannedAction {
             id: "opencode.run.resolve_pr_comments",
-            summary: "Run OpenCode command resolve_pr_comments",
+            summary: "Lazily start OpenCode if needed and run resolve_pr_comments",
         },
         PlannedAction {
             id: "stop.ready_for_human_review",
@@ -82,22 +77,34 @@ fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Durati
     std::time::Duration::from_secs(poll_interval_seconds.max(1))
 }
 
+fn transition_to_stopped_failed(state: &mut RunState, message: impl Into<String>) {
+    let message = message.into();
+    state.last_error = Some(message.clone());
+    state.stage.kind = StageKind::StoppedFailed;
+    state.stage.details = Some(message);
+}
+
 impl DagEngine {
-    pub async fn for_current_dir() -> Result<Self> {
-        let supervisor = OpenCodeSupervisor::start(Path::new(".")).await?;
+    pub fn for_current_dir() -> Result<Self> {
         Ok(Self {
-            supervisor,
+            supervisor: None,
             github: GitHubPrClient::new()?,
             coderabbit: CodeRabbitClient::new()?,
         })
     }
 
-    pub async fn run_until_stop(&self) -> Result<()> {
+    pub async fn run_until_stop(&mut self, stop_after: Option<StageKind>) -> Result<()> {
         loop {
             let mut state = ThoughtsStateStore::load()?
                 .ok_or_else(|| anyhow::anyhow!("no state; run start first"))?;
 
             if stages::is_terminal(&state.stage.kind) || stages::is_paused(&state.stage.kind) {
+                return Ok(());
+            }
+
+            if let Some(stop_after) = stop_after.as_ref()
+                && stages::is_beyond_stop_after(&state.stage.kind, stop_after)
+            {
                 return Ok(());
             }
 
@@ -111,6 +118,7 @@ impl DagEngine {
                     .await?;
                 }
                 StageKind::DispatchingTicketToPr => {
+                    // INVARIANT: duplicate-PR guard must remain before linear_ticket_2_pr dispatch.
                     if let Some(pr) = self
                         .github
                         .detect_open_pr_from_branch(&state.worktree.branch)
@@ -157,9 +165,10 @@ impl DagEngine {
                         state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
                         state.stage.details = None;
                     } else {
-                        state.stage.kind = StageKind::StoppedFailed;
-                        state.stage.details =
-                            Some("no open PR found for branch after ticket_to_pr run".to_string());
+                        transition_to_stopped_failed(
+                            &mut state,
+                            "no open PR found for branch after ticket_to_pr run",
+                        );
                     }
                     ThoughtsStateStore::save(&state)?;
                 }
@@ -286,13 +295,14 @@ impl DagEngine {
     }
 
     async fn run_supervised_command(
-        &self,
+        &mut self,
         state: &mut RunState,
         resume_stage: StageKind,
         command_name: &str,
         message: Option<&str>,
     ) -> Result<()> {
-        self.supervisor
+        self.supervisor()
+            .await?
             .ensure_commands_present(&[command_name, "linear_ticket_2_pr", "resolve_pr_comments"])
             .await?;
         state.opencode.resume_stage = Some(resume_stage.clone());
@@ -301,7 +311,8 @@ impl DagEngine {
         ThoughtsStateStore::save(state)?;
 
         let outcome = self
-            .supervisor
+            .supervisor()
+            .await?
             .run_command_supervised(
                 state.opencode.active_session_id.as_deref(),
                 command_name,
@@ -342,20 +353,50 @@ impl DagEngine {
             }
             SupervisedOutcome::Failed { session_id, error } => {
                 state.opencode.active_session_id = session_id;
-                state.last_error = Some(error.clone());
-                state.stage.kind = StageKind::StoppedFailed;
-                state.stage.details = Some(error);
+                transition_to_stopped_failed(state, error);
             }
         }
         ThoughtsStateStore::save(state)
+    }
+
+    async fn supervisor(&mut self) -> Result<&OpenCodeSupervisor> {
+        if self.supervisor.is_none() {
+            self.supervisor = Some(OpenCodeSupervisor::start(std::path::Path::new(".")).await?);
+        }
+
+        self.supervisor
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("supervisor should be initialized before use"))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::DagEngine;
     use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
+    use super::transition_to_stopped_failed;
+    use crate::state::RunState;
+    use crate::state::StageKind;
+    use crate::worktree::TargetWorktree;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
     use std::time::Duration;
+
+    static OPENCODE_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn sample_state() -> RunState {
+        RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().expect("cwd available for test"),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            false,
+        )
+        .expect("sample state builds")
+    }
 
     #[test]
     fn poll_interval_sleep_duration_clamps_to_one_second_minimum() {
@@ -377,7 +418,6 @@ mod tests {
                 "worktree.resolve",
                 "state.check_existing",
                 "state.write_initial",
-                "opencode.start",
                 "freshness.before_ticket_to_pr",
                 "github.pr.detect_existing",
                 "opencode.run.linear_ticket_2_pr",
@@ -388,5 +428,53 @@ mod tests {
                 "stop.ready_for_human_review",
             ]
         );
+    }
+
+    #[test]
+    fn transition_to_stopped_failed_sets_last_error_and_stage_details() {
+        let mut state = sample_state();
+
+        transition_to_stopped_failed(
+            &mut state,
+            "no open PR found for branch after ticket_to_pr run",
+        );
+
+        assert_eq!(state.stage.kind, StageKind::StoppedFailed);
+        assert_eq!(
+            state.stage.details.as_deref(),
+            Some("no open PR found for branch after ticket_to_pr run")
+        );
+        assert_eq!(
+            state.last_error.as_deref(),
+            Some("no open PR found for branch after ticket_to_pr run")
+        );
+    }
+
+    #[test]
+    fn for_current_dir_does_not_start_opencode_eagerly() {
+        let _guard = opencode_env_lock().lock().unwrap();
+        let previous = std::env::var_os("OPENCODE_BINARY");
+
+        // SAFETY: this test serializes OPENCODE_BINARY mutation with a process-wide mutex.
+        unsafe { std::env::set_var("OPENCODE_BINARY", "/definitely/not/opencode") };
+
+        let result = DagEngine::for_current_dir();
+
+        match previous {
+            Some(value) => {
+                // SAFETY: this test serializes OPENCODE_BINARY mutation with a process-wide mutex.
+                unsafe { std::env::set_var("OPENCODE_BINARY", value) };
+            }
+            None => {
+                // SAFETY: this test serializes OPENCODE_BINARY mutation with a process-wide mutex.
+                unsafe { std::env::remove_var("OPENCODE_BINARY") };
+            }
+        }
+
+        assert!(result.is_ok(), "engine construction should stay lazy");
+    }
+
+    fn opencode_env_lock() -> &'static Mutex<()> {
+        OPENCODE_ENV_LOCK.get_or_init(|| Mutex::new(()))
     }
 }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -19,6 +19,65 @@ pub struct DagEngine {
     coderabbit: CodeRabbitClient,
 }
 
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct PlannedAction {
+    pub id: &'static str,
+    pub summary: &'static str,
+}
+
+pub fn planned_actions_for_start() -> Vec<PlannedAction> {
+    vec![
+        PlannedAction {
+            id: "worktree.resolve",
+            summary: "Resolve target worktree (create if missing)",
+        },
+        PlannedAction {
+            id: "state.check_existing",
+            summary: "Check for existing outer DAG state file",
+        },
+        PlannedAction {
+            id: "state.write_initial",
+            summary: "Persist initial outer DAG run state",
+        },
+        PlannedAction {
+            id: "opencode.start",
+            summary: "Start embedded OpenCode server",
+        },
+        PlannedAction {
+            id: "freshness.before_ticket_to_pr",
+            summary: "Freshness gate before ticket_to_pr (fetch/rebase)",
+        },
+        PlannedAction {
+            id: "github.pr.detect_existing",
+            summary: "Detect existing open PR for branch",
+        },
+        PlannedAction {
+            id: "opencode.run.linear_ticket_2_pr",
+            summary: "If no PR, run OpenCode command linear_ticket_2_pr",
+        },
+        PlannedAction {
+            id: "github.pr.detect_after_ticket_to_pr",
+            summary: "Detect open PR after ticket_to_pr",
+        },
+        PlannedAction {
+            id: "freshness.before_coderabbit_wait",
+            summary: "Freshness gate before CodeRabbit wait (fetch/rebase)",
+        },
+        PlannedAction {
+            id: "github.coderabbit.wait",
+            summary: "Poll GitHub until CodeRabbit completes",
+        },
+        PlannedAction {
+            id: "opencode.run.resolve_pr_comments",
+            summary: "Run OpenCode command resolve_pr_comments",
+        },
+        PlannedAction {
+            id: "stop.ready_for_human_review",
+            summary: "Stop at ready_for_human_review",
+        },
+    ]
+}
+
 fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Duration {
     std::time::Duration::from_secs(poll_interval_seconds.max(1))
 }
@@ -294,6 +353,7 @@ impl DagEngine {
 
 #[cfg(test)]
 mod tests {
+    use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
     use std::time::Duration;
 
@@ -302,5 +362,31 @@ mod tests {
         assert_eq!(poll_interval_sleep_duration(0), Duration::from_secs(1));
         assert_eq!(poll_interval_sleep_duration(1), Duration::from_secs(1));
         assert_eq!(poll_interval_sleep_duration(5), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn planned_actions_for_start_returns_expected_ordered_ids() {
+        let ids: Vec<_> = planned_actions_for_start()
+            .into_iter()
+            .map(|action| action.id)
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "worktree.resolve",
+                "state.check_existing",
+                "state.write_initial",
+                "opencode.start",
+                "freshness.before_ticket_to_pr",
+                "github.pr.detect_existing",
+                "opencode.run.linear_ticket_2_pr",
+                "github.pr.detect_after_ticket_to_pr",
+                "freshness.before_coderabbit_wait",
+                "github.coderabbit.wait",
+                "opencode.run.resolve_pr_comments",
+                "stop.ready_for_human_review",
+            ]
+        );
     }
 }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -19,6 +19,10 @@ pub struct DagEngine {
     coderabbit: CodeRabbitClient,
 }
 
+fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Duration {
+    std::time::Duration::from_secs(poll_interval_seconds.max(1))
+}
+
 impl DagEngine {
     pub async fn for_current_dir() -> Result<Self> {
         let supervisor = OpenCodeSupervisor::start(Path::new(".")).await?;
@@ -147,7 +151,7 @@ impl DagEngine {
                                     ThoughtsStateStore::save(&state)?;
                                     return Ok(());
                                 }
-                                tokio::time::sleep(std::time::Duration::from_secs(
+                                tokio::time::sleep(poll_interval_sleep_duration(
                                     state.settings.poll_interval_seconds,
                                 ))
                                 .await;
@@ -285,5 +289,18 @@ impl DagEngine {
             }
         }
         ThoughtsStateStore::save(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::poll_interval_sleep_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn poll_interval_sleep_duration_clamps_to_one_second_minimum() {
+        assert_eq!(poll_interval_sleep_duration(0), Duration::from_secs(1));
+        assert_eq!(poll_interval_sleep_duration(1), Duration::from_secs(1));
+        assert_eq!(poll_interval_sleep_duration(5), Duration::from_secs(5));
     }
 }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -17,13 +17,13 @@ use std::fmt::Write as _;
 use std::future::Future;
 use std::time::Duration;
 
-const DETECTING_PR_MAX_ATTEMPTS: usize = 5;
 const DETECTING_PR_BACKOFFS: [Duration; 4] = [
     Duration::from_secs(1),
     Duration::from_secs(2),
     Duration::from_secs(4),
     Duration::from_secs(8),
 ];
+const DETECTING_PR_MAX_ATTEMPTS: usize = DETECTING_PR_BACKOFFS.len() + 1;
 
 pub struct DagEngine {
     supervisor: Option<OpenCodeSupervisor>,
@@ -92,6 +92,10 @@ fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Durati
 
 fn should_reset_coderabbit_timeout_baseline(was_recovered: bool, now_recovered: bool) -> bool {
     !was_recovered && now_recovered
+}
+
+fn detecting_pr_retry_attempt_number(attempt_index: usize) -> usize {
+    attempt_index + 2
 }
 
 fn transition_to_stopped_failed(state: &mut RunState, message: impl Into<String>) {
@@ -499,7 +503,16 @@ impl DagEngine {
                     ThoughtsStateStore::save(&state)?;
                     return Ok(());
                 }
-                _ => return Ok(()),
+                StageKind::Init
+                | StageKind::StoppedPermissionRequired
+                | StageKind::StoppedQuestionRequired
+                | StageKind::StoppedDirtyTree
+                | StageKind::StoppedRebaseConflict
+                | StageKind::StoppedManualHandoff
+                | StageKind::StoppedReviewSkipped
+                | StageKind::StoppedTimedOut
+                | StageKind::StoppedReadyForHumanReview
+                | StageKind::StoppedFailed => return Ok(()),
             }
         }
     }
@@ -664,7 +677,11 @@ where
             return Ok(lookup_result);
         }
 
-        on_retry(attempt_index + 2, backoff, &lookup_result)?;
+        on_retry(
+            detecting_pr_retry_attempt_number(attempt_index),
+            backoff,
+            &lookup_result,
+        )?;
         sleep(backoff).await;
     }
 
@@ -676,6 +693,7 @@ where
 mod tests {
     use super::DagEngine;
     use super::DraftSkipRecovery;
+    use super::detecting_pr_retry_attempt_number;
     use super::ensure_pr_ready_for_review;
     use super::persist_stop_state_before_handoff;
     use super::planned_actions_for_start;
@@ -732,6 +750,13 @@ mod tests {
         assert!(!should_reset_coderabbit_timeout_baseline(false, false));
         assert!(!should_reset_coderabbit_timeout_baseline(true, true));
         assert!(!should_reset_coderabbit_timeout_baseline(true, false));
+    }
+
+    #[test]
+    fn detecting_pr_retry_attempt_number_starts_from_second_attempt() {
+        assert_eq!(detecting_pr_retry_attempt_number(0), 2);
+        assert_eq!(detecting_pr_retry_attempt_number(1), 3);
+        assert_eq!(detecting_pr_retry_attempt_number(3), 5);
     }
 
     #[test]
@@ -956,9 +981,11 @@ mod tests {
     async fn detect_pr_with_retry_stops_after_pr_appears() {
         let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let seen_sleeps = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let seen_attempt_numbers = std::sync::Arc::new(Mutex::new(Vec::new()));
 
         let lookup_attempts = std::sync::Arc::clone(&attempts);
         let sleep_log = std::sync::Arc::clone(&seen_sleeps);
+        let attempt_log = std::sync::Arc::clone(&seen_attempt_numbers);
         let result = super::detect_pr_with_retry(
             move || {
                 let lookup_attempts = std::sync::Arc::clone(&lookup_attempts);
@@ -977,7 +1004,10 @@ mod tests {
                     })
                 }
             },
-            |_, _, _| Ok(()),
+            move |attempt_number, _, _| {
+                attempt_log.lock().unwrap().push(attempt_number);
+                Ok(())
+            },
             move |duration| {
                 let sleep_log = std::sync::Arc::clone(&sleep_log);
                 async move {
@@ -994,6 +1024,7 @@ mod tests {
             seen_sleeps.lock().unwrap().as_slice(),
             &[Duration::from_secs(1)]
         );
+        assert_eq!(seen_attempt_numbers.lock().unwrap().as_slice(), &[2]);
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -94,6 +94,8 @@ fn record_pr_lookup(state: &mut RunState, stage_kind: StageKind, lookup: &Detect
         current_branch: lookup.current_branch.clone(),
         repo_owner: lookup.repo_owner.clone(),
         repo_name: lookup.repo_name.clone(),
+        token_source: lookup.token_source.clone(),
+        empty_result_reason: lookup.empty_result_reason.clone(),
         outcome: if lookup.pr.is_some() {
             "found".to_string()
         } else {
@@ -121,6 +123,12 @@ fn transition_to_dispatch_disabled(
         if let Some(current_branch) = lookup.current_branch.as_deref() {
             let _ = write!(message, " (git HEAD: '{current_branch}')");
         }
+        if let Some(token_source) = lookup.token_source.as_deref() {
+            let _ = write!(message, "; token source={token_source}");
+        }
+        if let Some(empty_result_reason) = lookup.empty_result_reason.as_deref() {
+            let _ = write!(message, "; diagnostic={empty_result_reason}");
+        }
     }
 
     transition_to_stopped_failed(state, message);
@@ -134,6 +142,12 @@ fn transition_to_missing_pr_after_lookup(state: &mut RunState, context: &str) {
         );
         if let Some(current_branch) = lookup.current_branch.as_deref() {
             let _ = write!(message, " (git HEAD: '{current_branch}')");
+        }
+        if let Some(token_source) = lookup.token_source.as_deref() {
+            let _ = write!(message, "; token source={token_source}");
+        }
+        if let Some(empty_result_reason) = lookup.empty_result_reason.as_deref() {
+            let _ = write!(message, "; diagnostic={empty_result_reason}");
         }
         message
     } else {
@@ -540,6 +554,8 @@ mod tests {
                 current_branch: Some("feature/eng-992".to_string()),
                 repo_owner: "allisoneer".to_string(),
                 repo_name: "agentic_auxilary".to_string(),
+                token_source: Some("GH_TOKEN".to_string()),
+                empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
                 pr: None,
             },
         );
@@ -553,6 +569,11 @@ mod tests {
         assert_eq!(lookup.outcome, "not_found");
         assert_eq!(lookup.repo_owner, "allisoneer");
         assert_eq!(lookup.repo_name, "agentic_auxilary");
+        assert_eq!(lookup.token_source.as_deref(), Some("GH_TOKEN"));
+        assert_eq!(
+            lookup.empty_result_reason.as_deref(),
+            Some("no_open_pull_requests_matched_branch")
+        );
     }
 
     #[test]
@@ -567,6 +588,8 @@ mod tests {
                 current_branch: Some("feature/eng-992".to_string()),
                 repo_owner: "allisoneer".to_string(),
                 repo_name: "agentic_auxilary".to_string(),
+                token_source: Some("gh-config".to_string()),
+                empty_result_reason: Some("graphql_response_missing_data".to_string()),
                 pr: None,
             },
         );
@@ -593,6 +616,13 @@ mod tests {
                 .expect("last error should exist")
                 .contains("allisoneer/agentic_auxilary")
         );
+        assert!(
+            state
+                .last_error
+                .as_deref()
+                .expect("last error should exist")
+                .contains("token source=gh-config")
+        );
     }
 
     #[test]
@@ -606,6 +636,8 @@ mod tests {
                 current_branch: Some("feature/eng-992".to_string()),
                 repo_owner: "allisoneer".to_string(),
                 repo_name: "agentic_auxilary".to_string(),
+                token_source: Some("GH_TOKEN".to_string()),
+                empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
                 pr: None,
             },
         );
@@ -617,6 +649,13 @@ mod tests {
             .as_deref()
             .expect("last error should exist")
             .contains("no open PR found for branch 'feature/eng-992' in allisoneer/agentic_auxilary after ticket_to_pr run"));
+        assert!(
+            state
+                .last_error
+                .as_deref()
+                .expect("last error should exist")
+                .contains("diagnostic=no_open_pull_requests_matched_branch")
+        );
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -1,6 +1,7 @@
 use crate::dag::stages;
 use crate::github::coderabbit::CodeRabbitClient;
 use crate::github::coderabbit::CodeRabbitPoll;
+use crate::github::pr::DetectedPrLookup;
 use crate::github::pr::GitHubPrClient;
 use crate::linear;
 use crate::opencode::supervisor::OpenCodeSupervisor;
@@ -11,6 +12,7 @@ use crate::state::StageKind;
 use crate::state::store::ThoughtsStateStore;
 use crate::worktree::freshness;
 use anyhow::Result;
+use std::fmt::Write as _;
 
 pub struct DagEngine {
     supervisor: Option<OpenCodeSupervisor>,
@@ -84,6 +86,70 @@ fn transition_to_stopped_failed(state: &mut RunState, message: impl Into<String>
     state.stage.details = Some(message);
 }
 
+fn record_pr_lookup(state: &mut RunState, stage_kind: StageKind, lookup: &DetectedPrLookup) {
+    state.pr.last_lookup = Some(state::PrLookupDiagnostics {
+        checked_at: chrono::Utc::now().to_rfc3339(),
+        stage: stage_kind,
+        requested_branch: lookup.requested_branch.clone(),
+        current_branch: lookup.current_branch.clone(),
+        repo_owner: lookup.repo_owner.clone(),
+        repo_name: lookup.repo_name.clone(),
+        outcome: if lookup.pr.is_some() {
+            "found".to_string()
+        } else {
+            "not_found".to_string()
+        },
+    });
+}
+
+fn transition_to_dispatch_disabled(
+    state: &mut RunState,
+    resume_stage: &StageKind,
+    command_name: &str,
+) {
+    let mut message = format!(
+        "OpenCode dispatch disabled; refusing to run {command_name} at stage {}",
+        stage_kind_label(resume_stage)
+    );
+
+    if let Some(lookup) = state.pr.last_lookup.as_ref() {
+        let _ = write!(
+            message,
+            " after PR lookup outcome={} for branch '{}' in {}/{}",
+            lookup.outcome, lookup.requested_branch, lookup.repo_owner, lookup.repo_name,
+        );
+        if let Some(current_branch) = lookup.current_branch.as_deref() {
+            let _ = write!(message, " (git HEAD: '{current_branch}')");
+        }
+    }
+
+    transition_to_stopped_failed(state, message);
+}
+
+fn transition_to_missing_pr_after_lookup(state: &mut RunState, context: &str) {
+    let message = if let Some(lookup) = state.pr.last_lookup.as_ref() {
+        let mut message = format!(
+            "no open PR found for branch '{}' in {}/{} {context}",
+            lookup.requested_branch, lookup.repo_owner, lookup.repo_name,
+        );
+        if let Some(current_branch) = lookup.current_branch.as_deref() {
+            let _ = write!(message, " (git HEAD: '{current_branch}')");
+        }
+        message
+    } else {
+        format!("no open PR found {context}")
+    };
+
+    transition_to_stopped_failed(state, message);
+}
+
+fn stage_kind_label(kind: &StageKind) -> String {
+    serde_json::to_value(kind)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{kind:?}"))
+}
+
 impl DagEngine {
     pub fn for_current_dir() -> Result<Self> {
         Ok(Self {
@@ -119,11 +185,12 @@ impl DagEngine {
                 }
                 StageKind::DispatchingTicketToPr => {
                     // INVARIANT: duplicate-PR guard must remain before linear_ticket_2_pr dispatch.
-                    if let Some(pr) = self
+                    let lookup = self
                         .github
                         .detect_open_pr_from_branch(&state.worktree.branch)
-                        .await?
-                    {
+                        .await?;
+                    record_pr_lookup(&mut state, StageKind::DispatchingTicketToPr, &lookup);
+                    if let Some(pr) = lookup.pr {
                         state.pr.number = Some(pr.number);
                         state.pr.url = Some(pr.url);
                         state.pr.head_sha = Some(pr.head_sha.clone());
@@ -153,11 +220,12 @@ impl DagEngine {
                     ThoughtsStateStore::save(&state)?;
                 }
                 StageKind::DetectingPr => {
-                    if let Some(pr) = self
+                    let lookup = self
                         .github
                         .detect_open_pr_from_branch(&state.worktree.branch)
-                        .await?
-                    {
+                        .await?;
+                    record_pr_lookup(&mut state, StageKind::DetectingPr, &lookup);
+                    if let Some(pr) = lookup.pr {
                         state.pr.number = Some(pr.number);
                         state.pr.url = Some(pr.url);
                         state.pr.head_sha = Some(pr.head_sha.clone());
@@ -165,9 +233,9 @@ impl DagEngine {
                         state.stage.kind = StageKind::FreshnessBeforeCoderabbitWait;
                         state.stage.details = None;
                     } else {
-                        transition_to_stopped_failed(
+                        transition_to_missing_pr_after_lookup(
                             &mut state,
-                            "no open PR found for branch after ticket_to_pr run",
+                            "after ticket_to_pr run; inspect status.pr_lookup for lookup context",
                         );
                     }
                     ThoughtsStateStore::save(&state)?;
@@ -301,6 +369,11 @@ impl DagEngine {
         command_name: &str,
         message: Option<&str>,
     ) -> Result<()> {
+        if !state.settings.opencode_dispatch_enabled {
+            transition_to_dispatch_disabled(state, &resume_stage, command_name);
+            return ThoughtsStateStore::save(state);
+        }
+
         self.supervisor()
             .await?
             .ensure_commands_present(&[command_name, "linear_ticket_2_pr", "resolve_pr_comments"])
@@ -375,7 +448,12 @@ mod tests {
     use super::DagEngine;
     use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
+    use super::record_pr_lookup;
+    use super::stage_kind_label;
+    use super::transition_to_dispatch_disabled;
+    use super::transition_to_missing_pr_after_lookup;
     use super::transition_to_stopped_failed;
+    use crate::github::pr::DetectedPrLookup;
     use crate::state::RunState;
     use crate::state::StageKind;
     use crate::worktree::TargetWorktree;
@@ -447,6 +525,105 @@ mod tests {
         assert_eq!(
             state.last_error.as_deref(),
             Some("no open PR found for branch after ticket_to_pr run")
+        );
+    }
+
+    #[test]
+    fn record_pr_lookup_persists_safe_context_for_status_debugging() {
+        let mut state = sample_state();
+
+        record_pr_lookup(
+            &mut state,
+            StageKind::DispatchingTicketToPr,
+            &DetectedPrLookup {
+                requested_branch: "feature/eng-992".to_string(),
+                current_branch: Some("feature/eng-992".to_string()),
+                repo_owner: "allisoneer".to_string(),
+                repo_name: "agentic_auxilary".to_string(),
+                pr: None,
+            },
+        );
+
+        let lookup = state
+            .pr
+            .last_lookup
+            .as_ref()
+            .expect("lookup diagnostics should be stored");
+        assert_eq!(lookup.stage, StageKind::DispatchingTicketToPr);
+        assert_eq!(lookup.outcome, "not_found");
+        assert_eq!(lookup.repo_owner, "allisoneer");
+        assert_eq!(lookup.repo_name, "agentic_auxilary");
+    }
+
+    #[test]
+    fn transition_to_dispatch_disabled_sets_clear_failure_without_dispatch() {
+        let mut state = sample_state();
+        state.settings.opencode_dispatch_enabled = false;
+        record_pr_lookup(
+            &mut state,
+            StageKind::DispatchingTicketToPr,
+            &DetectedPrLookup {
+                requested_branch: "feature/eng-992".to_string(),
+                current_branch: Some("feature/eng-992".to_string()),
+                repo_owner: "allisoneer".to_string(),
+                repo_name: "agentic_auxilary".to_string(),
+                pr: None,
+            },
+        );
+
+        transition_to_dispatch_disabled(
+            &mut state,
+            &StageKind::DispatchingTicketToPr,
+            "linear_ticket_2_pr",
+        );
+
+        assert_eq!(state.stage.kind, StageKind::StoppedFailed);
+        assert!(
+            state
+                .stage
+                .details
+                .as_deref()
+                .expect("failure message should exist")
+                .contains("OpenCode dispatch disabled; refusing to run linear_ticket_2_pr")
+        );
+        assert!(
+            state
+                .last_error
+                .as_deref()
+                .expect("last error should exist")
+                .contains("allisoneer/agentic_auxilary")
+        );
+    }
+
+    #[test]
+    fn transition_to_missing_pr_after_lookup_uses_lookup_context() {
+        let mut state = sample_state();
+        record_pr_lookup(
+            &mut state,
+            StageKind::DetectingPr,
+            &DetectedPrLookup {
+                requested_branch: "feature/eng-992".to_string(),
+                current_branch: Some("feature/eng-992".to_string()),
+                repo_owner: "allisoneer".to_string(),
+                repo_name: "agentic_auxilary".to_string(),
+                pr: None,
+            },
+        );
+
+        transition_to_missing_pr_after_lookup(&mut state, "after ticket_to_pr run");
+
+        assert!(state
+            .last_error
+            .as_deref()
+            .expect("last error should exist")
+            .contains("no open PR found for branch 'feature/eng-992' in allisoneer/agentic_auxilary after ticket_to_pr run"));
+    }
+
+    #[test]
+    fn stage_kind_label_uses_snake_case_status_names() {
+        assert_eq!(
+            stage_kind_label(&StageKind::DispatchingResolvePrComments),
+            "dispatching_resolve_pr_comments"
         );
     }
 

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -13,6 +13,16 @@ use crate::state::store::ThoughtsStateStore;
 use crate::worktree::freshness;
 use anyhow::Result;
 use std::fmt::Write as _;
+use std::future::Future;
+use std::time::Duration;
+
+const DETECTING_PR_MAX_ATTEMPTS: usize = 5;
+const DETECTING_PR_BACKOFFS: [Duration; 4] = [
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+    Duration::from_secs(8),
+];
 
 pub struct DagEngine {
     supervisor: Option<OpenCodeSupervisor>,
@@ -234,10 +244,20 @@ impl DagEngine {
                     ThoughtsStateStore::save(&state)?;
                 }
                 StageKind::DetectingPr => {
-                    let lookup = self
-                        .github
-                        .detect_open_pr_from_branch(&state.worktree.branch)
-                        .await?;
+                    let branch = state.worktree.branch.clone();
+                    let lookup = detect_pr_with_retry(
+                        || self.github.detect_open_pr_from_branch(&branch),
+                        |next_attempt, backoff, lookup| {
+                            record_pr_lookup(&mut state, StageKind::DetectingPr, lookup);
+                            state.stage.details = Some(format!(
+                                "no PR visible yet after ticket_to_pr; retry {next_attempt}/{DETECTING_PR_MAX_ATTEMPTS} in {}s",
+                                backoff.as_secs()
+                            ));
+                            ThoughtsStateStore::save(&state)
+                        },
+                        tokio::time::sleep,
+                    )
+                    .await?;
                     record_pr_lookup(&mut state, StageKind::DetectingPr, &lookup);
                     if let Some(pr) = lookup.pr {
                         state.pr.number = Some(pr.number);
@@ -407,8 +427,12 @@ impl DagEngine {
             )
             .await?;
         match outcome {
-            SupervisedOutcome::Completed { session_id } => {
+            SupervisedOutcome::Completed {
+                session_id,
+                diagnostics,
+            } => {
                 state.opencode.active_session_id = Some(session_id);
+                state.opencode.last_diagnostics = Some(diagnostics);
                 state.opencode.pending_permission = None;
                 state.opencode.pending_question = None;
                 state.stage.kind = resume_stage;
@@ -438,8 +462,13 @@ impl DagEngine {
                 state.stage.kind = StageKind::StoppedQuestionRequired;
                 state.stage.details = Some("OpenCode question response required".to_string());
             }
-            SupervisedOutcome::Failed { session_id, error } => {
+            SupervisedOutcome::Failed {
+                session_id,
+                error,
+                diagnostics,
+            } => {
                 state.opencode.active_session_id = session_id;
+                state.opencode.last_diagnostics = diagnostics;
                 transition_to_stopped_failed(state, error);
             }
         }
@@ -455,6 +484,32 @@ impl DagEngine {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("supervisor should be initialized before use"))
     }
+}
+
+async fn detect_pr_with_retry<Lookup, LookupFut, OnRetry, Sleep, SleepFut>(
+    mut lookup: Lookup,
+    mut on_retry: OnRetry,
+    mut sleep: Sleep,
+) -> Result<DetectedPrLookup>
+where
+    Lookup: FnMut() -> LookupFut,
+    LookupFut: Future<Output = Result<DetectedPrLookup>>,
+    OnRetry: FnMut(usize, Duration, &DetectedPrLookup) -> Result<()>,
+    Sleep: FnMut(Duration) -> SleepFut,
+    SleepFut: Future<Output = ()>,
+{
+    for (attempt_index, backoff) in DETECTING_PR_BACKOFFS.into_iter().enumerate() {
+        let lookup_result = lookup().await?;
+        if lookup_result.pr.is_some() {
+            return Ok(lookup_result);
+        }
+
+        on_retry(attempt_index + 2, backoff, &lookup_result)?;
+        sleep(backoff).await;
+    }
+
+    let lookup_result = lookup().await?;
+    Ok(lookup_result)
 }
 
 #[cfg(test)]
@@ -688,6 +743,94 @@ mod tests {
         }
 
         assert!(result.is_ok(), "engine construction should stay lazy");
+    }
+
+    #[tokio::test]
+    async fn detect_pr_with_retry_stops_after_pr_appears() {
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen_sleeps = std::sync::Arc::new(Mutex::new(Vec::new()));
+
+        let lookup_attempts = std::sync::Arc::clone(&attempts);
+        let sleep_log = std::sync::Arc::clone(&seen_sleeps);
+        let result = super::detect_pr_with_retry(
+            move || {
+                let lookup_attempts = std::sync::Arc::clone(&lookup_attempts);
+                async move {
+                    let attempt =
+                        lookup_attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Ok(DetectedPrLookup {
+                        requested_branch: "feature/eng-992".to_string(),
+                        current_branch: Some("feature/eng-992".to_string()),
+                        repo_owner: "allisoneer".to_string(),
+                        repo_name: "agentic_auxilary".to_string(),
+                        token_source: Some("GH_TOKEN".to_string()),
+                        empty_result_reason: (attempt < 1)
+                            .then_some("no_open_pull_requests_matched_branch".to_string()),
+                        pr: (attempt >= 1).then_some(pr_comments::models::PrRef {
+                            number: 258,
+                            url: "https://example.invalid/pr/258".to_string(),
+                            head_sha: "abc123".to_string(),
+                        }),
+                    })
+                }
+            },
+            |_, _, _| Ok(()),
+            move |duration| {
+                let sleep_log = std::sync::Arc::clone(&sleep_log);
+                async move {
+                    sleep_log.lock().unwrap().push(duration);
+                }
+            },
+        )
+        .await
+        .expect("retry should succeed once PR appears");
+
+        assert_eq!(result.pr.as_ref().map(|pr| pr.number), Some(258));
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(
+            seen_sleeps.lock().unwrap().as_slice(),
+            &[Duration::from_secs(1)]
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_pr_with_retry_exhausts_backoff_schedule() {
+        let seen_sleeps = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sleep_log = std::sync::Arc::clone(&seen_sleeps);
+
+        let result = super::detect_pr_with_retry(
+            || async {
+                Ok(DetectedPrLookup {
+                    requested_branch: "feature/eng-992".to_string(),
+                    current_branch: Some("feature/eng-992".to_string()),
+                    repo_owner: "allisoneer".to_string(),
+                    repo_name: "agentic_auxilary".to_string(),
+                    token_source: Some("GH_TOKEN".to_string()),
+                    empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
+                    pr: None,
+                })
+            },
+            |_, _, _| Ok(()),
+            move |duration| {
+                let sleep_log = std::sync::Arc::clone(&sleep_log);
+                async move {
+                    sleep_log.lock().unwrap().push(duration);
+                }
+            },
+        )
+        .await
+        .expect("retry helper should return final empty lookup after exhaustion");
+
+        assert!(result.pr.is_none());
+        assert_eq!(
+            seen_sleeps.lock().unwrap().as_slice(),
+            &[
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8)
+            ]
+        );
     }
 
     fn opencode_env_lock() -> &'static Mutex<()> {

--- a/apps/agentic-outer-dag/src/dag/mod.rs
+++ b/apps/agentic-outer-dag/src/dag/mod.rs
@@ -1,0 +1,2 @@
+pub mod engine;
+pub mod stages;

--- a/apps/agentic-outer-dag/src/dag/stages.rs
+++ b/apps/agentic-outer-dag/src/dag/stages.rs
@@ -1,0 +1,38 @@
+use crate::state::StageKind;
+
+pub fn is_terminal(kind: &StageKind) -> bool {
+    matches!(
+        kind,
+        StageKind::StoppedManualHandoff
+            | StageKind::StoppedReviewSkipped
+            | StageKind::StoppedTimedOut
+            | StageKind::StoppedReadyForHumanReview
+            | StageKind::StoppedFailed
+    )
+}
+
+pub fn is_paused(kind: &StageKind) -> bool {
+    matches!(
+        kind,
+        StageKind::StoppedPermissionRequired | StageKind::StoppedQuestionRequired
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_terminal_states() {
+        assert!(is_terminal(&StageKind::StoppedReadyForHumanReview));
+        assert!(is_terminal(&StageKind::StoppedManualHandoff));
+        assert!(!is_terminal(&StageKind::WaitingForCoderabbit));
+    }
+
+    #[test]
+    fn classifies_paused_states() {
+        assert!(is_paused(&StageKind::StoppedPermissionRequired));
+        assert!(is_paused(&StageKind::StoppedQuestionRequired));
+        assert!(!is_paused(&StageKind::StoppedFailed));
+    }
+}

--- a/apps/agentic-outer-dag/src/dag/stages.rs
+++ b/apps/agentic-outer-dag/src/dag/stages.rs
@@ -17,6 +17,7 @@ pub fn is_terminal(kind: &StageKind) -> bool {
         | StageKind::StoppedReviewSkipped
         | StageKind::StoppedTimedOut
         | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedTicketToPrNoPrHandoff
         | StageKind::StoppedFailed => true,
     }
 }
@@ -37,6 +38,7 @@ pub fn is_paused(kind: &StageKind) -> bool {
         | StageKind::StoppedReviewSkipped
         | StageKind::StoppedTimedOut
         | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedTicketToPrNoPrHandoff
         | StageKind::StoppedFailed => false,
     }
 }
@@ -58,6 +60,7 @@ pub fn sequence_index(kind: &StageKind) -> Option<u8> {
         | StageKind::StoppedReviewSkipped
         | StageKind::StoppedTimedOut
         | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedTicketToPrNoPrHandoff
         | StageKind::StoppedFailed => None,
     }
 }
@@ -76,6 +79,7 @@ mod tests {
     #[test]
     fn classifies_terminal_states() {
         assert!(is_terminal(&StageKind::StoppedReadyForHumanReview));
+        assert!(is_terminal(&StageKind::StoppedTicketToPrNoPrHandoff));
         assert!(is_terminal(&StageKind::StoppedManualHandoff));
         assert!(is_terminal(&StageKind::StoppedDirtyTree));
         assert!(is_terminal(&StageKind::StoppedRebaseConflict));
@@ -86,6 +90,7 @@ mod tests {
     fn classifies_paused_states() {
         assert!(is_paused(&StageKind::StoppedPermissionRequired));
         assert!(is_paused(&StageKind::StoppedQuestionRequired));
+        assert!(!is_paused(&StageKind::StoppedTicketToPrNoPrHandoff));
         assert!(!is_paused(&StageKind::StoppedFailed));
     }
 
@@ -106,6 +111,10 @@ mod tests {
         assert_eq!(
             sequence_index(&StageKind::DispatchingResolvePrComments),
             Some(6)
+        );
+        assert_eq!(
+            sequence_index(&StageKind::StoppedTicketToPrNoPrHandoff),
+            None
         );
         assert_eq!(sequence_index(&StageKind::StoppedFailed), None);
     }

--- a/apps/agentic-outer-dag/src/dag/stages.rs
+++ b/apps/agentic-outer-dag/src/dag/stages.rs
@@ -1,23 +1,44 @@
 use crate::state::StageKind;
 
 pub fn is_terminal(kind: &StageKind) -> bool {
-    matches!(
-        kind,
-        StageKind::StoppedManualHandoff
-            | StageKind::StoppedReviewSkipped
-            | StageKind::StoppedTimedOut
-            | StageKind::StoppedReadyForHumanReview
-            | StageKind::StoppedDirtyTree
-            | StageKind::StoppedRebaseConflict
-            | StageKind::StoppedFailed
-    )
+    match kind {
+        StageKind::Init
+        | StageKind::FreshnessBeforeTicketToPr
+        | StageKind::DispatchingTicketToPr
+        | StageKind::DetectingPr
+        | StageKind::FreshnessBeforeCoderabbitWait
+        | StageKind::WaitingForCoderabbit
+        | StageKind::DispatchingResolvePrComments
+        | StageKind::StoppedPermissionRequired
+        | StageKind::StoppedQuestionRequired => false,
+        StageKind::StoppedDirtyTree
+        | StageKind::StoppedRebaseConflict
+        | StageKind::StoppedManualHandoff
+        | StageKind::StoppedReviewSkipped
+        | StageKind::StoppedTimedOut
+        | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedFailed => true,
+    }
 }
 
 pub fn is_paused(kind: &StageKind) -> bool {
-    matches!(
-        kind,
-        StageKind::StoppedPermissionRequired | StageKind::StoppedQuestionRequired
-    )
+    match kind {
+        StageKind::StoppedPermissionRequired | StageKind::StoppedQuestionRequired => true,
+        StageKind::Init
+        | StageKind::FreshnessBeforeTicketToPr
+        | StageKind::DispatchingTicketToPr
+        | StageKind::DetectingPr
+        | StageKind::FreshnessBeforeCoderabbitWait
+        | StageKind::WaitingForCoderabbit
+        | StageKind::DispatchingResolvePrComments
+        | StageKind::StoppedDirtyTree
+        | StageKind::StoppedRebaseConflict
+        | StageKind::StoppedManualHandoff
+        | StageKind::StoppedReviewSkipped
+        | StageKind::StoppedTimedOut
+        | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedFailed => false,
+    }
 }
 
 pub fn sequence_index(kind: &StageKind) -> Option<u8> {
@@ -29,7 +50,15 @@ pub fn sequence_index(kind: &StageKind) -> Option<u8> {
         StageKind::FreshnessBeforeCoderabbitWait => Some(4),
         StageKind::WaitingForCoderabbit => Some(5),
         StageKind::DispatchingResolvePrComments => Some(6),
-        _ => None,
+        StageKind::StoppedPermissionRequired
+        | StageKind::StoppedQuestionRequired
+        | StageKind::StoppedDirtyTree
+        | StageKind::StoppedRebaseConflict
+        | StageKind::StoppedManualHandoff
+        | StageKind::StoppedReviewSkipped
+        | StageKind::StoppedTimedOut
+        | StageKind::StoppedReadyForHumanReview
+        | StageKind::StoppedFailed => None,
     }
 }
 

--- a/apps/agentic-outer-dag/src/dag/stages.rs
+++ b/apps/agentic-outer-dag/src/dag/stages.rs
@@ -20,6 +20,26 @@ pub fn is_paused(kind: &StageKind) -> bool {
     )
 }
 
+pub fn sequence_index(kind: &StageKind) -> Option<u8> {
+    match kind {
+        StageKind::Init => Some(0),
+        StageKind::FreshnessBeforeTicketToPr => Some(1),
+        StageKind::DispatchingTicketToPr => Some(2),
+        StageKind::DetectingPr => Some(3),
+        StageKind::FreshnessBeforeCoderabbitWait => Some(4),
+        StageKind::WaitingForCoderabbit => Some(5),
+        StageKind::DispatchingResolvePrComments => Some(6),
+        _ => None,
+    }
+}
+
+pub fn is_beyond_stop_after(current: &StageKind, stop_after: &StageKind) -> bool {
+    match (sequence_index(current), sequence_index(stop_after)) {
+        (Some(current), Some(stop_after)) => current > stop_after,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -38,5 +58,46 @@ mod tests {
         assert!(is_paused(&StageKind::StoppedPermissionRequired));
         assert!(is_paused(&StageKind::StoppedQuestionRequired));
         assert!(!is_paused(&StageKind::StoppedFailed));
+    }
+
+    #[test]
+    fn sequence_index_orders_active_pipeline_stages() {
+        assert_eq!(sequence_index(&StageKind::Init), Some(0));
+        assert_eq!(
+            sequence_index(&StageKind::FreshnessBeforeTicketToPr),
+            Some(1)
+        );
+        assert_eq!(sequence_index(&StageKind::DispatchingTicketToPr), Some(2));
+        assert_eq!(sequence_index(&StageKind::DetectingPr), Some(3));
+        assert_eq!(
+            sequence_index(&StageKind::FreshnessBeforeCoderabbitWait),
+            Some(4)
+        );
+        assert_eq!(sequence_index(&StageKind::WaitingForCoderabbit), Some(5));
+        assert_eq!(
+            sequence_index(&StageKind::DispatchingResolvePrComments),
+            Some(6)
+        );
+        assert_eq!(sequence_index(&StageKind::StoppedFailed), None);
+    }
+
+    #[test]
+    fn identifies_when_current_stage_is_beyond_stop_after_ceiling() {
+        assert!(is_beyond_stop_after(
+            &StageKind::DispatchingResolvePrComments,
+            &StageKind::WaitingForCoderabbit,
+        ));
+        assert!(!is_beyond_stop_after(
+            &StageKind::WaitingForCoderabbit,
+            &StageKind::WaitingForCoderabbit,
+        ));
+        assert!(!is_beyond_stop_after(
+            &StageKind::DetectingPr,
+            &StageKind::WaitingForCoderabbit,
+        ));
+        assert!(!is_beyond_stop_after(
+            &StageKind::StoppedFailed,
+            &StageKind::WaitingForCoderabbit,
+        ));
     }
 }

--- a/apps/agentic-outer-dag/src/dag/stages.rs
+++ b/apps/agentic-outer-dag/src/dag/stages.rs
@@ -7,6 +7,8 @@ pub fn is_terminal(kind: &StageKind) -> bool {
             | StageKind::StoppedReviewSkipped
             | StageKind::StoppedTimedOut
             | StageKind::StoppedReadyForHumanReview
+            | StageKind::StoppedDirtyTree
+            | StageKind::StoppedRebaseConflict
             | StageKind::StoppedFailed
     )
 }
@@ -26,6 +28,8 @@ mod tests {
     fn classifies_terminal_states() {
         assert!(is_terminal(&StageKind::StoppedReadyForHumanReview));
         assert!(is_terminal(&StageKind::StoppedManualHandoff));
+        assert!(is_terminal(&StageKind::StoppedDirtyTree));
+        assert!(is_terminal(&StageKind::StoppedRebaseConflict));
         assert!(!is_terminal(&StageKind::WaitingForCoderabbit));
     }
 

--- a/apps/agentic-outer-dag/src/github/coderabbit.rs
+++ b/apps/agentic-outer-dag/src/github/coderabbit.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use pr_comments::PrComments;
+use pr_comments::models::CheckSuiteSummary;
+use pr_comments::models::IssueCommentSummary;
+use pr_comments::models::PullRequestReviewSummary;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodeRabbitPoll {
+    Waiting,
+    Completed,
+    Skipped { reason: String },
+}
+
+pub struct CodeRabbitClient {
+    pr_comments: PrComments,
+}
+
+impl CodeRabbitClient {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            pr_comments: PrComments::new()?,
+        })
+    }
+
+    pub async fn poll_once(&self, pr_number: u64, head_sha: &str) -> Result<CodeRabbitPoll> {
+        let suites = self.pr_comments.list_check_suites_for_ref(head_sha).await?;
+        if let Some(outcome) = interpret_check_suites(&suites) {
+            return Ok(outcome);
+        }
+
+        let reviews = self
+            .pr_comments
+            .list_pull_request_reviews(pr_number)
+            .await?;
+        if has_coderabbit_review(&reviews) {
+            return Ok(CodeRabbitPoll::Completed);
+        }
+
+        let comments = self.pr_comments.list_issue_comments(pr_number).await?;
+        Ok(interpret_issue_comments(&comments))
+    }
+}
+
+fn interpret_check_suites(suites: &[CheckSuiteSummary]) -> Option<CodeRabbitPoll> {
+    let coderabbit: Vec<_> = suites
+        .iter()
+        .filter(|suite| suite.app_slug.as_deref() == Some("coderabbitai"))
+        .collect();
+    if coderabbit.is_empty() {
+        return None;
+    }
+    if coderabbit.iter().any(|suite| suite.status == "completed") {
+        Some(CodeRabbitPoll::Completed)
+    } else {
+        Some(CodeRabbitPoll::Waiting)
+    }
+}
+
+fn has_coderabbit_review(reviews: &[PullRequestReviewSummary]) -> bool {
+    reviews.iter().any(|review| {
+        review
+            .user_login
+            .to_ascii_lowercase()
+            .contains("coderabbit")
+            || review.user_type.as_deref() == Some("Bot")
+    })
+}
+
+fn interpret_issue_comments(comments: &[IssueCommentSummary]) -> CodeRabbitPoll {
+    for comment in comments {
+        let body = comment.body.to_ascii_lowercase();
+        let is_coderabbit = comment
+            .user_login
+            .to_ascii_lowercase()
+            .contains("coderabbit")
+            || comment.user_type.as_deref() == Some("Bot");
+        if is_coderabbit && body.contains("review skipped") {
+            return CodeRabbitPoll::Skipped {
+                reason: comment.body.clone(),
+            };
+        }
+        if is_coderabbit {
+            return CodeRabbitPoll::Completed;
+        }
+    }
+
+    CodeRabbitPoll::Waiting
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_skipped_comment() {
+        let result = interpret_issue_comments(&[IssueCommentSummary {
+            id: 1,
+            user_login: "coderabbitai[bot]".to_string(),
+            user_type: Some("Bot".to_string()),
+            body: "Review skipped because no actionable changes were found".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }]);
+        assert!(matches!(result, CodeRabbitPoll::Skipped { .. }));
+    }
+}

--- a/apps/agentic-outer-dag/src/github/coderabbit.rs
+++ b/apps/agentic-outer-dag/src/github/coderabbit.rs
@@ -57,23 +57,19 @@ fn interpret_check_suites(suites: &[CheckSuiteSummary]) -> Option<CodeRabbitPoll
 }
 
 fn has_coderabbit_review(reviews: &[PullRequestReviewSummary]) -> bool {
-    reviews.iter().any(|review| {
-        review
-            .user_login
-            .to_ascii_lowercase()
-            .contains("coderabbit")
-            || review.user_type.as_deref() == Some("Bot")
-    })
+    reviews
+        .iter()
+        .any(|review| is_coderabbit_login(&review.user_login))
+}
+
+fn is_coderabbit_login(login: &str) -> bool {
+    login.to_ascii_lowercase().contains("coderabbit")
 }
 
 fn interpret_issue_comments(comments: &[IssueCommentSummary]) -> CodeRabbitPoll {
     for comment in comments {
         let body = comment.body.to_ascii_lowercase();
-        let is_coderabbit = comment
-            .user_login
-            .to_ascii_lowercase()
-            .contains("coderabbit")
-            || comment.user_type.as_deref() == Some("Bot");
+        let is_coderabbit = is_coderabbit_login(&comment.user_login);
         if is_coderabbit && body.contains("review skipped") {
             return CodeRabbitPoll::Skipped {
                 reason: comment.body.clone(),
@@ -91,15 +87,72 @@ fn interpret_issue_comments(comments: &[IssueCommentSummary]) -> CodeRabbitPoll 
 mod tests {
     use super::*;
 
+    fn issue_comment(user_login: &str, body: &str) -> IssueCommentSummary {
+        IssueCommentSummary {
+            id: 1,
+            user_login: user_login.to_string(),
+            user_type: Some("Bot".to_string()),
+            body: body.to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn review(user_login: &str) -> PullRequestReviewSummary {
+        PullRequestReviewSummary {
+            id: 1,
+            user_login: user_login.to_string(),
+            user_type: Some("Bot".to_string()),
+            state: "COMMENTED".to_string(),
+            submitted_at: Some("2026-01-01T00:00:00Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn matches_coderabbit_logins_case_insensitively() {
+        for login in [
+            "coderabbitai",
+            "coderabbitai[bot]",
+            "CodeRabbitAI",
+            "my-coderabbit-helper",
+        ] {
+            assert!(is_coderabbit_login(login), "expected match for {login}");
+        }
+    }
+
+    #[test]
+    fn rejects_unrelated_bot_logins() {
+        for login in ["dependabot[bot]", "renovate[bot]"] {
+            assert!(!is_coderabbit_login(login), "unexpected match for {login}");
+        }
+    }
+
+    #[test]
+    fn coderabbit_review_detection_requires_coderabbit_login() {
+        assert!(has_coderabbit_review(&[review("coderabbitai[bot]")]));
+        assert!(!has_coderabbit_review(&[review("dependabot[bot]")]));
+    }
+
     #[test]
     fn detects_skipped_comment() {
-        let result = interpret_issue_comments(&[IssueCommentSummary {
-            id: 1,
-            user_login: "coderabbitai[bot]".to_string(),
-            user_type: Some("Bot".to_string()),
-            body: "Review skipped because no actionable changes were found".to_string(),
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-        }]);
+        let result = interpret_issue_comments(&[issue_comment(
+            "coderabbitai[bot]",
+            "Review skipped because no actionable changes were found",
+        )]);
         assert!(matches!(result, CodeRabbitPoll::Skipped { .. }));
+    }
+
+    #[test]
+    fn unrelated_bot_comment_does_not_complete_poll() {
+        let result = interpret_issue_comments(&[issue_comment(
+            "dependabot[bot]",
+            "Review skipped because no actionable changes were found",
+        )]);
+        assert_eq!(result, CodeRabbitPoll::Waiting);
+    }
+
+    #[test]
+    fn coderabbit_comment_completes_poll() {
+        let result = interpret_issue_comments(&[issue_comment("CodeRabbitAI", "Looks good to me")]);
+        assert_eq!(result, CodeRabbitPoll::Completed);
     }
 }

--- a/apps/agentic-outer-dag/src/github/coderabbit.rs
+++ b/apps/agentic-outer-dag/src/github/coderabbit.rs
@@ -83,6 +83,13 @@ fn interpret_issue_comments(comments: &[IssueCommentSummary]) -> CodeRabbitPoll 
     CodeRabbitPoll::Waiting
 }
 
+pub fn skip_reason_indicates_draft(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    reason.contains("draft detected")
+        || reason.contains("draft pull request")
+        || reason.contains("pr is draft")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,5 +161,18 @@ mod tests {
     fn coderabbit_comment_completes_poll() {
         let result = interpret_issue_comments(&[issue_comment("CodeRabbitAI", "Looks good to me")]);
         assert_eq!(result, CodeRabbitPoll::Completed);
+    }
+
+    #[test]
+    fn detects_draft_skip_reason_variants() {
+        assert!(skip_reason_indicates_draft(
+            "Review skipped. Draft detected."
+        ));
+        assert!(skip_reason_indicates_draft(
+            "review skipped because PR is draft"
+        ));
+        assert!(!skip_reason_indicates_draft(
+            "Review skipped because no actionable changes were found"
+        ));
     }
 }

--- a/apps/agentic-outer-dag/src/github/coderabbit.rs
+++ b/apps/agentic-outer-dag/src/github/coderabbit.rs
@@ -115,6 +115,20 @@ mod tests {
         }
     }
 
+    fn check_suite(
+        status: &str,
+        conclusion: Option<&str>,
+        app_slug: Option<&str>,
+    ) -> CheckSuiteSummary {
+        CheckSuiteSummary {
+            id: 1,
+            status: status.to_string(),
+            conclusion: conclusion.map(str::to_string),
+            app_slug: app_slug.map(str::to_string),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
     #[test]
     fn matches_coderabbit_logins_case_insensitively() {
         for login in [
@@ -132,6 +146,48 @@ mod tests {
         for login in ["dependabot[bot]", "renovate[bot]"] {
             assert!(!is_coderabbit_login(login), "unexpected match for {login}");
         }
+    }
+
+    #[test]
+    fn interpret_check_suites_returns_none_without_coderabbit_suite() {
+        assert_eq!(
+            interpret_check_suites(&[check_suite("queued", None, Some("github-actions"))]),
+            None
+        );
+    }
+
+    #[test]
+    fn interpret_check_suites_treats_queued_and_in_progress_as_waiting() {
+        for status in ["queued", "in_progress"] {
+            assert_eq!(
+                interpret_check_suites(&[check_suite(status, None, Some("coderabbitai"))]),
+                Some(CodeRabbitPoll::Waiting)
+            );
+        }
+    }
+
+    #[test]
+    fn interpret_check_suites_treats_completed_success_as_completed() {
+        assert_eq!(
+            interpret_check_suites(&[check_suite(
+                "completed",
+                Some("success"),
+                Some("coderabbitai")
+            )]),
+            Some(CodeRabbitPoll::Completed)
+        );
+    }
+
+    #[test]
+    fn interpret_check_suites_keeps_completed_non_success_as_completed_for_current_policy() {
+        assert_eq!(
+            interpret_check_suites(&[check_suite(
+                "completed",
+                Some("failure"),
+                Some("coderabbitai")
+            )]),
+            Some(CodeRabbitPoll::Completed)
+        );
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/github/coderabbit.rs
+++ b/apps/agentic-outer-dag/src/github/coderabbit.rs
@@ -24,20 +24,25 @@ impl CodeRabbitClient {
 
     pub async fn poll_once(&self, pr_number: u64, head_sha: &str) -> Result<CodeRabbitPoll> {
         let suites = self.pr_comments.list_check_suites_for_ref(head_sha).await?;
-        if let Some(outcome) = interpret_check_suites(&suites) {
-            return Ok(outcome);
+        let suites_outcome = interpret_check_suites(&suites);
+        if matches!(suites_outcome, Some(CodeRabbitPoll::Completed)) {
+            return Ok(CodeRabbitPoll::Completed);
         }
 
         let reviews = self
             .pr_comments
             .list_pull_request_reviews(pr_number)
             .await?;
-        if has_coderabbit_review(&reviews) {
+        if has_coderabbit_review_for_head(&reviews, head_sha) {
             return Ok(CodeRabbitPoll::Completed);
         }
 
         let comments = self.pr_comments.list_issue_comments(pr_number).await?;
-        Ok(interpret_issue_comments(&comments))
+        if let Some(reason) = interpret_issue_comments_for_skip(&comments) {
+            return Ok(CodeRabbitPoll::Skipped { reason });
+        }
+
+        Ok(suites_outcome.unwrap_or(CodeRabbitPoll::Waiting))
     }
 }
 
@@ -56,31 +61,26 @@ fn interpret_check_suites(suites: &[CheckSuiteSummary]) -> Option<CodeRabbitPoll
     }
 }
 
-fn has_coderabbit_review(reviews: &[PullRequestReviewSummary]) -> bool {
-    reviews
-        .iter()
-        .any(|review| is_coderabbit_login(&review.user_login))
+fn has_coderabbit_review_for_head(reviews: &[PullRequestReviewSummary], head_sha: &str) -> bool {
+    reviews.iter().any(|review| {
+        is_coderabbit_login(&review.user_login) && review.commit_id.as_deref() == Some(head_sha)
+    })
 }
 
 fn is_coderabbit_login(login: &str) -> bool {
     login.to_ascii_lowercase().contains("coderabbit")
 }
 
-fn interpret_issue_comments(comments: &[IssueCommentSummary]) -> CodeRabbitPoll {
+fn interpret_issue_comments_for_skip(comments: &[IssueCommentSummary]) -> Option<String> {
     for comment in comments {
         let body = comment.body.to_ascii_lowercase();
         let is_coderabbit = is_coderabbit_login(&comment.user_login);
         if is_coderabbit && body.contains("review skipped") {
-            return CodeRabbitPoll::Skipped {
-                reason: comment.body.clone(),
-            };
-        }
-        if is_coderabbit {
-            return CodeRabbitPoll::Completed;
+            return Some(comment.body.clone());
         }
     }
 
-    CodeRabbitPoll::Waiting
+    None
 }
 
 pub fn skip_reason_indicates_draft(reason: &str) -> bool {
@@ -104,13 +104,14 @@ mod tests {
         }
     }
 
-    fn review(user_login: &str) -> PullRequestReviewSummary {
+    fn review(user_login: &str, commit_id: Option<&str>) -> PullRequestReviewSummary {
         PullRequestReviewSummary {
             id: 1,
             user_login: user_login.to_string(),
             user_type: Some("Bot".to_string()),
             state: "COMMENTED".to_string(),
             submitted_at: Some("2026-01-01T00:00:00Z".to_string()),
+            commit_id: commit_id.map(str::to_string),
         }
     }
 
@@ -134,33 +135,51 @@ mod tests {
     }
 
     #[test]
-    fn coderabbit_review_detection_requires_coderabbit_login() {
-        assert!(has_coderabbit_review(&[review("coderabbitai[bot]")]));
-        assert!(!has_coderabbit_review(&[review("dependabot[bot]")]));
+    fn coderabbit_review_completion_requires_matching_head_sha() {
+        assert!(has_coderabbit_review_for_head(
+            &[review("coderabbitai[bot]", Some("abc123"))],
+            "abc123"
+        ));
+        assert!(!has_coderabbit_review_for_head(
+            &[review("coderabbitai[bot]", Some("deadbeef"))],
+            "abc123"
+        ));
+        assert!(!has_coderabbit_review_for_head(
+            &[review("dependabot[bot]", Some("abc123"))],
+            "abc123"
+        ));
+        assert!(!has_coderabbit_review_for_head(
+            &[review("coderabbitai[bot]", None)],
+            "abc123"
+        ));
     }
 
     #[test]
     fn detects_skipped_comment() {
-        let result = interpret_issue_comments(&[issue_comment(
+        let result = interpret_issue_comments_for_skip(&[issue_comment(
             "coderabbitai[bot]",
             "Review skipped because no actionable changes were found",
         )]);
-        assert!(matches!(result, CodeRabbitPoll::Skipped { .. }));
+        assert_eq!(
+            result.as_deref(),
+            Some("Review skipped because no actionable changes were found")
+        );
     }
 
     #[test]
     fn unrelated_bot_comment_does_not_complete_poll() {
-        let result = interpret_issue_comments(&[issue_comment(
+        let result = interpret_issue_comments_for_skip(&[issue_comment(
             "dependabot[bot]",
             "Review skipped because no actionable changes were found",
         )]);
-        assert_eq!(result, CodeRabbitPoll::Waiting);
+        assert!(result.is_none());
     }
 
     #[test]
-    fn coderabbit_comment_completes_poll() {
-        let result = interpret_issue_comments(&[issue_comment("CodeRabbitAI", "Looks good to me")]);
-        assert_eq!(result, CodeRabbitPoll::Completed);
+    fn coderabbit_issue_comment_does_not_complete_without_skip_phrase() {
+        let result =
+            interpret_issue_comments_for_skip(&[issue_comment("CodeRabbitAI", "Looks good to me")]);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/github/mod.rs
+++ b/apps/agentic-outer-dag/src/github/mod.rs
@@ -1,0 +1,2 @@
+pub mod coderabbit;
+pub mod pr;

--- a/apps/agentic-outer-dag/src/github/pr.rs
+++ b/apps/agentic-outer-dag/src/github/pr.rs
@@ -1,19 +1,104 @@
 use anyhow::Result;
+use git2::Repository;
 use pr_comments::PrComments;
 use pr_comments::models::PrRef;
 
 pub struct GitHubPrClient {
     pr_comments: PrComments,
+    repo_context: RepoContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedPrLookup {
+    pub requested_branch: String,
+    pub current_branch: Option<String>,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub pr: Option<PrRef>,
+}
+
+#[derive(Debug, Clone)]
+struct RepoContext {
+    owner: String,
+    repo: String,
+    current_branch: Option<String>,
 }
 
 impl GitHubPrClient {
     pub fn new() -> Result<Self> {
         Ok(Self {
             pr_comments: PrComments::new()?,
+            repo_context: RepoContext::from_current_dir()?,
         })
     }
 
-    pub async fn detect_open_pr_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
-        self.pr_comments.get_open_pr_ref_from_branch(branch).await
+    pub async fn detect_open_pr_from_branch(&self, branch: &str) -> Result<DetectedPrLookup> {
+        Ok(DetectedPrLookup {
+            requested_branch: branch.to_string(),
+            current_branch: self.repo_context.current_branch.clone(),
+            repo_owner: self.repo_context.owner.clone(),
+            repo_name: self.repo_context.repo.clone(),
+            pr: self.pr_comments.get_open_pr_ref_from_branch(branch).await?,
+        })
+    }
+}
+
+impl RepoContext {
+    fn from_current_dir() -> Result<Self> {
+        let repo = Repository::discover(".")?;
+        let remote = repo.find_remote("origin")?;
+        let url = remote
+            .url()
+            .ok_or_else(|| anyhow::anyhow!("Remote 'origin' has no URL"))?;
+        let (owner, repo_name) = parse_github_remote(url)?;
+        let current_branch = repo
+            .head()
+            .ok()
+            .and_then(|head| head.shorthand().map(String::from));
+
+        Ok(Self {
+            owner,
+            repo: repo_name,
+            current_branch,
+        })
+    }
+}
+
+fn parse_github_remote(url: &str) -> Result<(String, String)> {
+    if let Some(path) = url.strip_prefix("git@github.com:") {
+        return parse_repo_path(path);
+    }
+
+    if let Some(path) = url.strip_prefix("https://github.com/") {
+        return parse_repo_path(path);
+    }
+
+    anyhow::bail!("Not a supported GitHub remote URL: {url}");
+}
+
+fn parse_repo_path(path: &str) -> Result<(String, String)> {
+    let trimmed = path.trim_end_matches(".git");
+    let mut parts = trimmed.split('/');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(owner), Some(repo), None) => Ok((owner.to_string(), repo.to_string())),
+        _ => anyhow::bail!("Invalid GitHub repository path: {trimmed}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_github_remote;
+
+    #[test]
+    fn parse_github_remote_supports_https_and_ssh() {
+        assert_eq!(
+            parse_github_remote("https://github.com/owner/repo.git")
+                .expect("https remote should parse"),
+            ("owner".to_string(), "repo".to_string())
+        );
+        assert_eq!(
+            parse_github_remote("git@github.com:owner/repo").expect("ssh remote should parse"),
+            ("owner".to_string(), "repo".to_string())
+        );
     }
 }

--- a/apps/agentic-outer-dag/src/github/pr.rs
+++ b/apps/agentic-outer-dag/src/github/pr.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use pr_comments::PrComments;
+use pr_comments::models::PrRef;
+
+pub struct GitHubPrClient {
+    pr_comments: PrComments,
+}
+
+impl GitHubPrClient {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            pr_comments: PrComments::new()?,
+        })
+    }
+
+    pub async fn detect_open_pr_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+        self.pr_comments.get_open_pr_ref_from_branch(branch).await
+    }
+}

--- a/apps/agentic-outer-dag/src/github/pr.rs
+++ b/apps/agentic-outer-dag/src/github/pr.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use git2::Repository;
 use pr_comments::PrComments;
+use pr_comments::git;
 use pr_comments::models::PrRef;
 
 pub struct GitHubPrClient {
@@ -14,6 +14,8 @@ pub struct DetectedPrLookup {
     pub current_branch: Option<String>,
     pub repo_owner: String,
     pub repo_name: String,
+    pub token_source: Option<String>,
+    pub empty_result_reason: Option<String>,
     pub pr: Option<PrRef>,
 }
 
@@ -26,79 +28,42 @@ struct RepoContext {
 
 impl GitHubPrClient {
     pub fn new() -> Result<Self> {
+        let repo_context = RepoContext::from_current_dir()?;
         Ok(Self {
-            pr_comments: PrComments::new()?,
-            repo_context: RepoContext::from_current_dir()?,
+            pr_comments: PrComments::with_repo(
+                repo_context.owner.clone(),
+                repo_context.repo.clone(),
+            ),
+            repo_context,
         })
     }
 
     pub async fn detect_open_pr_from_branch(&self, branch: &str) -> Result<DetectedPrLookup> {
+        let lookup = self
+            .pr_comments
+            .get_open_pr_ref_from_branch_detailed(branch)
+            .await?;
+
         Ok(DetectedPrLookup {
             requested_branch: branch.to_string(),
             current_branch: self.repo_context.current_branch.clone(),
             repo_owner: self.repo_context.owner.clone(),
             repo_name: self.repo_context.repo.clone(),
-            pr: self.pr_comments.get_open_pr_ref_from_branch(branch).await?,
+            token_source: self.pr_comments.token_source_label().map(str::to_string),
+            empty_result_reason: lookup.empty_result_reason,
+            pr: lookup.pr,
         })
     }
 }
 
 impl RepoContext {
     fn from_current_dir() -> Result<Self> {
-        let repo = Repository::discover(".")?;
-        let remote = repo.find_remote("origin")?;
-        let url = remote
-            .url()
-            .ok_or_else(|| anyhow::anyhow!("Remote 'origin' has no URL"))?;
-        let (owner, repo_name) = parse_github_remote(url)?;
-        let current_branch = repo
-            .head()
-            .ok()
-            .and_then(|head| head.shorthand().map(String::from));
+        let git_info = git::get_git_info()?;
 
         Ok(Self {
-            owner,
-            repo: repo_name,
-            current_branch,
+            owner: git_info.owner,
+            repo: git_info.repo,
+            current_branch: git_info.current_branch,
         })
-    }
-}
-
-fn parse_github_remote(url: &str) -> Result<(String, String)> {
-    if let Some(path) = url.strip_prefix("git@github.com:") {
-        return parse_repo_path(path);
-    }
-
-    if let Some(path) = url.strip_prefix("https://github.com/") {
-        return parse_repo_path(path);
-    }
-
-    anyhow::bail!("Not a supported GitHub remote URL: {url}");
-}
-
-fn parse_repo_path(path: &str) -> Result<(String, String)> {
-    let trimmed = path.trim_end_matches(".git");
-    let mut parts = trimmed.split('/');
-    match (parts.next(), parts.next(), parts.next()) {
-        (Some(owner), Some(repo), None) => Ok((owner.to_string(), repo.to_string())),
-        _ => anyhow::bail!("Invalid GitHub repository path: {trimmed}"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_github_remote;
-
-    #[test]
-    fn parse_github_remote_supports_https_and_ssh() {
-        assert_eq!(
-            parse_github_remote("https://github.com/owner/repo.git")
-                .expect("https remote should parse"),
-            ("owner".to_string(), "repo".to_string())
-        );
-        assert_eq!(
-            parse_github_remote("git@github.com:owner/repo").expect("ssh remote should parse"),
-            ("owner".to_string(), "repo".to_string())
-        );
     }
 }

--- a/apps/agentic-outer-dag/src/github/pr.rs
+++ b/apps/agentic-outer-dag/src/github/pr.rs
@@ -54,6 +54,10 @@ impl GitHubPrClient {
             pr: lookup.pr,
         })
     }
+
+    pub async fn mark_ready_for_review(&self, pr: &PrRef) -> Result<PrRef> {
+        self.pr_comments.mark_pr_ready_for_review(&pr.node_id).await
+    }
 }
 
 impl RepoContext {

--- a/apps/agentic-outer-dag/src/linear/mod.rs
+++ b/apps/agentic-outer-dag/src/linear/mod.rs
@@ -1,0 +1,55 @@
+use crate::state::RunState;
+use anyhow::Result;
+use linear_tools::LinearTools;
+use sha2::Digest;
+use sha2::Sha256;
+
+pub async fn post_handoff_once(state: &mut RunState, message: &str) -> Result<()> {
+    let digest = handoff_digest(message);
+    if should_skip_handoff(state, &digest) {
+        return Ok(());
+    }
+
+    let tools = LinearTools::new();
+    tools
+        .add_comment(state.ticket.linear_key.clone(), message.to_string(), None)
+        .await?;
+    state.handoff.linear_comment_posted = true;
+    state.handoff.linear_comment_body_sha256 = Some(digest);
+    state.handoff.posted_at = Some(chrono::Utc::now().to_rfc3339());
+    Ok(())
+}
+
+fn handoff_digest(message: &str) -> String {
+    format!("{:x}", Sha256::digest(message.as_bytes()))
+}
+
+fn should_skip_handoff(state: &RunState, digest: &str) -> bool {
+    state.handoff.linear_comment_posted
+        && state.handoff.linear_comment_body_sha256.as_deref() == Some(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handoff_skips_when_same_digest_was_already_posted() {
+        let digest = handoff_digest("same");
+        let mut state = crate::state::RunState::for_start(
+            "ENG-992",
+            &crate::worktree::TargetWorktree {
+                path: std::env::current_dir().unwrap(),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            true,
+        )
+        .unwrap();
+        state.handoff.linear_comment_posted = true;
+        state.handoff.linear_comment_body_sha256 = Some(digest.clone());
+
+        assert!(should_skip_handoff(&state, &digest));
+        assert!(!should_skip_handoff(&state, &handoff_digest("different")));
+    }
+}

--- a/apps/agentic-outer-dag/src/linear/mod.rs
+++ b/apps/agentic-outer-dag/src/linear/mod.rs
@@ -5,6 +5,18 @@ use sha2::Digest;
 use sha2::Sha256;
 
 pub async fn post_handoff_once(state: &mut RunState, message: &str) -> Result<()> {
+    if !state.settings.linear_handoff_enabled {
+        return Ok(());
+    }
+
+    post_handoff_once_unchecked(state, message).await
+}
+
+pub async fn post_handoff_once_forced(state: &mut RunState, message: &str) -> Result<()> {
+    post_handoff_once_unchecked(state, message).await
+}
+
+async fn post_handoff_once_unchecked(state: &mut RunState, message: &str) -> Result<()> {
     let digest = handoff_digest(message);
     if should_skip_handoff(state, &digest) {
         return Ok(());
@@ -51,5 +63,28 @@ mod tests {
 
         assert!(should_skip_handoff(&state, &digest));
         assert!(!should_skip_handoff(&state, &handoff_digest("different")));
+    }
+
+    #[tokio::test]
+    async fn handoff_is_suppressed_when_disabled_in_settings() {
+        let mut state = crate::state::RunState::for_start(
+            "ENG-992",
+            &crate::worktree::TargetWorktree {
+                path: std::env::current_dir().unwrap(),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            true,
+        )
+        .unwrap();
+        state.settings.linear_handoff_enabled = false;
+
+        post_handoff_once(&mut state, "suppressed during safety test")
+            .await
+            .unwrap();
+
+        assert!(!state.handoff.linear_comment_posted);
+        assert!(state.handoff.linear_comment_body_sha256.is_none());
+        assert!(state.handoff.posted_at.is_none());
     }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -18,6 +18,24 @@ mod preview;
 mod state;
 mod worktree;
 
+struct StartOptions<'a> {
+    branch: Option<&'a str>,
+    worktree_path: Option<&'a Path>,
+    dry_run: bool,
+    force: bool,
+    no_linear_handoff: bool,
+    no_opencode_dispatch: bool,
+    stop_after: Option<state::StageKind>,
+}
+
+struct ResumeOptions<'a> {
+    branch: Option<&'a str>,
+    worktree_path: Option<&'a Path>,
+    no_linear_handoff: bool,
+    no_opencode_dispatch: bool,
+    stop_after: Option<state::StageKind>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Install the rustls CryptoProvider before any HTTP clients are created.
@@ -64,16 +82,20 @@ async fn main() -> Result<()> {
             worktree,
             force,
             no_linear_handoff,
+            no_opencode_dispatch,
             stop_after,
         } => {
             handle_start(
                 &ticket,
-                branch.as_deref(),
-                worktree.as_deref(),
-                dry_run,
-                force,
-                no_linear_handoff,
-                stop_after,
+                StartOptions {
+                    branch: branch.as_deref(),
+                    worktree_path: worktree.as_deref(),
+                    dry_run,
+                    force,
+                    no_linear_handoff,
+                    no_opencode_dispatch,
+                    stop_after,
+                },
             )
             .await
         }
@@ -81,14 +103,16 @@ async fn main() -> Result<()> {
             branch,
             worktree,
             no_linear_handoff,
+            no_opencode_dispatch,
             stop_after,
         } => {
-            handle_resume(
-                branch.as_deref(),
-                worktree.as_deref(),
+            handle_resume(ResumeOptions {
+                branch: branch.as_deref(),
+                worktree_path: worktree.as_deref(),
                 no_linear_handoff,
+                no_opencode_dispatch,
                 stop_after,
-            )
+            })
             .await
         }
         cli::Commands::Status { json } => handle_status(json),
@@ -101,59 +125,57 @@ async fn main() -> Result<()> {
     }
 }
 
-async fn handle_start(
-    ticket: &str,
-    branch: Option<&str>,
-    worktree_path: Option<&Path>,
-    dry_run: bool,
-    force: bool,
-    no_linear_handoff: bool,
-    stop_after: Option<state::StageKind>,
-) -> Result<()> {
-    if dry_run {
-        let plan = preview::build_dry_run_start_preview(ticket, branch, worktree_path, force)?;
+async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
+    if options.dry_run {
+        let plan = preview::build_dry_run_start_preview(
+            ticket,
+            options.branch,
+            options.worktree_path,
+            options.force,
+        )?;
         println!("{}", serde_json::to_string_pretty(&plan)?);
         return Ok(());
     }
 
-    let target = worktree::resolve(branch, worktree_path, true)?;
+    let target = worktree::resolve(options.branch, options.worktree_path, true)?;
     worktree::chdir_to(&target)?;
 
-    if state::store::ThoughtsStateStore::load()?.is_some() && !force {
+    if state::store::ThoughtsStateStore::load()?.is_some() && !options.force {
         anyhow::bail!(
             "state file already exists for branch '{}'; rerun with --force to overwrite",
             target.branch
         );
     }
 
-    let mut state = state::RunState::for_start(ticket, &target, dry_run)?;
-    state.settings.linear_handoff_enabled = !no_linear_handoff;
+    let mut state = state::RunState::for_start(ticket, &target, options.dry_run)?;
+    state.settings.linear_handoff_enabled = !options.no_linear_handoff;
+    state.settings.opencode_dispatch_enabled = !options.no_opencode_dispatch;
     state::store::ThoughtsStateStore::save(&state)?;
 
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(stop_after).await?;
+    engine.run_until_stop(options.stop_after).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after start"))?;
     print_status(&state, false)
 }
 
-async fn handle_resume(
-    branch: Option<&str>,
-    worktree_path: Option<&Path>,
-    no_linear_handoff: bool,
-    stop_after: Option<state::StageKind>,
-) -> Result<()> {
-    let target = worktree::resolve(branch, worktree_path, false)?;
+async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
+    let target = worktree::resolve(options.branch, options.worktree_path, false)?;
     worktree::chdir_to(&target)?;
 
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
-    if no_linear_handoff {
+    if options.no_linear_handoff {
         state.settings.linear_handoff_enabled = false;
+    }
+    if options.no_opencode_dispatch {
+        state.settings.opencode_dispatch_enabled = false;
+    }
+    if options.no_linear_handoff || options.no_opencode_dispatch {
         state::store::ThoughtsStateStore::save(&state)?;
     }
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(stop_after).await?;
+    engine.run_until_stop(options.stop_after).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after resume"))?;
     print_status(&state, false)
@@ -196,9 +218,11 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
         "opencode_last_command": state.opencode.last_command,
         "ticket_to_pr_runs": state.counters.ticket_to_pr_runs,
         "resolve_comments_runs": state.counters.resolve_comments_runs,
+        "opencode_dispatch_enabled": state.settings.opencode_dispatch_enabled,
         "linear_handoff_enabled": state.settings.linear_handoff_enabled,
         "linear_handoff_posted": state.handoff.linear_comment_posted,
         "linear_handoff_posted_at": state.handoff.posted_at,
+        "pr_lookup": state.pr.last_lookup,
         "run_id": state.run_id,
         "updated_at": state.updated_at,
     })
@@ -334,6 +358,16 @@ mod tests {
         state.opencode.last_command = Some("linear_ticket_2_pr".to_string());
         state.counters.ticket_to_pr_runs = 1;
         state.counters.resolve_comments_runs = 0;
+        state.settings.opencode_dispatch_enabled = false;
+        state.pr.last_lookup = Some(state::PrLookupDiagnostics {
+            checked_at: "2026-01-01T00:00:00Z".to_string(),
+            stage: state::StageKind::DispatchingTicketToPr,
+            requested_branch: "feature/eng-992".to_string(),
+            current_branch: Some("feature/eng-992".to_string()),
+            repo_owner: "allisoneer".to_string(),
+            repo_name: "agentic_auxilary".to_string(),
+            outcome: "not_found".to_string(),
+        });
         state.handoff.linear_comment_posted = false;
         state
     }
@@ -363,9 +397,11 @@ mod tests {
             "opencode_last_command",
             "ticket_to_pr_runs",
             "resolve_comments_runs",
+            "opencode_dispatch_enabled",
             "linear_handoff_enabled",
             "linear_handoff_posted",
             "linear_handoff_posted_at",
+            "pr_lookup",
             "run_id",
             "updated_at",
         ] {
@@ -402,12 +438,22 @@ mod tests {
         );
         assert_eq!(payload.get("worktree_exists"), Some(&Value::Bool(false)));
         assert_eq!(
+            payload.get("opencode_dispatch_enabled"),
+            Some(&Value::Bool(false))
+        );
+        assert_eq!(
             payload.get("linear_handoff_enabled"),
             Some(&Value::Bool(true))
         );
         assert_eq!(
             payload.get("pr_number"),
             Some(&Value::Number(258_u64.into()))
+        );
+        assert_eq!(
+            payload
+                .get("pr_lookup")
+                .and_then(|lookup| lookup.get("repo_owner")),
+            Some(&Value::String("allisoneer".to_string()))
         );
     }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -280,6 +280,7 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
         "pr_url": state.pr.url,
         "opencode_session_id": state.opencode.active_session_id,
         "opencode_last_command": state.opencode.last_command,
+        "opencode_last_diagnostics": state.opencode.last_diagnostics,
         "ticket_to_pr_runs": state.counters.ticket_to_pr_runs,
         "resolve_comments_runs": state.counters.resolve_comments_runs,
         "opencode_dispatch_enabled": state.settings.opencode_dispatch_enabled,
@@ -422,6 +423,17 @@ mod tests {
         state.pr.url = Some("https://example.invalid/pr/258".to_string());
         state.opencode.active_session_id = Some("session-123".to_string());
         state.opencode.last_command = Some("linear_ticket_2_pr".to_string());
+        state.opencode.last_diagnostics = Some(state::OpenCodeDiagnostics {
+            checked_at: "2026-01-01T00:00:00Z".to_string(),
+            command_message_id: Some("msg-outer-dag-1".to_string()),
+            final_assistant_message_id: Some("msg-assistant-1".to_string()),
+            final_finish_reason: Some("stop".to_string()),
+            guard_detected: true,
+            final_tool_error: Some(state::OpenCodeToolErrorDiagnostics {
+                tool: "read".to_string(),
+                error: "nested guard tripped".to_string(),
+            }),
+        });
         state.counters.ticket_to_pr_runs = 1;
         state.counters.resolve_comments_runs = 0;
         state.settings.opencode_dispatch_enabled = false;
@@ -463,6 +475,7 @@ mod tests {
             "pr_url",
             "opencode_session_id",
             "opencode_last_command",
+            "opencode_last_diagnostics",
             "ticket_to_pr_runs",
             "resolve_comments_runs",
             "opencode_dispatch_enabled",
@@ -522,6 +535,12 @@ mod tests {
                 .get("pr_lookup")
                 .and_then(|lookup| lookup.get("repo_owner")),
             Some(&Value::String("allisoneer".to_string()))
+        );
+        assert_eq!(
+            payload
+                .get("opencode_last_diagnostics")
+                .and_then(|diagnostics| diagnostics.get("guard_detected")),
+            Some(&Value::Bool(true))
         );
     }
 

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -366,6 +366,8 @@ mod tests {
             current_branch: Some("feature/eng-992".to_string()),
             repo_owner: "allisoneer".to_string(),
             repo_name: "agentic_auxilary".to_string(),
+            token_source: Some("GH_TOKEN".to_string()),
+            empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
             outcome: "not_found".to_string(),
         });
         state.handoff.linear_comment_posted = false;

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -63,6 +63,8 @@ async fn main() -> Result<()> {
             branch,
             worktree,
             force,
+            no_linear_handoff,
+            stop_after,
         } => {
             handle_start(
                 &ticket,
@@ -70,11 +72,24 @@ async fn main() -> Result<()> {
                 worktree.as_deref(),
                 dry_run,
                 force,
+                no_linear_handoff,
+                stop_after,
             )
             .await
         }
-        cli::Commands::Resume { branch, worktree } => {
-            handle_resume(branch.as_deref(), worktree.as_deref()).await
+        cli::Commands::Resume {
+            branch,
+            worktree,
+            no_linear_handoff,
+            stop_after,
+        } => {
+            handle_resume(
+                branch.as_deref(),
+                worktree.as_deref(),
+                no_linear_handoff,
+                stop_after,
+            )
+            .await
         }
         cli::Commands::Status { json } => handle_status(json),
         cli::Commands::RespondPermission { allow, deny } => {
@@ -92,6 +107,8 @@ async fn handle_start(
     worktree_path: Option<&Path>,
     dry_run: bool,
     force: bool,
+    no_linear_handoff: bool,
+    stop_after: Option<state::StageKind>,
 ) -> Result<()> {
     if dry_run {
         let plan = preview::build_dry_run_start_preview(ticket, branch, worktree_path, force)?;
@@ -109,24 +126,34 @@ async fn handle_start(
         );
     }
 
-    let state = state::RunState::for_start(ticket, &target, dry_run)?;
+    let mut state = state::RunState::for_start(ticket, &target, dry_run)?;
+    state.settings.linear_handoff_enabled = !no_linear_handoff;
     state::store::ThoughtsStateStore::save(&state)?;
 
-    let engine = dag::engine::DagEngine::for_current_dir().await?;
-    engine.run_until_stop().await?;
+    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    engine.run_until_stop(stop_after).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after start"))?;
     print_status(&state, false)
 }
 
-async fn handle_resume(branch: Option<&str>, worktree_path: Option<&Path>) -> Result<()> {
+async fn handle_resume(
+    branch: Option<&str>,
+    worktree_path: Option<&Path>,
+    no_linear_handoff: bool,
+    stop_after: Option<state::StageKind>,
+) -> Result<()> {
     let target = worktree::resolve(branch, worktree_path, false)?;
     worktree::chdir_to(&target)?;
 
-    state::store::ThoughtsStateStore::load()?
+    let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
-    let engine = dag::engine::DagEngine::for_current_dir().await?;
-    engine.run_until_stop().await?;
+    if no_linear_handoff {
+        state.settings.linear_handoff_enabled = false;
+        state::store::ThoughtsStateStore::save(&state)?;
+    }
+    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    engine.run_until_stop(stop_after).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after resume"))?;
     print_status(&state, false)
@@ -144,17 +171,37 @@ fn print_status(state: &state::RunState, as_json: bool) -> Result<()> {
     } else {
         println!(
             "{}",
-            serde_json::to_string_pretty(&json!({
-                "ticket": state.ticket.linear_key,
-                "branch": state.worktree.branch,
-                "worktree": state.worktree.path,
-                "stage": state.stage.kind,
-                "state_file": format!("./thoughts/{}/artifacts/{}", state.worktree.branch, state::STATE_FILENAME),
-            }))?
+            serde_json::to_string_pretty(&compact_status_payload(state))?
         );
     }
 
     Ok(())
+}
+
+fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
+    let worktree_exists = Path::new(&state.worktree.path).exists();
+
+    json!({
+        "ticket": state.ticket.linear_key,
+        "branch": state.worktree.branch,
+        "worktree": state.worktree.path,
+        "stage": state.stage.kind,
+        "state_file": format!("./thoughts/{}/artifacts/{}", state.worktree.branch, state::STATE_FILENAME),
+        "stage_details": state.stage.details,
+        "last_error": state.last_error,
+        "worktree_exists": worktree_exists,
+        "pr_number": state.pr.number,
+        "pr_url": state.pr.url,
+        "opencode_session_id": state.opencode.active_session_id,
+        "opencode_last_command": state.opencode.last_command,
+        "ticket_to_pr_runs": state.counters.ticket_to_pr_runs,
+        "resolve_comments_runs": state.counters.resolve_comments_runs,
+        "linear_handoff_enabled": state.settings.linear_handoff_enabled,
+        "linear_handoff_posted": state.handoff.linear_comment_posted,
+        "linear_handoff_posted_at": state.handoff.posted_at,
+        "run_id": state.run_id,
+        "updated_at": state.updated_at,
+    })
 }
 
 async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
@@ -194,8 +241,8 @@ async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
     state.stage.details = None;
     state::store::ThoughtsStateStore::save(&state)?;
 
-    let engine = dag::engine::DagEngine::for_current_dir().await?;
-    engine.run_until_stop().await?;
+    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    engine.run_until_stop(None).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
     print_status(&state, false)
@@ -234,8 +281,8 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
     state.stage.details = None;
     state::store::ThoughtsStateStore::save(&state)?;
 
-    let engine = dag::engine::DagEngine::for_current_dir().await?;
-    engine.run_until_stop().await?;
+    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    engine.run_until_stop(None).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
     print_status(&state, false)
@@ -245,7 +292,7 @@ async fn handle_handoff(message: Option<&str>) -> Result<()> {
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
     let body = message.unwrap_or("manual handoff requested from agentic-outer-dag");
-    linear::post_handoff_once(&mut state, body).await?;
+    linear::post_handoff_once_forced(&mut state, body).await?;
     state.stage.kind = state::StageKind::StoppedManualHandoff;
     state.stage.details = Some(body.to_string());
     state::store::ThoughtsStateStore::save(&state)?;
@@ -257,4 +304,110 @@ fn handle_reset(yes: bool) -> Result<()> {
     state::store::ThoughtsStateStore::delete()?;
     println!("state reset");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_status_payload;
+    use super::state;
+    use crate::worktree::TargetWorktree;
+    use serde_json::Value;
+
+    fn sample_state() -> state::RunState {
+        let mut state = state::RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().expect("cwd available for test"),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            false,
+        )
+        .expect("sample state builds");
+
+        state.stage.kind = state::StageKind::StoppedFailed;
+        state.stage.details = Some("detailed failure".to_string());
+        state.last_error = Some("detailed failure".to_string());
+        state.pr.number = Some(258);
+        state.pr.url = Some("https://example.invalid/pr/258".to_string());
+        state.opencode.active_session_id = Some("session-123".to_string());
+        state.opencode.last_command = Some("linear_ticket_2_pr".to_string());
+        state.counters.ticket_to_pr_runs = 1;
+        state.counters.resolve_comments_runs = 0;
+        state.handoff.linear_comment_posted = false;
+        state
+    }
+
+    #[test]
+    fn compact_status_payload_preserves_existing_fields_and_adds_diagnostics() {
+        let mut state = sample_state();
+        state.worktree.path = std::env::temp_dir()
+            .join(format!("missing-outer-dag-worktree-{}", std::process::id()))
+            .display()
+            .to_string();
+
+        let payload = compact_status_payload(&state);
+
+        for key in [
+            "ticket",
+            "branch",
+            "worktree",
+            "stage",
+            "state_file",
+            "stage_details",
+            "last_error",
+            "worktree_exists",
+            "pr_number",
+            "pr_url",
+            "opencode_session_id",
+            "opencode_last_command",
+            "ticket_to_pr_runs",
+            "resolve_comments_runs",
+            "linear_handoff_enabled",
+            "linear_handoff_posted",
+            "linear_handoff_posted_at",
+            "run_id",
+            "updated_at",
+        ] {
+            assert!(payload.get(key).is_some(), "missing key: {key}");
+        }
+
+        assert_eq!(
+            payload.get("ticket"),
+            Some(&Value::String("ENG-992".to_string()))
+        );
+        assert_eq!(
+            payload.get("branch"),
+            Some(&Value::String("feature/eng-992".to_string()))
+        );
+        assert_eq!(
+            payload.get("state_file"),
+            Some(&Value::String(format!(
+                "./thoughts/{}/artifacts/{}",
+                state.worktree.branch,
+                state::STATE_FILENAME
+            )))
+        );
+        assert_eq!(
+            payload.get("stage"),
+            Some(&Value::String("stopped_failed".to_string()))
+        );
+        assert_eq!(
+            payload.get("stage_details"),
+            Some(&Value::String("detailed failure".to_string()))
+        );
+        assert_eq!(
+            payload.get("last_error"),
+            Some(&Value::String("detailed failure".to_string()))
+        );
+        assert_eq!(payload.get("worktree_exists"), Some(&Value::Bool(false)));
+        assert_eq!(
+            payload.get("linear_handoff_enabled"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            payload.get("pr_number"),
+            Some(&Value::Number(258_u64.into()))
+        );
+    }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -26,6 +26,8 @@ struct StartOptions<'a> {
     no_linear_handoff: bool,
     no_opencode_dispatch: bool,
     stop_after: Option<state::StageKind>,
+    poll_interval_seconds: Option<u64>,
+    coderabbit_timeout_seconds: Option<u64>,
 }
 
 struct ResumeOptions<'a> {
@@ -34,6 +36,16 @@ struct ResumeOptions<'a> {
     no_linear_handoff: bool,
     no_opencode_dispatch: bool,
     stop_after: Option<state::StageKind>,
+    poll_interval_seconds: Option<u64>,
+    coderabbit_timeout_seconds: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SettingsOverrides {
+    linear_handoff_enabled: Option<bool>,
+    opencode_dispatch_enabled: Option<bool>,
+    poll_interval_seconds: Option<u64>,
+    coderabbit_timeout_seconds: Option<u64>,
 }
 
 #[tokio::main]
@@ -84,6 +96,8 @@ async fn main() -> Result<()> {
             no_linear_handoff,
             no_opencode_dispatch,
             stop_after,
+            poll_interval_seconds,
+            coderabbit_timeout_seconds,
         } => {
             handle_start(
                 &ticket,
@@ -95,6 +109,8 @@ async fn main() -> Result<()> {
                     no_linear_handoff,
                     no_opencode_dispatch,
                     stop_after,
+                    poll_interval_seconds,
+                    coderabbit_timeout_seconds,
                 },
             )
             .await
@@ -105,6 +121,8 @@ async fn main() -> Result<()> {
             no_linear_handoff,
             no_opencode_dispatch,
             stop_after,
+            poll_interval_seconds,
+            coderabbit_timeout_seconds,
         } => {
             handle_resume(ResumeOptions {
                 branch: branch.as_deref(),
@@ -112,6 +130,8 @@ async fn main() -> Result<()> {
                 no_linear_handoff,
                 no_opencode_dispatch,
                 stop_after,
+                poll_interval_seconds,
+                coderabbit_timeout_seconds,
             })
             .await
         }
@@ -123,6 +143,40 @@ async fn main() -> Result<()> {
         cli::Commands::Handoff { message } => handle_handoff(message.as_deref()).await,
         cli::Commands::Reset { yes } => handle_reset(yes),
     }
+}
+
+fn apply_settings_overrides(
+    settings: &mut state::Settings,
+    overrides: SettingsOverrides,
+) -> Result<bool> {
+    if let Some(poll_interval_seconds) = overrides.poll_interval_seconds {
+        anyhow::ensure!(
+            poll_interval_seconds > 0,
+            "poll interval must be at least 1 second"
+        );
+        settings.poll_interval_seconds = poll_interval_seconds;
+    }
+
+    if let Some(coderabbit_timeout_seconds) = overrides.coderabbit_timeout_seconds {
+        anyhow::ensure!(
+            coderabbit_timeout_seconds > 0,
+            "CodeRabbit timeout must be at least 1 second"
+        );
+        settings.coderabbit_timeout_seconds = coderabbit_timeout_seconds;
+    }
+
+    if let Some(linear_handoff_enabled) = overrides.linear_handoff_enabled {
+        settings.linear_handoff_enabled = linear_handoff_enabled;
+    }
+
+    if let Some(opencode_dispatch_enabled) = overrides.opencode_dispatch_enabled {
+        settings.opencode_dispatch_enabled = opencode_dispatch_enabled;
+    }
+
+    Ok(overrides.poll_interval_seconds.is_some()
+        || overrides.coderabbit_timeout_seconds.is_some()
+        || overrides.linear_handoff_enabled.is_some()
+        || overrides.opencode_dispatch_enabled.is_some())
 }
 
 async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
@@ -148,8 +202,15 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
     }
 
     let mut state = state::RunState::for_start(ticket, &target, options.dry_run)?;
-    state.settings.linear_handoff_enabled = !options.no_linear_handoff;
-    state.settings.opencode_dispatch_enabled = !options.no_opencode_dispatch;
+    apply_settings_overrides(
+        &mut state.settings,
+        SettingsOverrides {
+            linear_handoff_enabled: Some(!options.no_linear_handoff),
+            opencode_dispatch_enabled: Some(!options.no_opencode_dispatch),
+            poll_interval_seconds: options.poll_interval_seconds,
+            coderabbit_timeout_seconds: options.coderabbit_timeout_seconds,
+        },
+    )?;
     state::store::ThoughtsStateStore::save(&state)?;
 
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
@@ -165,13 +226,16 @@ async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
 
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
-    if options.no_linear_handoff {
-        state.settings.linear_handoff_enabled = false;
-    }
-    if options.no_opencode_dispatch {
-        state.settings.opencode_dispatch_enabled = false;
-    }
-    if options.no_linear_handoff || options.no_opencode_dispatch {
+    let settings_changed = apply_settings_overrides(
+        &mut state.settings,
+        SettingsOverrides {
+            linear_handoff_enabled: options.no_linear_handoff.then_some(false),
+            opencode_dispatch_enabled: options.no_opencode_dispatch.then_some(false),
+            poll_interval_seconds: options.poll_interval_seconds,
+            coderabbit_timeout_seconds: options.coderabbit_timeout_seconds,
+        },
+    )?;
+    if settings_changed {
         state::store::ThoughtsStateStore::save(&state)?;
     }
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
@@ -332,6 +396,8 @@ fn handle_reset(yes: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::SettingsOverrides;
+    use super::apply_settings_overrides;
     use super::compact_status_payload;
     use super::state;
     use crate::worktree::TargetWorktree;
@@ -456,6 +522,74 @@ mod tests {
                 .get("pr_lookup")
                 .and_then(|lookup| lookup.get("repo_owner")),
             Some(&Value::String("allisoneer".to_string()))
+        );
+    }
+
+    #[test]
+    fn apply_settings_overrides_updates_resume_relevant_fields() {
+        let mut state = sample_state();
+
+        let changed = apply_settings_overrides(
+            &mut state.settings,
+            SettingsOverrides {
+                linear_handoff_enabled: Some(false),
+                opencode_dispatch_enabled: Some(false),
+                poll_interval_seconds: Some(3),
+                coderabbit_timeout_seconds: Some(90),
+            },
+        )
+        .expect("overrides should apply");
+
+        assert!(changed);
+        assert!(!state.settings.linear_handoff_enabled);
+        assert!(!state.settings.opencode_dispatch_enabled);
+        assert_eq!(state.settings.poll_interval_seconds, 3);
+        assert_eq!(state.settings.coderabbit_timeout_seconds, 90);
+    }
+
+    #[test]
+    fn apply_settings_overrides_preserves_defaults_when_no_overrides_given() {
+        let mut state = sample_state();
+        let original = state.settings.clone();
+
+        let changed = apply_settings_overrides(&mut state.settings, SettingsOverrides::default())
+            .expect("empty overrides should succeed");
+
+        assert!(!changed);
+        assert_eq!(
+            state.settings.poll_interval_seconds,
+            original.poll_interval_seconds
+        );
+        assert_eq!(
+            state.settings.coderabbit_timeout_seconds,
+            original.coderabbit_timeout_seconds
+        );
+        assert_eq!(
+            state.settings.linear_handoff_enabled,
+            original.linear_handoff_enabled
+        );
+        assert_eq!(
+            state.settings.opencode_dispatch_enabled,
+            original.opencode_dispatch_enabled
+        );
+    }
+
+    #[test]
+    fn apply_settings_overrides_rejects_zero_poll_interval() {
+        let mut state = sample_state();
+
+        let err = apply_settings_overrides(
+            &mut state.settings,
+            SettingsOverrides {
+                poll_interval_seconds: Some(0),
+                ..SettingsOverrides::default()
+            },
+        )
+        .expect_err("zero poll interval should fail");
+
+        assert!(
+            err.to_string()
+                .contains("poll interval must be at least 1 second")
         );
     }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -14,6 +14,7 @@ mod dag;
 mod github;
 mod linear;
 mod opencode;
+mod preview;
 mod state;
 mod worktree;
 
@@ -90,6 +91,12 @@ async fn handle_start(
     dry_run: bool,
     force: bool,
 ) -> Result<()> {
+    if dry_run {
+        let plan = preview::build_dry_run_start_preview(ticket, branch, worktree_path, force)?;
+        println!("{}", serde_json::to_string_pretty(&plan)?);
+        return Ok(());
+    }
+
     let target = worktree::resolve(branch, worktree_path, true)?;
     worktree::chdir_to(&target)?;
 

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -16,6 +16,8 @@ mod linear;
 mod opencode;
 mod preview;
 mod state;
+#[cfg(test)]
+mod test_support;
 mod worktree;
 
 struct StartOptions<'a> {
@@ -54,6 +56,34 @@ struct SettingsOverrides {
     opencode_inactivity_timeout_seconds: Option<u64>,
 }
 
+fn ensure_supported_dry_run_usage(dry_run: bool, command: &cli::Commands) -> Result<()> {
+    if !dry_run {
+        return Ok(());
+    }
+
+    match command {
+        cli::Commands::Start { .. } | cli::Commands::Status { .. } => Ok(()),
+        _ => anyhow::bail!(
+            "--dry-run is only supported with `start` (preview); remove it for this command"
+        ),
+    }
+}
+
+fn require_actionable_resume_stage(state: &state::RunState) -> Result<state::StageKind> {
+    let resume_stage = state.opencode.resume_stage.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing resume_stage in state; state may be corrupted; consider `agentic-outer-dag reset --yes`"
+        )
+    })?;
+
+    anyhow::ensure!(
+        crate::dag::stages::sequence_index(&resume_stage).is_some(),
+        "invalid resume_stage in state ({resume_stage:?}); expected an actionable stage; consider `agentic-outer-dag reset --yes`"
+    );
+
+    Ok(resume_stage)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Install the rustls CryptoProvider before any HTTP clients are created.
@@ -67,6 +97,7 @@ async fn main() -> Result<()> {
     let cli = cli::Cli::parse();
     let dry_run = cli.dry_run;
     let command = cli.command;
+    ensure_supported_dry_run_usage(dry_run, &command)?;
 
     let log_level = match (cli.quiet, cli.verbose) {
         (true, _) => "error",
@@ -366,11 +397,7 @@ async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
         .await?;
 
     state.opencode.pending_permission = None;
-    state.stage.kind = state
-        .opencode
-        .resume_stage
-        .clone()
-        .unwrap_or(state::StageKind::DispatchingTicketToPr);
+    state.stage.kind = require_actionable_resume_stage(&state)?;
     state.stage.details = None;
     state::store::ThoughtsStateStore::save(&state)?;
 
@@ -409,11 +436,7 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
         .await?;
 
     state.opencode.pending_question = None;
-    state.stage.kind = state
-        .opencode
-        .resume_stage
-        .clone()
-        .unwrap_or(state::StageKind::DispatchingTicketToPr);
+    state.stage.kind = require_actionable_resume_stage(&state)?;
     state.stage.details = None;
     state::store::ThoughtsStateStore::save(&state)?;
 
@@ -447,7 +470,10 @@ mod tests {
     use super::SettingsOverrides;
     use super::apply_settings_overrides;
     use super::compact_status_payload;
+    use super::ensure_supported_dry_run_usage;
+    use super::require_actionable_resume_stage;
     use super::state;
+    use crate::cli;
     use crate::worktree::TargetWorktree;
     use serde_json::Value;
 
@@ -696,6 +722,63 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("OpenCode session deadline must be at least 1 second")
+        );
+    }
+
+    #[test]
+    fn ensure_supported_dry_run_usage_rejects_mutating_non_start_commands() {
+        for command in [
+            cli::Commands::Resume {
+                branch: None,
+                worktree: None,
+                no_linear_handoff: false,
+                no_opencode_dispatch: false,
+                stop_after: None,
+                poll_interval_seconds: None,
+                coderabbit_timeout_seconds: None,
+                opencode_session_deadline_seconds: None,
+                opencode_inactivity_timeout_seconds: None,
+            },
+            cli::Commands::RespondPermission {
+                allow: true,
+                deny: false,
+            },
+            cli::Commands::RespondQuestion {
+                answer: "yes".to_string(),
+            },
+            cli::Commands::Handoff { message: None },
+            cli::Commands::Reset { yes: true },
+        ] {
+            let err = ensure_supported_dry_run_usage(true, &command)
+                .expect_err("mutating command should reject --dry-run");
+            assert!(
+                err.to_string()
+                    .contains("--dry-run is only supported with `start`")
+            );
+        }
+    }
+
+    #[test]
+    fn require_actionable_resume_stage_rejects_missing_and_terminal_stages() {
+        let mut state = sample_state();
+        state.opencode.resume_stage = None;
+        let err =
+            require_actionable_resume_stage(&state).expect_err("missing resume stage should fail");
+        assert!(err.to_string().contains("missing resume_stage in state"));
+
+        state.opencode.resume_stage = Some(state::StageKind::StoppedFailed);
+        let err =
+            require_actionable_resume_stage(&state).expect_err("terminal resume stage should fail");
+        assert!(err.to_string().contains("invalid resume_stage in state"));
+    }
+
+    #[test]
+    fn require_actionable_resume_stage_accepts_active_stage() {
+        let mut state = sample_state();
+        state.opencode.resume_stage = Some(state::StageKind::DispatchingResolvePrComments);
+        assert_eq!(
+            require_actionable_resume_stage(&state).unwrap(),
+            state::StageKind::DispatchingResolvePrComments
         );
     }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -19,6 +19,12 @@ mod worktree;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install the rustls CryptoProvider before any HTTP clients are created.
+    // Required because Cargo's additive features cause both ring and aws-lc-rs
+    // to be compiled in via transitive dependencies, and rustls 0.23+ panics
+    // if it can't auto-select a single provider.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cli = cli::Cli::parse();
     let dry_run = cli.dry_run;
     let command = cli.command;

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -315,6 +315,8 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
         "worktree_exists": worktree_exists,
         "pr_number": state.pr.number,
         "pr_url": state.pr.url,
+        "pr_is_draft": state.pr.is_draft,
+        "pr_ready_for_review": state.pr.ready_for_review,
         "opencode_session_id": state.opencode.active_session_id,
         "opencode_last_command": state.opencode.last_command,
         "opencode_last_diagnostics": state.opencode.last_diagnostics,
@@ -466,6 +468,8 @@ mod tests {
         state.last_error = Some("detailed failure".to_string());
         state.pr.number = Some(258);
         state.pr.url = Some("https://example.invalid/pr/258".to_string());
+        state.pr.is_draft = Some(false);
+        state.pr.ready_for_review.last_result = Some("already_ready:existing_pr_guard".to_string());
         state.opencode.active_session_id = Some("session-123".to_string());
         state.opencode.last_command = Some("linear_ticket_2_pr".to_string());
         state.opencode.last_diagnostics = Some(state::OpenCodeDiagnostics {
@@ -491,6 +495,8 @@ mod tests {
             repo_name: "agentic_auxilary".to_string(),
             token_source: Some("GH_TOKEN".to_string()),
             empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
+            pr_number: None,
+            pr_is_draft: None,
             outcome: "not_found".to_string(),
         });
         state.handoff.linear_comment_posted = false;
@@ -518,6 +524,8 @@ mod tests {
             "worktree_exists",
             "pr_number",
             "pr_url",
+            "pr_is_draft",
+            "pr_ready_for_review",
             "opencode_session_id",
             "opencode_last_command",
             "opencode_last_diagnostics",
@@ -577,6 +585,7 @@ mod tests {
             payload.get("pr_number"),
             Some(&Value::Number(258_u64.into()))
         );
+        assert_eq!(payload.get("pr_is_draft"), Some(&Value::Bool(false)));
         assert_eq!(
             payload
                 .get("pr_lookup")

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -1,0 +1,245 @@
+#[cfg(not(unix))]
+compile_error!("agentic-outer-dag only supports Unix-like platforms (Linux/macOS).");
+
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
+use std::path::Path;
+use tracing::info;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+mod cli;
+mod dag;
+mod github;
+mod linear;
+mod opencode;
+mod state;
+mod worktree;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = cli::Cli::parse();
+    let dry_run = cli.dry_run;
+    let command = cli.command;
+
+    let log_level = match (cli.quiet, cli.verbose) {
+        (true, _) => "error",
+        (false, 0) => "info",
+        (false, 1) => "debug",
+        (false, _) => "trace",
+    };
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_thread_names(false);
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .init();
+
+    info!(
+        version = env!("CARGO_PKG_VERSION"),
+        "starting agentic-outer-dag"
+    );
+
+    match command {
+        cli::Commands::Start {
+            ticket,
+            branch,
+            worktree,
+            force,
+        } => {
+            handle_start(
+                &ticket,
+                branch.as_deref(),
+                worktree.as_deref(),
+                dry_run,
+                force,
+            )
+            .await
+        }
+        cli::Commands::Resume { branch, worktree } => {
+            handle_resume(branch.as_deref(), worktree.as_deref()).await
+        }
+        cli::Commands::Status { json } => handle_status(json),
+        cli::Commands::RespondPermission { allow, deny } => {
+            handle_respond_permission(allow, deny).await
+        }
+        cli::Commands::RespondQuestion { answer } => handle_respond_question(&answer).await,
+        cli::Commands::Handoff { message } => handle_handoff(message.as_deref()).await,
+        cli::Commands::Reset { yes } => handle_reset(yes),
+    }
+}
+
+async fn handle_start(
+    ticket: &str,
+    branch: Option<&str>,
+    worktree_path: Option<&Path>,
+    dry_run: bool,
+    force: bool,
+) -> Result<()> {
+    let target = worktree::resolve(branch, worktree_path, true)?;
+    worktree::chdir_to(&target)?;
+
+    if state::store::ThoughtsStateStore::load()?.is_some() && !force {
+        anyhow::bail!(
+            "state file already exists for branch '{}'; rerun with --force to overwrite",
+            target.branch
+        );
+    }
+
+    let state = state::RunState::for_start(ticket, &target, dry_run)?;
+    state::store::ThoughtsStateStore::save(&state)?;
+
+    let engine = dag::engine::DagEngine::for_current_dir().await?;
+    engine.run_until_stop().await?;
+    let state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after start"))?;
+    print_status(&state, false)
+}
+
+async fn handle_resume(branch: Option<&str>, worktree_path: Option<&Path>) -> Result<()> {
+    let target = worktree::resolve(branch, worktree_path, false)?;
+    worktree::chdir_to(&target)?;
+
+    state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
+    let engine = dag::engine::DagEngine::for_current_dir().await?;
+    engine.run_until_stop().await?;
+    let state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after resume"))?;
+    print_status(&state, false)
+}
+
+fn handle_status(as_json: bool) -> Result<()> {
+    let state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
+    print_status(&state, as_json)
+}
+
+fn print_status(state: &state::RunState, as_json: bool) -> Result<()> {
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(state)?);
+    } else {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ticket": state.ticket.linear_key,
+                "branch": state.worktree.branch,
+                "worktree": state.worktree.path,
+                "stage": state.stage.kind,
+                "state_file": format!("./thoughts/{}/artifacts/{}", state.worktree.branch, state::STATE_FILENAME),
+            }))?
+        );
+    }
+
+    Ok(())
+}
+
+async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
+    anyhow::ensure!(allow ^ deny, "exactly one of --allow or --deny is required");
+    let mut state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
+    anyhow::ensure!(
+        matches!(
+            state.stage.kind,
+            state::StageKind::StoppedPermissionRequired
+        ),
+        "current state is not waiting on a permission response"
+    );
+    let pending = state
+        .opencode
+        .pending_permission
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no pending permission payload found in state"))?;
+    let session_id = state
+        .opencode
+        .active_session_id
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
+
+    let supervisor =
+        opencode::supervisor::OpenCodeSupervisor::start(std::path::Path::new(".")).await?;
+    supervisor
+        .respond_permission(&session_id, &pending.request_id, allow)
+        .await?;
+
+    state.opencode.pending_permission = None;
+    state.stage.kind = state
+        .opencode
+        .resume_stage
+        .clone()
+        .unwrap_or(state::StageKind::DispatchingTicketToPr);
+    state.stage.details = None;
+    state::store::ThoughtsStateStore::save(&state)?;
+
+    let engine = dag::engine::DagEngine::for_current_dir().await?;
+    engine.run_until_stop().await?;
+    let state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
+    print_status(&state, false)
+}
+
+async fn handle_respond_question(answer: &str) -> Result<()> {
+    let mut state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
+    anyhow::ensure!(
+        matches!(state.stage.kind, state::StageKind::StoppedQuestionRequired),
+        "current state is not waiting on a question response"
+    );
+    let pending = state
+        .opencode
+        .pending_question
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no pending question payload found in state"))?;
+    let session_id = state
+        .opencode
+        .active_session_id
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
+
+    let supervisor =
+        opencode::supervisor::OpenCodeSupervisor::start(std::path::Path::new(".")).await?;
+    supervisor
+        .respond_question(&session_id, &pending.request_id, answer)
+        .await?;
+
+    state.opencode.pending_question = None;
+    state.stage.kind = state
+        .opencode
+        .resume_stage
+        .clone()
+        .unwrap_or(state::StageKind::DispatchingTicketToPr);
+    state.stage.details = None;
+    state::store::ThoughtsStateStore::save(&state)?;
+
+    let engine = dag::engine::DagEngine::for_current_dir().await?;
+    engine.run_until_stop().await?;
+    let state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
+    print_status(&state, false)
+}
+
+async fn handle_handoff(message: Option<&str>) -> Result<()> {
+    let mut state = state::store::ThoughtsStateStore::load()?
+        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
+    let body = message.unwrap_or("manual handoff requested from agentic-outer-dag");
+    linear::post_handoff_once(&mut state, body).await?;
+    state.stage.kind = state::StageKind::StoppedManualHandoff;
+    state.stage.details = Some(body.to_string());
+    state::store::ThoughtsStateStore::save(&state)?;
+    print_status(&state, false)
+}
+
+fn handle_reset(yes: bool) -> Result<()> {
+    anyhow::ensure!(yes, "reset requires --yes");
+    state::store::ThoughtsStateStore::delete()?;
+    println!("state reset");
+    Ok(())
+}

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -395,6 +395,7 @@ async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
     supervisor
         .respond_permission(&session_id, &pending.request_id, allow)
         .await?;
+    drop(supervisor);
 
     state.opencode.pending_permission = None;
     state.stage.kind = require_actionable_resume_stage(&state)?;
@@ -434,6 +435,7 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
     supervisor
         .respond_question(&session_id, &pending.request_id, answer)
         .await?;
+    drop(supervisor);
 
     state.opencode.pending_question = None;
     state.stage.kind = require_actionable_resume_stage(&state)?;

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -28,6 +28,8 @@ struct StartOptions<'a> {
     stop_after: Option<state::StageKind>,
     poll_interval_seconds: Option<u64>,
     coderabbit_timeout_seconds: Option<u64>,
+    opencode_session_deadline_seconds: Option<u64>,
+    opencode_inactivity_timeout_seconds: Option<u64>,
 }
 
 struct ResumeOptions<'a> {
@@ -38,6 +40,8 @@ struct ResumeOptions<'a> {
     stop_after: Option<state::StageKind>,
     poll_interval_seconds: Option<u64>,
     coderabbit_timeout_seconds: Option<u64>,
+    opencode_session_deadline_seconds: Option<u64>,
+    opencode_inactivity_timeout_seconds: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -46,6 +50,8 @@ struct SettingsOverrides {
     opencode_dispatch_enabled: Option<bool>,
     poll_interval_seconds: Option<u64>,
     coderabbit_timeout_seconds: Option<u64>,
+    opencode_session_deadline_seconds: Option<u64>,
+    opencode_inactivity_timeout_seconds: Option<u64>,
 }
 
 #[tokio::main]
@@ -98,6 +104,8 @@ async fn main() -> Result<()> {
             stop_after,
             poll_interval_seconds,
             coderabbit_timeout_seconds,
+            opencode_session_deadline_seconds,
+            opencode_inactivity_timeout_seconds,
         } => {
             handle_start(
                 &ticket,
@@ -111,6 +119,8 @@ async fn main() -> Result<()> {
                     stop_after,
                     poll_interval_seconds,
                     coderabbit_timeout_seconds,
+                    opencode_session_deadline_seconds,
+                    opencode_inactivity_timeout_seconds,
                 },
             )
             .await
@@ -123,6 +133,8 @@ async fn main() -> Result<()> {
             stop_after,
             poll_interval_seconds,
             coderabbit_timeout_seconds,
+            opencode_session_deadline_seconds,
+            opencode_inactivity_timeout_seconds,
         } => {
             handle_resume(ResumeOptions {
                 branch: branch.as_deref(),
@@ -132,6 +144,8 @@ async fn main() -> Result<()> {
                 stop_after,
                 poll_interval_seconds,
                 coderabbit_timeout_seconds,
+                opencode_session_deadline_seconds,
+                opencode_inactivity_timeout_seconds,
             })
             .await
         }
@@ -165,6 +179,23 @@ fn apply_settings_overrides(
         settings.coderabbit_timeout_seconds = coderabbit_timeout_seconds;
     }
 
+    if let Some(opencode_session_deadline_seconds) = overrides.opencode_session_deadline_seconds {
+        anyhow::ensure!(
+            opencode_session_deadline_seconds > 0,
+            "OpenCode session deadline must be at least 1 second"
+        );
+        settings.opencode_session_deadline_seconds = opencode_session_deadline_seconds;
+    }
+
+    if let Some(opencode_inactivity_timeout_seconds) = overrides.opencode_inactivity_timeout_seconds
+    {
+        anyhow::ensure!(
+            opencode_inactivity_timeout_seconds > 0,
+            "OpenCode inactivity timeout must be at least 1 second"
+        );
+        settings.opencode_inactivity_timeout_seconds = opencode_inactivity_timeout_seconds;
+    }
+
     if let Some(linear_handoff_enabled) = overrides.linear_handoff_enabled {
         settings.linear_handoff_enabled = linear_handoff_enabled;
     }
@@ -175,6 +206,8 @@ fn apply_settings_overrides(
 
     Ok(overrides.poll_interval_seconds.is_some()
         || overrides.coderabbit_timeout_seconds.is_some()
+        || overrides.opencode_session_deadline_seconds.is_some()
+        || overrides.opencode_inactivity_timeout_seconds.is_some()
         || overrides.linear_handoff_enabled.is_some()
         || overrides.opencode_dispatch_enabled.is_some())
 }
@@ -209,6 +242,8 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
             opencode_dispatch_enabled: Some(!options.no_opencode_dispatch),
             poll_interval_seconds: options.poll_interval_seconds,
             coderabbit_timeout_seconds: options.coderabbit_timeout_seconds,
+            opencode_session_deadline_seconds: options.opencode_session_deadline_seconds,
+            opencode_inactivity_timeout_seconds: options.opencode_inactivity_timeout_seconds,
         },
     )?;
     state::store::ThoughtsStateStore::save(&state)?;
@@ -233,6 +268,8 @@ async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
             opencode_dispatch_enabled: options.no_opencode_dispatch.then_some(false),
             poll_interval_seconds: options.poll_interval_seconds,
             coderabbit_timeout_seconds: options.coderabbit_timeout_seconds,
+            opencode_session_deadline_seconds: options.opencode_session_deadline_seconds,
+            opencode_inactivity_timeout_seconds: options.opencode_inactivity_timeout_seconds,
         },
     )?;
     if settings_changed {
@@ -284,6 +321,8 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
         "ticket_to_pr_runs": state.counters.ticket_to_pr_runs,
         "resolve_comments_runs": state.counters.resolve_comments_runs,
         "opencode_dispatch_enabled": state.settings.opencode_dispatch_enabled,
+        "opencode_session_deadline_seconds": state.settings.opencode_session_deadline_seconds,
+        "opencode_inactivity_timeout_seconds": state.settings.opencode_inactivity_timeout_seconds,
         "linear_handoff_enabled": state.settings.linear_handoff_enabled,
         "linear_handoff_posted": state.handoff.linear_comment_posted,
         "linear_handoff_posted_at": state.handoff.posted_at,
@@ -315,8 +354,11 @@ async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
         .clone()
         .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
 
-    let supervisor =
-        opencode::supervisor::OpenCodeSupervisor::start(std::path::Path::new(".")).await?;
+    let supervisor = opencode::supervisor::OpenCodeSupervisor::start(
+        std::path::Path::new("."),
+        opencode::supervisor::OpenCodeSupervisorTimeouts::from_settings(&state.settings),
+    )
+    .await?;
     supervisor
         .respond_permission(&session_id, &pending.request_id, allow)
         .await?;
@@ -355,8 +397,11 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
         .clone()
         .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
 
-    let supervisor =
-        opencode::supervisor::OpenCodeSupervisor::start(std::path::Path::new(".")).await?;
+    let supervisor = opencode::supervisor::OpenCodeSupervisor::start(
+        std::path::Path::new("."),
+        opencode::supervisor::OpenCodeSupervisorTimeouts::from_settings(&state.settings),
+    )
+    .await?;
     supervisor
         .respond_question(&session_id, &pending.request_id, answer)
         .await?;
@@ -479,6 +524,8 @@ mod tests {
             "ticket_to_pr_runs",
             "resolve_comments_runs",
             "opencode_dispatch_enabled",
+            "opencode_session_deadline_seconds",
+            "opencode_inactivity_timeout_seconds",
             "linear_handoff_enabled",
             "linear_handoff_posted",
             "linear_handoff_posted_at",
@@ -555,6 +602,8 @@ mod tests {
                 opencode_dispatch_enabled: Some(false),
                 poll_interval_seconds: Some(3),
                 coderabbit_timeout_seconds: Some(90),
+                opencode_session_deadline_seconds: Some(28_800),
+                opencode_inactivity_timeout_seconds: Some(900),
             },
         )
         .expect("overrides should apply");
@@ -564,6 +613,8 @@ mod tests {
         assert!(!state.settings.opencode_dispatch_enabled);
         assert_eq!(state.settings.poll_interval_seconds, 3);
         assert_eq!(state.settings.coderabbit_timeout_seconds, 90);
+        assert_eq!(state.settings.opencode_session_deadline_seconds, 28_800);
+        assert_eq!(state.settings.opencode_inactivity_timeout_seconds, 900);
     }
 
     #[test]
@@ -582,6 +633,14 @@ mod tests {
         assert_eq!(
             state.settings.coderabbit_timeout_seconds,
             original.coderabbit_timeout_seconds
+        );
+        assert_eq!(
+            state.settings.opencode_session_deadline_seconds,
+            original.opencode_session_deadline_seconds
+        );
+        assert_eq!(
+            state.settings.opencode_inactivity_timeout_seconds,
+            original.opencode_inactivity_timeout_seconds
         );
         assert_eq!(
             state.settings.linear_handoff_enabled,
@@ -609,6 +668,25 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("poll interval must be at least 1 second")
+        );
+    }
+
+    #[test]
+    fn apply_settings_overrides_rejects_zero_opencode_session_deadline() {
+        let mut state = sample_state();
+
+        let err = apply_settings_overrides(
+            &mut state.settings,
+            SettingsOverrides {
+                opencode_session_deadline_seconds: Some(0),
+                ..SettingsOverrides::default()
+            },
+        )
+        .expect_err("zero deadline should fail");
+
+        assert!(
+            err.to_string()
+                .contains("OpenCode session deadline must be at least 1 second")
         );
     }
 }

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -510,6 +510,7 @@ mod tests {
                 tool: "read".to_string(),
                 error: "nested guard tripped".to_string(),
             }),
+            command_transport_error: None,
         });
         state.counters.ticket_to_pr_runs = 1;
         state.counters.resolve_comments_runs = 0;

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -24,7 +24,9 @@ async fn main() -> Result<()> {
     // Required because Cargo's additive features cause both ring and aws-lc-rs
     // to be compiled in via transitive dependencies, and rustls 0.23+ panics
     // if it can't auto-select a single provider.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .map_err(|_| anyhow::anyhow!("failed to install rustls aws-lc-rs CryptoProvider"))?;
 
     let cli = cli::Cli::parse();
     let dry_run = cli.dry_run;

--- a/apps/agentic-outer-dag/src/opencode/mod.rs
+++ b/apps/agentic-outer-dag/src/opencode/mod.rs
@@ -1,0 +1,1 @@
+pub mod supervisor;

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -1,0 +1,566 @@
+use anyhow::Context;
+use anyhow::Result;
+use opencode_rs::Client;
+use opencode_rs::server::ManagedServer;
+use opencode_rs::server::ServerOptions;
+use opencode_rs::types::event::Event;
+use opencode_rs::types::message::CommandRequest;
+use opencode_rs::types::permission::PermissionReply;
+use opencode_rs::types::permission::PermissionReplyRequest;
+use opencode_rs::types::question::QuestionReply;
+use opencode_rs::types::session::CreateSessionRequest;
+use opencode_rs::types::session::SessionStatusInfo;
+use opencode_rs::version;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const IDLE_GRACE: Duration = Duration::from_millis(1000);
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SESSION_DEADLINE: Duration = Duration::from_secs(3600);
+const INACTIVITY_TIMEOUT: Duration = Duration::from_secs(300);
+
+pub struct OpenCodeSupervisor {
+    _managed_server: ManagedServer,
+    client: Client,
+    _directory: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SupervisedOutcome {
+    Completed {
+        session_id: String,
+    },
+    PermissionRequired {
+        session_id: String,
+        request_id: String,
+        permission_type: String,
+    },
+    QuestionRequired {
+        session_id: String,
+        request_id: String,
+        prompt: String,
+    },
+    Failed {
+        session_id: Option<String>,
+        error: String,
+    },
+}
+
+impl OpenCodeSupervisor {
+    pub async fn start(directory: &Path) -> Result<Self> {
+        let cwd = directory.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize OpenCode directory {}",
+                directory.display()
+            )
+        })?;
+        let launcher_config = resolve_launcher_config(&cwd)
+            .context("failed to resolve OpenCode launcher configuration")?;
+
+        tracing::info!(
+            binary = %launcher_config.binary,
+            launcher_args = ?launcher_config.launcher_args,
+            expected_version = %version::PINNED_OPENCODE_VERSION,
+            "starting app-local opencode serve"
+        );
+
+        let managed = ManagedServer::start(
+            ServerOptions::default()
+                .binary(&launcher_config.binary)
+                .launcher_args(launcher_config.launcher_args)
+                .directory(cwd.clone()),
+        )
+        .await
+        .context("failed to start embedded opencode serve")?;
+
+        let base_url = managed.url().to_string().trim_end_matches('/').to_string();
+        let client = Client::builder()
+            .base_url(&base_url)
+            .directory(cwd.to_string_lossy().to_string())
+            .build()
+            .context("failed to build opencode client")?;
+
+        let health = client
+            .misc()
+            .health()
+            .await
+            .context("failed to fetch /global/health for version validation")?;
+        version::validate_exact_version(health.version.as_deref()).with_context(|| {
+            format!(
+                "embedded OpenCode server did not match pinned stable v{} (binary={})",
+                version::PINNED_OPENCODE_VERSION,
+                launcher_config.binary
+            )
+        })?;
+
+        Ok(Self {
+            _managed_server: managed,
+            client,
+            _directory: cwd,
+        })
+    }
+
+    pub async fn ensure_commands_present(&self, required: &[&str]) -> Result<()> {
+        let commands = self
+            .client
+            .tools()
+            .commands()
+            .await
+            .context("failed to list OpenCode commands")?;
+        for required_name in required {
+            if commands.iter().all(|command| {
+                command.name != *required_name
+                    && command.name.trim_start_matches('/') != required_name.trim_start_matches('/')
+            }) {
+                anyhow::bail!("required OpenCode command not found: {required_name}");
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn run_command_supervised(
+        &self,
+        existing_session_id: Option<&str>,
+        command_name: &str,
+        message: Option<&str>,
+    ) -> Result<SupervisedOutcome> {
+        let session_id = if let Some(session_id) = existing_session_id {
+            self.client
+                .sessions()
+                .get(session_id)
+                .await
+                .with_context(|| format!("failed to load session {session_id}"))?;
+            session_id.to_string()
+        } else {
+            self.client
+                .sessions()
+                .create(&CreateSessionRequest::default())
+                .await
+                .context("failed to create OpenCode session")?
+                .id
+        };
+
+        if let Some(outcome) = self.preflight_pending_interruptions(&session_id).await? {
+            return Ok(outcome);
+        }
+
+        let mut subscription = self
+            .client
+            .subscribe_session(&session_id)
+            .context("failed to subscribe to session events")?;
+
+        let cmd_client = self.client.clone();
+        let dispatch_session_id = session_id.clone();
+        let dispatch_command = command_name.to_string();
+        let dispatch_message = message.unwrap_or_default().to_string();
+        let mut command_task = Some(tokio::spawn(async move {
+            let request = CommandRequest {
+                command: dispatch_command,
+                arguments: dispatch_message,
+                message_id: None,
+            };
+            cmd_client
+                .messages()
+                .command(&dispatch_session_id, &request)
+                .await
+                .map(|_| ())
+        }));
+
+        let deadline = tokio::time::Instant::now() + SESSION_DEADLINE;
+        let mut last_activity = tokio::time::Instant::now();
+        let mut poll_interval = tokio::time::interval(POLL_INTERVAL);
+        poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut observed_busy = false;
+        let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
+        let mut awaiting_idle_grace = false;
+        let mut sse_active = true;
+
+        loop {
+            let now = tokio::time::Instant::now();
+            if now.duration_since(last_activity) >= INACTIVITY_TIMEOUT {
+                return Ok(SupervisedOutcome::Failed {
+                    session_id: Some(session_id.clone()),
+                    error: "session idle timeout after 5 minutes".to_string(),
+                });
+            }
+            if now >= deadline {
+                return Ok(SupervisedOutcome::Failed {
+                    session_id: Some(session_id.clone()),
+                    error: "session execution timed out after 1 hour".to_string(),
+                });
+            }
+
+            tokio::select! {
+                maybe_event = subscription.recv(), if sse_active => {
+                    let Some(event) = maybe_event else {
+                        sse_active = false;
+                        continue;
+                    };
+
+                    match event {
+                        Event::PermissionAsked { properties } => {
+                            return Ok(SupervisedOutcome::PermissionRequired {
+                                session_id,
+                                request_id: properties.request.id,
+                                permission_type: properties.request.permission,
+                            });
+                        }
+                        Event::QuestionAsked { properties } => {
+                            let prompt = properties
+                                .request
+                                .questions
+                                .first()
+                                .map(|question| question.question.clone())
+                                .unwrap_or_default();
+                            return Ok(SupervisedOutcome::QuestionRequired {
+                                session_id,
+                                request_id: properties.request.id,
+                                prompt,
+                            });
+                        }
+                        Event::MessagePartDelta { .. }
+                        | Event::MessagePartUpdated { .. }
+                        | Event::MessageUpdated { .. } => {
+                            last_activity = tokio::time::Instant::now();
+                            observed_busy = true;
+                            awaiting_idle_grace = false;
+                        }
+                        Event::SessionIdle { .. } => {
+                            return Ok(SupervisedOutcome::Completed { session_id });
+                        }
+                        Event::SessionError { properties } => {
+                            return Ok(SupervisedOutcome::Failed {
+                                session_id: properties.session_id.or(Some(session_id)),
+                                error: format!("session error: {:?}", properties.error),
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                _ = poll_interval.tick() => {
+                    if let Some(outcome) = self.preflight_pending_interruptions(&session_id).await? {
+                        return Ok(outcome);
+                    }
+
+                    match self.client.sessions().status_for(&session_id).await {
+                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. } | SessionStatusInfo::Unknown) => {
+                            last_activity = tokio::time::Instant::now();
+                            observed_busy = true;
+                            awaiting_idle_grace = false;
+                        }
+                        Ok(SessionStatusInfo::Idle) => {
+                            if observed_busy {
+                                return Ok(SupervisedOutcome::Completed { session_id });
+                            }
+
+                            let grace = idle_grace_deadline.get_or_insert_with(|| tokio::time::Instant::now() + IDLE_GRACE);
+                            if tokio::time::Instant::now() >= *grace {
+                                return Ok(SupervisedOutcome::Completed { session_id });
+                            }
+                            awaiting_idle_grace = true;
+                        }
+                        Err(error) => {
+                            tracing::warn!(error = %error, "failed to poll session status");
+                        }
+                    }
+                }
+                result = async {
+                    match command_task.as_mut() {
+                        Some(task) => Some(task.await),
+                        None => std::future::pending::<Option<Result<Result<(), opencode_rs::OpencodeError>, tokio::task::JoinError>>>().await,
+                    }
+                }, if command_task.is_some() => {
+                    match result {
+                        Some(Ok(Ok(()))) => {
+                            idle_grace_deadline = Some(tokio::time::Instant::now() + IDLE_GRACE);
+                            command_task = None;
+                        }
+                        Some(Ok(Err(error))) => {
+                            return Ok(SupervisedOutcome::Failed {
+                                session_id: Some(session_id),
+                                error: error.to_string(),
+                            });
+                        }
+                        Some(Err(error)) => {
+                            return Ok(SupervisedOutcome::Failed {
+                                session_id: Some(session_id),
+                                error: format!("command task failed: {error}"),
+                            });
+                        }
+                        None => unreachable!("command task guard should prevent None"),
+                    }
+                }
+                () = async {
+                    match idle_grace_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                }, if awaiting_idle_grace => {
+                    awaiting_idle_grace = false;
+                    if matches!(self.client.sessions().status_for(&session_id).await, Ok(SessionStatusInfo::Idle)) {
+                        return Ok(SupervisedOutcome::Completed { session_id });
+                    }
+                    observed_busy = true;
+                    last_activity = tokio::time::Instant::now();
+                }
+            }
+        }
+    }
+
+    pub async fn respond_permission(
+        &self,
+        _session_id: &str,
+        request_id: &str,
+        allow: bool,
+    ) -> Result<()> {
+        let reply = if allow {
+            PermissionReply::Once
+        } else {
+            PermissionReply::Reject
+        };
+
+        self.client
+            .permissions()
+            .reply(
+                request_id,
+                &PermissionReplyRequest {
+                    reply,
+                    message: None,
+                },
+            )
+            .await
+            .with_context(|| format!("failed to respond to permission request {request_id}"))?;
+        Ok(())
+    }
+
+    pub async fn respond_question(
+        &self,
+        _session_id: &str,
+        request_id: &str,
+        answer: &str,
+    ) -> Result<()> {
+        self.client
+            .question()
+            .reply(
+                request_id,
+                &QuestionReply {
+                    answers: vec![vec![answer.to_string()]],
+                },
+            )
+            .await
+            .with_context(|| format!("failed to respond to question request {request_id}"))?;
+        Ok(())
+    }
+
+    async fn preflight_pending_interruptions(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SupervisedOutcome>> {
+        let permissions = self
+            .client
+            .permissions()
+            .list()
+            .await
+            .context("failed to list permissions")?;
+        if let Some(permission) = permissions
+            .into_iter()
+            .find(|permission| permission.session_id == session_id)
+        {
+            return Ok(Some(SupervisedOutcome::PermissionRequired {
+                session_id: session_id.to_string(),
+                request_id: permission.id,
+                permission_type: permission.permission,
+            }));
+        }
+
+        let questions = self
+            .client
+            .question()
+            .list()
+            .await
+            .context("failed to list questions")?;
+        if let Some(question) = questions
+            .into_iter()
+            .find(|question| question.session_id == session_id)
+        {
+            return Ok(Some(SupervisedOutcome::QuestionRequired {
+                session_id: session_id.to_string(),
+                request_id: question.id,
+                prompt: question
+                    .questions
+                    .first()
+                    .map(|entry| entry.question.clone())
+                    .unwrap_or_default(),
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LauncherConfig {
+    binary: String,
+    launcher_args: Vec<String>,
+}
+
+fn resolve_launcher_config(base_dir: &Path) -> Result<LauncherConfig> {
+    let launcher_args = parse_launcher_args();
+    if !launcher_args.is_empty() {
+        let binary = std::env::var(version::OPENCODE_BINARY_ENV)
+            .map_or_else(|_| "opencode".to_string(), |value| value.trim().to_string());
+        if binary.is_empty() {
+            anyhow::bail!(
+                "OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is empty; set it to the launcher command"
+            );
+        }
+
+        return Ok(LauncherConfig {
+            binary,
+            launcher_args,
+        });
+    }
+
+    let binary = resolve_opencode_binary(base_dir)?;
+    Ok(LauncherConfig {
+        binary: binary.to_string_lossy().to_string(),
+        launcher_args: Vec::new(),
+    })
+}
+
+fn resolve_opencode_binary(base_dir: &Path) -> Result<PathBuf> {
+    if let Ok(value) = std::env::var(version::OPENCODE_BINARY_ENV) {
+        let value = value.trim();
+        if !value.is_empty() {
+            let path = PathBuf::from(value);
+            return path.canonicalize().with_context(|| {
+                format!("OPENCODE_BINARY points to missing path: {}", path.display())
+            });
+        }
+    }
+
+    let candidate = base_dir
+        .join(".opencode")
+        .join("bin")
+        .join(format!("opencode-v{}", version::PINNED_OPENCODE_VERSION));
+    if candidate.exists() {
+        return candidate
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize {}", candidate.display()));
+    }
+
+    Ok(PathBuf::from("opencode"))
+}
+
+fn parse_launcher_args() -> Vec<String> {
+    match std::env::var(version::OPENCODE_BINARY_ARGS_ENV) {
+        Ok(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                Vec::new()
+            } else {
+                value.split_whitespace().map(str::to_string).collect()
+            }
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use tempfile::TempDir;
+    use tokio::process::Command;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test]
+    async fn preflight_returns_pending_permission() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/permission"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "perm-1",
+                    "sessionID": "session-1",
+                    "permission": "file.write",
+                    "patterns": ["src/**/*.rs"]
+                }
+            ])))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/question"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let outcome = supervisor
+            .preflight_pending_interruptions("session-1")
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            Some(SupervisedOutcome::PermissionRequired { request_id, .. }) if request_id == "perm-1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn preflight_returns_pending_question() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/permission"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/question"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "question-1",
+                    "sessionID": "session-2",
+                    "questions": [{ "question": "Continue?" }]
+                }
+            ])))
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let outcome = supervisor
+            .preflight_pending_interruptions("session-2")
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            Some(SupervisedOutcome::QuestionRequired { request_id, .. }) if request_id == "question-1"
+        ));
+    }
+
+    fn test_supervisor(mock: &MockServer, directory: &Path) -> OpenCodeSupervisor {
+        let child = Command::new("sleep")
+            .arg("60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let managed = ManagedServer::from_child_for_testing(child, mock.uri(), 1234);
+        let client = Client::builder()
+            .base_url(mock.uri())
+            .directory(directory.display().to_string())
+            .build()
+            .unwrap();
+        OpenCodeSupervisor {
+            _managed_server: managed,
+            client,
+            _directory: directory.to_path_buf(),
+        }
+    }
+}

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -823,6 +823,7 @@ fn parse_launcher_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::EnvVarGuard;
     use crate::test_support::process_state_lock;
     use std::process::Stdio;
     use std::sync::Arc;
@@ -1513,38 +1514,11 @@ mod tests {
     #[test]
     fn resolve_launcher_config_errors_when_args_set_but_binary_missing() {
         let _guard = process_state_lock().lock().unwrap();
-        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
-        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
-
-        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-        unsafe {
-            std::env::remove_var(version::OPENCODE_BINARY_ENV);
-            std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
-        }
+        let _binary = EnvVarGuard::remove(version::OPENCODE_BINARY_ENV);
+        let _args = EnvVarGuard::set(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
 
         let err = resolve_launcher_config(Path::new("/tmp/project"))
             .expect_err("missing launcher binary should fail");
-
-        match previous_binary {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
-            }
-        }
-        match previous_args {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
-            }
-        }
 
         assert!(
             err.to_string()
@@ -1555,38 +1529,11 @@ mod tests {
     #[test]
     fn resolve_launcher_config_errors_when_args_set_but_binary_empty() {
         let _guard = process_state_lock().lock().unwrap();
-        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
-        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
-
-        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-        unsafe {
-            std::env::set_var(version::OPENCODE_BINARY_ENV, "   ");
-            std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
-        }
+        let _binary = EnvVarGuard::set(version::OPENCODE_BINARY_ENV, "   ");
+        let _args = EnvVarGuard::set(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
 
         let err = resolve_launcher_config(Path::new("/tmp/project"))
             .expect_err("empty launcher binary should fail");
-
-        match previous_binary {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
-            }
-        }
-        match previous_args {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
-            }
-        }
 
         assert!(err.to_string().contains("OPENCODE_BINARY is empty"));
     }
@@ -1594,41 +1541,14 @@ mod tests {
     #[test]
     fn resolve_launcher_config_accepts_explicit_binary_with_args() {
         let _guard = process_state_lock().lock().unwrap();
-        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
-        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
-
-        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-        unsafe {
-            std::env::set_var(version::OPENCODE_BINARY_ENV, "bunx");
-            std::env::set_var(
-                version::OPENCODE_BINARY_ARGS_ENV,
-                "--yes opencode-ai@1.17.4",
-            );
-        }
+        let _binary = EnvVarGuard::set(version::OPENCODE_BINARY_ENV, "bunx");
+        let _args = EnvVarGuard::set(
+            version::OPENCODE_BINARY_ARGS_ENV,
+            "--yes opencode-ai@1.17.4",
+        );
 
         let config = resolve_launcher_config(Path::new("/tmp/project"))
             .expect("explicit launcher binary should succeed");
-
-        match previous_binary {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
-            }
-        }
-        match previous_args {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
-            }
-            None => {
-                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
-                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
-            }
-        }
 
         assert_eq!(config.binary, "bunx");
         assert_eq!(config.launcher_args, vec!["--yes", "opencode-ai@1.17.4"]);

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -1,3 +1,5 @@
+use crate::state::OpenCodeDiagnostics;
+use crate::state::OpenCodeToolErrorDiagnostics;
 use anyhow::Context;
 use anyhow::Result;
 use opencode_rs::Client;
@@ -5,6 +7,9 @@ use opencode_rs::server::ManagedServer;
 use opencode_rs::server::ServerOptions;
 use opencode_rs::types::event::Event;
 use opencode_rs::types::message::CommandRequest;
+use opencode_rs::types::message::Message;
+use opencode_rs::types::message::Part;
+use opencode_rs::types::message::ToolState;
 use opencode_rs::types::permission::PermissionReply;
 use opencode_rs::types::permission::PermissionReplyRequest;
 use opencode_rs::types::question::QuestionReply;
@@ -13,12 +18,20 @@ use opencode_rs::types::session::SessionStatusInfo;
 use opencode_rs::version;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 const IDLE_GRACE: Duration = Duration::from_millis(1000);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const SESSION_DEADLINE: Duration = Duration::from_secs(3600);
 const INACTIVITY_TIMEOUT: Duration = Duration::from_secs(300);
+const TRANSCRIPT_EMPTY_RETRY_BACKOFFS: [Duration; 2] =
+    [Duration::from_millis(250), Duration::from_millis(500)];
+const NESTED_GUARD_NEEDLE: &str = "OPENCODE_ORCHESTRATOR_MANAGED";
+const TOOL_ERROR_SUMMARY_LIMIT: usize = 240;
+
+static COMMAND_MESSAGE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub struct OpenCodeSupervisor {
     _managed_server: ManagedServer,
@@ -30,6 +43,7 @@ pub struct OpenCodeSupervisor {
 pub enum SupervisedOutcome {
     Completed {
         session_id: String,
+        diagnostics: OpenCodeDiagnostics,
     },
     PermissionRequired {
         session_id: String,
@@ -44,6 +58,44 @@ pub enum SupervisedOutcome {
     Failed {
         session_id: Option<String>,
         error: String,
+        diagnostics: Option<OpenCodeDiagnostics>,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct TranscriptWindow {
+    command_message_id: String,
+    baseline_tail_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TranscriptAnalysis {
+    has_assistant_message: bool,
+    final_assistant_message_id: Option<String>,
+    final_finish_reason: Option<String>,
+    guard_detected: bool,
+    final_tool_error: Option<OpenCodeToolErrorDiagnostics>,
+}
+
+impl TranscriptAnalysis {
+    fn diagnostics(&self, command_message_id: &str) -> OpenCodeDiagnostics {
+        OpenCodeDiagnostics {
+            checked_at: chrono::Utc::now().to_rfc3339(),
+            command_message_id: Some(command_message_id.to_string()),
+            final_assistant_message_id: self.final_assistant_message_id.clone(),
+            final_finish_reason: self.final_finish_reason.clone(),
+            guard_detected: self.guard_detected,
+            final_tool_error: self.final_tool_error.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CompletionValidation {
+    Passed(OpenCodeDiagnostics),
+    Failed {
+        error: String,
+        diagnostics: Option<OpenCodeDiagnostics>,
     },
 }
 
@@ -69,6 +121,7 @@ impl OpenCodeSupervisor {
             ServerOptions::default()
                 .binary(&launcher_config.binary)
                 .launcher_args(launcher_config.launcher_args)
+                .inject_orchestrator_managed_env(false)
                 .directory(cwd.clone()),
         )
         .await
@@ -149,16 +202,21 @@ impl OpenCodeSupervisor {
             .client
             .subscribe_session(&session_id)
             .context("failed to subscribe to session events")?;
+        let transcript_window = TranscriptWindow {
+            command_message_id: generate_command_message_id(),
+            baseline_tail_message_id: self.fetch_transcript_tail_id(&session_id).await?,
+        };
 
         let cmd_client = self.client.clone();
         let dispatch_session_id = session_id.clone();
         let dispatch_command = command_name.to_string();
         let dispatch_message = message.unwrap_or_default().to_string();
+        let dispatch_message_id = transcript_window.command_message_id.clone();
         let mut command_task = Some(tokio::spawn(async move {
             let request = CommandRequest {
                 command: dispatch_command,
                 arguments: dispatch_message,
-                message_id: None,
+                message_id: Some(dispatch_message_id),
             };
             cmd_client
                 .messages()
@@ -182,12 +240,14 @@ impl OpenCodeSupervisor {
                 return Ok(SupervisedOutcome::Failed {
                     session_id: Some(session_id.clone()),
                     error: "session idle timeout after 5 minutes".to_string(),
+                    diagnostics: None,
                 });
             }
             if now >= deadline {
                 return Ok(SupervisedOutcome::Failed {
                     session_id: Some(session_id.clone()),
                     error: "session execution timed out after 1 hour".to_string(),
+                    diagnostics: None,
                 });
             }
 
@@ -227,12 +287,15 @@ impl OpenCodeSupervisor {
                             awaiting_idle_grace = false;
                         }
                         Event::SessionIdle { .. } => {
-                            return Ok(SupervisedOutcome::Completed { session_id });
+                            return Ok(self
+                                .completion_outcome(session_id, &transcript_window)
+                                .await);
                         }
                         Event::SessionError { properties } => {
                             return Ok(SupervisedOutcome::Failed {
                                 session_id: properties.session_id.or(Some(session_id)),
                                 error: format!("session error: {:?}", properties.error),
+                                diagnostics: None,
                             });
                         }
                         _ => {}
@@ -251,12 +314,16 @@ impl OpenCodeSupervisor {
                         }
                         Ok(SessionStatusInfo::Idle) => {
                             if observed_busy {
-                                return Ok(SupervisedOutcome::Completed { session_id });
+                                return Ok(self
+                                    .completion_outcome(session_id, &transcript_window)
+                                    .await);
                             }
 
                             let grace = idle_grace_deadline.get_or_insert_with(|| tokio::time::Instant::now() + IDLE_GRACE);
                             if tokio::time::Instant::now() >= *grace {
-                                return Ok(SupervisedOutcome::Completed { session_id });
+                                return Ok(self
+                                    .completion_outcome(session_id, &transcript_window)
+                                    .await);
                             }
                             awaiting_idle_grace = true;
                         }
@@ -280,12 +347,14 @@ impl OpenCodeSupervisor {
                             return Ok(SupervisedOutcome::Failed {
                                 session_id: Some(session_id),
                                 error: error.to_string(),
+                                diagnostics: None,
                             });
                         }
                         Some(Err(error)) => {
                             return Ok(SupervisedOutcome::Failed {
                                 session_id: Some(session_id),
                                 error: format!("command task failed: {error}"),
+                                diagnostics: None,
                             });
                         }
                         None => unreachable!("command task guard should prevent None"),
@@ -299,7 +368,9 @@ impl OpenCodeSupervisor {
                 }, if awaiting_idle_grace => {
                     awaiting_idle_grace = false;
                     if matches!(self.client.sessions().status_for(&session_id).await, Ok(SessionStatusInfo::Idle)) {
-                        return Ok(SupervisedOutcome::Completed { session_id });
+                        return Ok(self
+                            .completion_outcome(session_id, &transcript_window)
+                            .await);
                     }
                     observed_busy = true;
                     last_activity = tokio::time::Instant::now();
@@ -397,6 +468,194 @@ impl OpenCodeSupervisor {
 
         Ok(None)
     }
+
+    async fn completion_outcome(
+        &self,
+        session_id: String,
+        transcript_window: &TranscriptWindow,
+    ) -> SupervisedOutcome {
+        match self
+            .validate_completion_with_retries(&session_id, transcript_window)
+            .await
+        {
+            CompletionValidation::Passed(diagnostics) => SupervisedOutcome::Completed {
+                session_id,
+                diagnostics,
+            },
+            CompletionValidation::Failed { error, diagnostics } => SupervisedOutcome::Failed {
+                session_id: Some(session_id),
+                error,
+                diagnostics,
+            },
+        }
+    }
+
+    async fn fetch_transcript_tail_id(&self, session_id: &str) -> Result<Option<String>> {
+        Ok(self
+            .client
+            .messages()
+            .list(session_id)
+            .await
+            .with_context(|| {
+                format!("failed to list transcript messages for session {session_id}")
+            })?
+            .last()
+            .map(|message| message.id().to_string()))
+    }
+
+    async fn validate_completion_with_retries(
+        &self,
+        session_id: &str,
+        transcript_window: &TranscriptWindow,
+    ) -> CompletionValidation {
+        for attempt in 0..=TRANSCRIPT_EMPTY_RETRY_BACKOFFS.len() {
+            if attempt > 0 {
+                tokio::time::sleep(TRANSCRIPT_EMPTY_RETRY_BACKOFFS[attempt - 1]).await;
+            }
+
+            let messages = match self.client.messages().list(session_id).await {
+                Ok(messages) => messages,
+                Err(error) => {
+                    return CompletionValidation::Failed {
+                        error: format!(
+                            "failed to validate completed transcript for session {session_id}: {error}"
+                        ),
+                        diagnostics: None,
+                    };
+                }
+            };
+
+            let analysis = analyze_transcript_window(&messages, transcript_window);
+            let diagnostics = analysis.diagnostics(&transcript_window.command_message_id);
+            if analysis.guard_detected {
+                return CompletionValidation::Failed {
+                    error:
+                        "completed session transcript contains nested orchestrator guard failure"
+                            .to_string(),
+                    diagnostics: Some(diagnostics),
+                };
+            }
+            if analysis.final_tool_error.is_some() {
+                return CompletionValidation::Failed {
+                    error: "completed session transcript ended with a tool error".to_string(),
+                    diagnostics: Some(diagnostics),
+                };
+            }
+            if analysis.has_assistant_message {
+                return CompletionValidation::Passed(diagnostics);
+            }
+            if attempt == TRANSCRIPT_EMPTY_RETRY_BACKOFFS.len() {
+                return CompletionValidation::Failed {
+                    error: "completed session transcript did not contain an assistant response after dispatch"
+                        .to_string(),
+                    diagnostics: Some(diagnostics),
+                };
+            }
+        }
+
+        CompletionValidation::Failed {
+            error: "completed session transcript validation exited unexpectedly".to_string(),
+            diagnostics: None,
+        }
+    }
+}
+
+fn generate_command_message_id() -> String {
+    let tick = COMMAND_MESSAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "msg-outer-dag-{}-{tick}",
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    )
+}
+
+fn analyze_transcript_window(
+    messages: &[Message],
+    transcript_window: &TranscriptWindow,
+) -> TranscriptAnalysis {
+    let start_index = messages
+        .iter()
+        .position(|message| message.id() == transcript_window.command_message_id)
+        .or_else(|| {
+            transcript_window
+                .baseline_tail_message_id
+                .as_ref()
+                .and_then(|baseline| messages.iter().position(|message| message.id() == baseline))
+                .map(|index| index + 1)
+        })
+        .unwrap_or(0);
+    let window = &messages[start_index.min(messages.len())..];
+    let final_assistant = window
+        .iter()
+        .rev()
+        .find(|message| message.role() == "assistant");
+    let mut guard_detected = false;
+
+    for message in window {
+        for part in &message.parts {
+            match part {
+                Part::Text { text, .. } | Part::Reasoning { text, .. } => {
+                    if text.contains(NESTED_GUARD_NEEDLE) {
+                        guard_detected = true;
+                    }
+                }
+                Part::Tool {
+                    state: Some(tool_state),
+                    ..
+                } => {
+                    if tool_state
+                        .error()
+                        .is_some_and(|error| error.contains(NESTED_GUARD_NEEDLE))
+                    {
+                        guard_detected = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let final_tool_error = final_assistant.and_then(|message| {
+        message.parts.iter().find_map(|part| {
+            let Part::Tool {
+                tool,
+                state: Some(ToolState::Error(error_state)),
+                ..
+            } = part
+            else {
+                return None;
+            };
+            Some(OpenCodeToolErrorDiagnostics {
+                tool: tool.clone(),
+                error: truncate_tool_error(&error_state.error),
+            })
+        })
+    });
+
+    TranscriptAnalysis {
+        has_assistant_message: final_assistant.is_some(),
+        final_assistant_message_id: final_assistant.map(|message| message.id().to_string()),
+        final_finish_reason: final_assistant.and_then(|message| {
+            message.info.finish.clone().or_else(|| {
+                message.parts.iter().rev().find_map(|part| match part {
+                    Part::StepFinish { reason, .. } => Some(reason.clone()),
+                    _ => None,
+                })
+            })
+        }),
+        guard_detected,
+        final_tool_error,
+    }
+}
+
+fn truncate_tool_error(error: &str) -> String {
+    let mut truncated = error
+        .chars()
+        .take(TOOL_ERROR_SUMMARY_LIMIT)
+        .collect::<String>();
+    if error.chars().count() > TOOL_ERROR_SUMMARY_LIMIT {
+        truncated.push('…');
+    }
+    truncated
 }
 
 #[derive(Debug, Clone)]
@@ -479,6 +738,23 @@ mod tests {
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
+    fn transcript_message(role: &str, id: &str, parts: &serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "info": {
+                "id": id,
+                "sessionID": "session-1",
+                "role": role,
+                "time": { "created": 1 },
+                "finish": if role == "assistant" { serde_json::json!("stop") } else { serde_json::Value::Null }
+            },
+            "parts": parts,
+        })
+    }
+
+    fn parse_messages(value: serde_json::Value) -> Vec<Message> {
+        serde_json::from_value(value).unwrap()
+    }
+
     #[tokio::test]
     async fn preflight_returns_pending_permission() {
         let mock = MockServer::start().await;
@@ -542,6 +818,132 @@ mod tests {
             outcome,
             Some(SupervisedOutcome::QuestionRequired { request_id, .. }) if request_id == "question-1"
         ));
+    }
+
+    #[test]
+    fn detects_final_tool_error_as_failure() {
+        let messages = parse_messages(serde_json::json!([
+            transcript_message("user", "msg-user", &serde_json::json!([])),
+            transcript_message(
+                "assistant",
+                "msg-assistant",
+                &serde_json::json!([
+                    {
+                        "type": "tool",
+                        "callID": "call-1",
+                        "tool": "read",
+                        "state": {
+                            "status": "error",
+                            "input": {},
+                            "error": "permission denied",
+                            "time": { "start": 1, "end": 2 }
+                        }
+                    }
+                ])
+            )
+        ]));
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-user".to_string(),
+                baseline_tail_message_id: None,
+            },
+        );
+
+        assert_eq!(
+            analysis.final_assistant_message_id.as_deref(),
+            Some("msg-assistant")
+        );
+        assert_eq!(
+            analysis
+                .final_tool_error
+                .as_ref()
+                .map(|error| error.tool.as_str()),
+            Some("read")
+        );
+    }
+
+    #[test]
+    fn detects_guard_text_as_failure() {
+        let messages = parse_messages(serde_json::json!([transcript_message(
+            "assistant",
+            "msg-assistant",
+            &serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "nested launch blocked by OPENCODE_ORCHESTRATOR_MANAGED"
+                }
+            ])
+        )]));
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-missing".to_string(),
+                baseline_tail_message_id: None,
+            },
+        );
+
+        assert!(analysis.guard_detected);
+    }
+
+    #[test]
+    fn requires_assistant_message_after_dispatch_window() {
+        let messages = parse_messages(serde_json::json!([
+            transcript_message("assistant", "msg-before", &serde_json::json!([])),
+            transcript_message("user", "msg-baseline", &serde_json::json!([]))
+        ]));
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-missing".to_string(),
+                baseline_tail_message_id: Some("msg-baseline".to_string()),
+            },
+        );
+
+        assert!(!analysis.has_assistant_message);
+    }
+
+    #[tokio::test]
+    async fn fetches_and_validates_completed_transcript() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        { "type": "text", "text": "done" },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])))
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let validation = supervisor
+            .validate_completion_with_retries(
+                "session-1",
+                &TranscriptWindow {
+                    command_message_id: "msg-dispatch".to_string(),
+                    baseline_tail_message_id: None,
+                },
+            )
+            .await;
+
+        let CompletionValidation::Passed(diagnostics) = validation else {
+            panic!("expected transcript validation success");
+        };
+        assert_eq!(
+            diagnostics.final_assistant_message_id.as_deref(),
+            Some("msg-assistant")
+        );
+        assert_eq!(diagnostics.final_finish_reason.as_deref(), Some("stop"));
     }
 
     fn test_supervisor(mock: &MockServer, directory: &Path) -> OpenCodeSupervisor {

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -24,8 +24,12 @@ use std::time::Duration;
 
 const IDLE_GRACE: Duration = Duration::from_millis(1000);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-const TRANSCRIPT_EMPTY_RETRY_BACKOFFS: [Duration; 2] =
-    [Duration::from_millis(250), Duration::from_millis(500)];
+const TRANSCRIPT_SETTLING_RETRY_BACKOFFS: [Duration; 4] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+];
 const NESTED_GUARD_NEEDLE: &str = "OPENCODE_ORCHESTRATOR_MANAGED";
 const TOOL_ERROR_SUMMARY_LIMIT: usize = 240;
 
@@ -89,6 +93,14 @@ struct TranscriptAnalysis {
     final_finish_reason: Option<String>,
     guard_detected: bool,
     final_tool_error: Option<OpenCodeToolErrorDiagnostics>,
+    unresolved_tool_calls: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdleGateDecision {
+    Finalize,
+    WaitForGrace,
+    IgnoreUntilDispatchConfirmed,
 }
 
 impl TranscriptAnalysis {
@@ -101,6 +113,22 @@ impl TranscriptAnalysis {
             guard_detected: self.guard_detected,
             final_tool_error: self.final_tool_error.clone(),
         }
+    }
+}
+
+fn idle_gate_decision(
+    observed_busy: bool,
+    idle_grace_deadline: Option<tokio::time::Instant>,
+    now: tokio::time::Instant,
+) -> IdleGateDecision {
+    if observed_busy {
+        return IdleGateDecision::Finalize;
+    }
+
+    match idle_grace_deadline {
+        Some(deadline) if now >= deadline => IdleGateDecision::Finalize,
+        Some(_) => IdleGateDecision::WaitForGrace,
+        None => IdleGateDecision::IgnoreUntilDispatchConfirmed,
     }
 }
 
@@ -308,9 +336,21 @@ impl OpenCodeSupervisor {
                             awaiting_idle_grace = false;
                         }
                         Event::SessionIdle { .. } => {
-                            return Ok(self
-                                .completion_outcome(session_id, &transcript_window)
-                                .await);
+                            match idle_gate_decision(
+                                observed_busy,
+                                idle_grace_deadline,
+                                tokio::time::Instant::now(),
+                            ) {
+                                IdleGateDecision::Finalize => {
+                                    return Ok(self
+                                        .completion_outcome(session_id, &transcript_window)
+                                        .await);
+                                }
+                                IdleGateDecision::WaitForGrace => {
+                                    awaiting_idle_grace = true;
+                                }
+                                IdleGateDecision::IgnoreUntilDispatchConfirmed => {}
+                            }
                         }
                         Event::SessionError { properties } => {
                             return Ok(SupervisedOutcome::Failed {
@@ -334,19 +374,21 @@ impl OpenCodeSupervisor {
                             awaiting_idle_grace = false;
                         }
                         Ok(SessionStatusInfo::Idle) => {
-                            if observed_busy {
-                                return Ok(self
-                                    .completion_outcome(session_id, &transcript_window)
-                                    .await);
+                            match idle_gate_decision(
+                                observed_busy,
+                                idle_grace_deadline,
+                                tokio::time::Instant::now(),
+                            ) {
+                                IdleGateDecision::Finalize => {
+                                    return Ok(self
+                                        .completion_outcome(session_id, &transcript_window)
+                                        .await);
+                                }
+                                IdleGateDecision::WaitForGrace => {
+                                    awaiting_idle_grace = true;
+                                }
+                                IdleGateDecision::IgnoreUntilDispatchConfirmed => {}
                             }
-
-                            let grace = idle_grace_deadline.get_or_insert_with(|| tokio::time::Instant::now() + IDLE_GRACE);
-                            if tokio::time::Instant::now() >= *grace {
-                                return Ok(self
-                                    .completion_outcome(session_id, &transcript_window)
-                                    .await);
-                            }
-                            awaiting_idle_grace = true;
                         }
                         Err(error) => {
                             tracing::warn!(error = %error, "failed to poll session status");
@@ -529,9 +571,9 @@ impl OpenCodeSupervisor {
         session_id: &str,
         transcript_window: &TranscriptWindow,
     ) -> CompletionValidation {
-        for attempt in 0..=TRANSCRIPT_EMPTY_RETRY_BACKOFFS.len() {
+        for attempt in 0..=TRANSCRIPT_SETTLING_RETRY_BACKOFFS.len() {
             if attempt > 0 {
-                tokio::time::sleep(TRANSCRIPT_EMPTY_RETRY_BACKOFFS[attempt - 1]).await;
+                tokio::time::sleep(TRANSCRIPT_SETTLING_RETRY_BACKOFFS[attempt - 1]).await;
             }
 
             let messages = match self.client.messages().list(session_id).await {
@@ -562,15 +604,23 @@ impl OpenCodeSupervisor {
                     diagnostics: Some(diagnostics),
                 };
             }
+            if analysis.unresolved_tool_calls > 0 {
+                if attempt == TRANSCRIPT_SETTLING_RETRY_BACKOFFS.len() {
+                    return CompletionValidation::Failed {
+                        error: format!(
+                            "completed session transcript still has {} unresolved tool call(s) after settling retries",
+                            analysis.unresolved_tool_calls
+                        ),
+                        diagnostics: Some(diagnostics),
+                    };
+                }
+                continue;
+            }
             if analysis.has_assistant_message {
                 return CompletionValidation::Passed(diagnostics);
             }
-            if attempt == TRANSCRIPT_EMPTY_RETRY_BACKOFFS.len() {
-                return CompletionValidation::Failed {
-                    error: "completed session transcript did not contain an assistant response after dispatch"
-                        .to_string(),
-                    diagnostics: Some(diagnostics),
-                };
+            if attempt == TRANSCRIPT_SETTLING_RETRY_BACKOFFS.len() {
+                return CompletionValidation::Passed(diagnostics);
             }
         }
 
@@ -623,6 +673,7 @@ fn analyze_transcript_window(
         .rev()
         .find(|message| message.role() == "assistant");
     let mut guard_detected = false;
+    let mut unresolved_tool_calls = 0;
 
     for message in window {
         for part in &message.parts {
@@ -632,14 +683,18 @@ fn analyze_transcript_window(
                         guard_detected = true;
                     }
                 }
-                Part::Tool {
-                    state: Some(tool_state),
-                    ..
-                } => {
-                    if tool_state
-                        .error()
-                        .is_some_and(|error| error.contains(NESTED_GUARD_NEEDLE))
-                    {
+                Part::Tool { state, .. } => {
+                    if state.as_ref().is_none_or(|tool_state| {
+                        !matches!(tool_state, ToolState::Completed(_) | ToolState::Error(_))
+                    }) {
+                        unresolved_tool_calls += 1;
+                    }
+
+                    if state.as_ref().is_some_and(|tool_state| {
+                        tool_state
+                            .error()
+                            .is_some_and(|error| error.contains(NESTED_GUARD_NEEDLE))
+                    }) {
                         guard_detected = true;
                     }
                 }
@@ -678,6 +733,7 @@ fn analyze_transcript_window(
         }),
         guard_detected,
         final_tool_error,
+        unresolved_tool_calls,
     }
 }
 
@@ -769,13 +825,49 @@ mod tests {
     use super::*;
     use crate::test_support::process_state_lock;
     use std::process::Stdio;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering as AtomicOrdering;
     use tempfile::TempDir;
     use tokio::process::Command;
+    use tokio::time::timeout;
     use wiremock::Mock;
     use wiremock::MockServer;
+    use wiremock::Request;
+    use wiremock::Respond;
     use wiremock::ResponseTemplate;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
+
+    #[derive(Clone)]
+    struct SequenceResponder {
+        responders: Vec<ResponseTemplate>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SequenceResponder {
+        fn new(responders: Vec<ResponseTemplate>) -> Self {
+            assert!(!responders.is_empty(), "responders must not be empty");
+            Self {
+                responders,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    impl Respond for SequenceResponder {
+        fn respond(&self, _req: &Request) -> ResponseTemplate {
+            let idx = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            self.responders
+                .get(idx)
+                .cloned()
+                .unwrap_or_else(|| self.responders.last().cloned().expect("non-empty"))
+        }
+    }
 
     fn test_timeouts() -> OpenCodeSupervisorTimeouts {
         OpenCodeSupervisorTimeouts {
@@ -799,6 +891,41 @@ mod tests {
 
     fn parse_messages(value: serde_json::Value) -> Vec<Message> {
         serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn idle_gate_ignores_idle_until_dispatch_is_confirmed() {
+        assert_eq!(
+            idle_gate_decision(false, None, tokio::time::Instant::now()),
+            IdleGateDecision::IgnoreUntilDispatchConfirmed
+        );
+    }
+
+    #[test]
+    fn idle_gate_finalizes_after_observed_busy() {
+        let future_deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        assert_eq!(
+            idle_gate_decision(true, Some(future_deadline), tokio::time::Instant::now()),
+            IdleGateDecision::Finalize
+        );
+    }
+
+    #[test]
+    fn idle_gate_waits_for_grace_before_deadline() {
+        let now = tokio::time::Instant::now();
+        assert_eq!(
+            idle_gate_decision(false, Some(now + Duration::from_millis(50)), now),
+            IdleGateDecision::WaitForGrace
+        );
+    }
+
+    #[test]
+    fn idle_gate_finalizes_after_grace_deadline_elapses() {
+        let now = tokio::time::Instant::now();
+        assert_eq!(
+            idle_gate_decision(false, Some(now), now),
+            IdleGateDecision::Finalize
+        );
     }
 
     #[tokio::test]
@@ -962,6 +1089,81 @@ mod tests {
         assert!(!analysis.has_assistant_message);
     }
 
+    #[test]
+    fn counts_unresolved_tool_states_conservatively() {
+        let messages = parse_messages(serde_json::json!([transcript_message(
+            "assistant",
+            "msg-assistant",
+            &serde_json::json!([
+                {
+                    "type": "tool",
+                    "callID": "call-pending",
+                    "tool": "read",
+                    "state": {
+                        "status": "pending",
+                        "input": {},
+                        "raw": "read"
+                    }
+                },
+                {
+                    "type": "tool",
+                    "callID": "call-running",
+                    "tool": "grep",
+                    "state": {
+                        "status": "running",
+                        "input": {},
+                        "time": { "start": 1 }
+                    }
+                },
+                {
+                    "type": "tool",
+                    "callID": "call-none",
+                    "tool": "write"
+                },
+                {
+                    "type": "tool",
+                    "callID": "call-unknown",
+                    "tool": "edit",
+                    "state": { "status": "paused" }
+                },
+                {
+                    "type": "tool",
+                    "callID": "call-completed",
+                    "tool": "done",
+                    "state": {
+                        "status": "completed",
+                        "input": {},
+                        "output": "ok",
+                        "title": "done",
+                        "metadata": {},
+                        "time": { "start": 1, "end": 2 }
+                    }
+                },
+                {
+                    "type": "tool",
+                    "callID": "call-error",
+                    "tool": "fail",
+                    "state": {
+                        "status": "error",
+                        "input": {},
+                        "error": "boom",
+                        "time": { "start": 1, "end": 2 }
+                    }
+                }
+            ]),
+        )]));
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-assistant".to_string(),
+                baseline_tail_message_id: None,
+            },
+        );
+
+        assert_eq!(analysis.unresolved_tool_calls, 4);
+    }
+
     #[tokio::test]
     async fn fetches_and_validates_completed_transcript() {
         let mock = MockServer::start().await;
@@ -1000,6 +1202,291 @@ mod tests {
             Some("msg-assistant")
         );
         assert_eq!(diagnostics.final_finish_reason.as_deref(), Some("stop"));
+    }
+
+    #[tokio::test]
+    async fn missing_assistant_after_settling_still_passes() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([]))
+            ])))
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let validation = supervisor
+            .validate_completion_with_retries(
+                "session-1",
+                &TranscriptWindow {
+                    command_message_id: "msg-dispatch".to_string(),
+                    baseline_tail_message_id: None,
+                },
+            )
+            .await;
+
+        let CompletionValidation::Passed(diagnostics) = validation else {
+            panic!("expected transcript validation success without assistant");
+        };
+        assert_eq!(diagnostics.final_assistant_message_id, None);
+    }
+
+    #[tokio::test]
+    async fn assistant_appears_after_settling_retry() {
+        let mock = MockServer::start().await;
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
+                "user",
+                "msg-dispatch",
+                &serde_json::json!([])
+            )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        { "type": "text", "text": "done" },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])),
+        ]);
+        let transcript_seq_for_assert = transcript_seq.clone();
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let validation = supervisor
+            .validate_completion_with_retries(
+                "session-1",
+                &TranscriptWindow {
+                    command_message_id: "msg-dispatch".to_string(),
+                    baseline_tail_message_id: None,
+                },
+            )
+            .await;
+
+        let CompletionValidation::Passed(diagnostics) = validation else {
+            panic!("expected transcript validation success after assistant retry");
+        };
+        assert_eq!(
+            diagnostics.final_assistant_message_id.as_deref(),
+            Some("msg-assistant")
+        );
+        assert!(transcript_seq_for_assert.call_count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn unresolved_tool_state_retries_until_resolved() {
+        let mock = MockServer::start().await;
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        {
+                            "type": "tool",
+                            "callID": "call-1",
+                            "tool": "read",
+                            "state": {
+                                "status": "pending",
+                                "input": {},
+                                "raw": "read"
+                            }
+                        },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        {
+                            "type": "tool",
+                            "callID": "call-1",
+                            "tool": "read",
+                            "state": {
+                                "status": "completed",
+                                "input": {},
+                                "output": "ok",
+                                "title": "read",
+                                "metadata": {},
+                                "time": { "start": 1, "end": 2 }
+                            }
+                        },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])),
+        ]);
+        let transcript_seq_for_assert = transcript_seq.clone();
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let validation = supervisor
+            .validate_completion_with_retries(
+                "session-1",
+                &TranscriptWindow {
+                    command_message_id: "msg-dispatch".to_string(),
+                    baseline_tail_message_id: None,
+                },
+            )
+            .await;
+
+        assert!(matches!(validation, CompletionValidation::Passed(_)));
+        assert!(transcript_seq_for_assert.call_count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn unresolved_tool_state_after_settling_fails() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-dispatch", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        {
+                            "type": "tool",
+                            "callID": "call-1",
+                            "tool": "read"
+                        },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])))
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let validation = supervisor
+            .validate_completion_with_retries(
+                "session-1",
+                &TranscriptWindow {
+                    command_message_id: "msg-dispatch".to_string(),
+                    baseline_tail_message_id: None,
+                },
+            )
+            .await;
+
+        let CompletionValidation::Failed { error, .. } = validation else {
+            panic!("expected unresolved tool state to fail after retries");
+        };
+        assert!(error.contains("unresolved tool call"));
+    }
+
+    #[tokio::test]
+    async fn run_command_supervised_does_not_complete_before_dispatch_confirmation() {
+        let mock = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/session-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "session-1",
+                "slug": "session-1",
+                "projectId": "proj-1",
+                "directory": "/tmp",
+                "path": null,
+                "title": "Test Session",
+                "version": "1.0",
+                "time": { "created": 1, "updated": 1 }
+            })))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/permission"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/question"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/event"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_delay(Duration::from_secs(30)),
+            )
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(2))
+                    .set_body_json(serde_json::json!({})),
+            )
+            .mount(&mock)
+            .await;
+
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
+                "assistant",
+                "msg-assistant",
+                &serde_json::json!([
+                    { "type": "text", "text": "done" },
+                    { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                ]),
+            )])),
+        ]);
+        let transcript_seq_for_assert = transcript_seq.clone();
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let temp_dir = TempDir::new().unwrap();
+        let supervisor = test_supervisor(&mock, temp_dir.path());
+        let mut handle = tokio::spawn(async move {
+            supervisor
+                .run_command_supervised(Some("session-1"), "implement_plan", Some("do it"))
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(1200), &mut handle)
+                .await
+                .is_err(),
+            "supervisor should still be waiting before dispatch is confirmed"
+        );
+
+        let outcome = timeout(Duration::from_secs(5), &mut handle)
+            .await
+            .expect("supervisor should eventually complete")
+            .expect("join should succeed")
+            .expect("run should succeed");
+
+        assert!(matches!(outcome, SupervisedOutcome::Completed { .. }));
+        assert!(
+            transcript_seq_for_assert.call_count() >= 2,
+            "expected baseline and completion transcript fetches"
+        );
     }
 
     fn test_supervisor(mock: &MockServer, directory: &Path) -> OpenCodeSupervisor {

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -3,6 +3,7 @@ use crate::state::OpenCodeToolErrorDiagnostics;
 use anyhow::Context;
 use anyhow::Result;
 use opencode_rs::Client;
+use opencode_rs::OpencodeError;
 use opencode_rs::server::ManagedServer;
 use opencode_rs::server::ServerOptions;
 use opencode_rs::types::event::Event;
@@ -112,6 +113,7 @@ impl TranscriptAnalysis {
             final_finish_reason: self.final_finish_reason.clone(),
             guard_detected: self.guard_detected,
             final_tool_error: self.final_tool_error.clone(),
+            command_transport_error: None,
         }
     }
 }
@@ -130,6 +132,27 @@ fn idle_gate_decision(
         Some(_) => IdleGateDecision::WaitForGrace,
         None => IdleGateDecision::IgnoreUntilDispatchConfirmed,
     }
+}
+
+fn transcript_indicates_dispatch(
+    messages: &[Message],
+    transcript_window: &TranscriptWindow,
+) -> bool {
+    if messages
+        .iter()
+        .any(|message| message.id() == transcript_window.command_message_id)
+    {
+        return true;
+    }
+
+    if let Some(baseline) = transcript_window.baseline_tail_message_id.as_ref() {
+        return messages
+            .iter()
+            .position(|message| message.id() == baseline)
+            .is_some_and(|index| index + 1 < messages.len());
+    }
+
+    !messages.is_empty()
 }
 
 #[derive(Debug)]
@@ -276,6 +299,7 @@ impl OpenCodeSupervisor {
         let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
         let mut awaiting_idle_grace = false;
         let mut sse_active = true;
+        let mut command_transport_error: Option<String> = None;
 
         loop {
             let now = tokio::time::Instant::now();
@@ -343,7 +367,11 @@ impl OpenCodeSupervisor {
                             ) {
                                 IdleGateDecision::Finalize => {
                                     return Ok(self
-                                        .completion_outcome(session_id, &transcript_window)
+                                        .completion_outcome(
+                                            session_id,
+                                            &transcript_window,
+                                            command_transport_error.as_ref(),
+                                        )
                                         .await);
                                 }
                                 IdleGateDecision::WaitForGrace => {
@@ -381,7 +409,11 @@ impl OpenCodeSupervisor {
                             ) {
                                 IdleGateDecision::Finalize => {
                                     return Ok(self
-                                        .completion_outcome(session_id, &transcript_window)
+                                        .completion_outcome(
+                                            session_id,
+                                            &transcript_window,
+                                            command_transport_error.as_ref(),
+                                        )
                                         .await);
                                 }
                                 IdleGateDecision::WaitForGrace => {
@@ -407,10 +439,66 @@ impl OpenCodeSupervisor {
                             command_task = None;
                         }
                         Some(Ok(Err(error))) => {
+                            if !matches!(error, OpencodeError::Transport(_)) {
+                                return Ok(SupervisedOutcome::Failed {
+                                    session_id: Some(session_id),
+                                    error: error.to_string(),
+                                    diagnostics: None,
+                                });
+                            }
+
+                            let mut start_evidence = observed_busy;
+
+                            if !start_evidence
+                                && let Ok(status) = self.client.sessions().status_for(&session_id).await
+                                && status.is_busy_like()
+                            {
+                                start_evidence = true;
+                                observed_busy = true;
+                                last_activity = tokio::time::Instant::now();
+                                awaiting_idle_grace = false;
+                            }
+
+                            if !start_evidence {
+                                match self.client.messages().list(&session_id).await {
+                                    Ok(messages) if transcript_indicates_dispatch(&messages, &transcript_window) => {
+                                        start_evidence = true;
+                                        idle_grace_deadline
+                                            .get_or_insert_with(|| tokio::time::Instant::now() + IDLE_GRACE);
+                                        last_activity = tokio::time::Instant::now();
+                                    }
+                                    Ok(_) => {}
+                                    Err(probe_error) => {
+                                        tracing::warn!(error = %probe_error, "failed transcript probe after /command transport error");
+                                    }
+                                }
+                            }
+
+                            if start_evidence {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    error = %error,
+                                    "POST /session/{session_id}/command transport error after start evidence; continuing supervision via SSE/status"
+                                );
+                                command_transport_error.get_or_insert_with(|| error.to_string());
+                                command_task = None;
+                                continue;
+                            }
+
                             return Ok(SupervisedOutcome::Failed {
                                 session_id: Some(session_id),
-                                error: error.to_string(),
-                                diagnostics: None,
+                                error: format!(
+                                    "transport error dispatching OpenCode command '{command_name}' (no session start evidence observed): {error}"
+                                ),
+                                diagnostics: Some(OpenCodeDiagnostics {
+                                    checked_at: chrono::Utc::now().to_rfc3339(),
+                                    command_message_id: Some(transcript_window.command_message_id.clone()),
+                                    final_assistant_message_id: None,
+                                    final_finish_reason: None,
+                                    guard_detected: false,
+                                    final_tool_error: None,
+                                    command_transport_error: Some(error.to_string()),
+                                }),
                             });
                         }
                         Some(Err(error)) => {
@@ -432,7 +520,11 @@ impl OpenCodeSupervisor {
                     awaiting_idle_grace = false;
                     if matches!(self.client.sessions().status_for(&session_id).await, Ok(SessionStatusInfo::Idle)) {
                         return Ok(self
-                            .completion_outcome(session_id, &transcript_window)
+                            .completion_outcome(
+                                session_id,
+                                &transcript_window,
+                                command_transport_error.as_ref(),
+                            )
                             .await);
                     }
                     observed_busy = true;
@@ -536,8 +628,9 @@ impl OpenCodeSupervisor {
         &self,
         session_id: String,
         transcript_window: &TranscriptWindow,
+        command_transport_error: Option<&String>,
     ) -> SupervisedOutcome {
-        match self
+        let outcome = match self
             .validate_completion_with_retries(&session_id, transcript_window)
             .await
         {
@@ -550,7 +643,9 @@ impl OpenCodeSupervisor {
                 error,
                 diagnostics,
             },
-        }
+        };
+
+        attach_transport_warning(outcome, command_transport_error)
     }
 
     async fn fetch_transcript_tail_id(&self, session_id: &str) -> Result<Option<String>> {
@@ -734,6 +829,41 @@ fn analyze_transcript_window(
         guard_detected,
         final_tool_error,
         unresolved_tool_calls,
+    }
+}
+
+fn attach_transport_warning(
+    outcome: SupervisedOutcome,
+    warning: Option<&String>,
+) -> SupervisedOutcome {
+    let Some(warning) = warning.cloned() else {
+        return outcome;
+    };
+
+    match outcome {
+        SupervisedOutcome::Completed {
+            session_id,
+            mut diagnostics,
+        } => {
+            diagnostics.command_transport_error.get_or_insert(warning);
+            SupervisedOutcome::Completed {
+                session_id,
+                diagnostics,
+            }
+        }
+        SupervisedOutcome::Failed {
+            session_id,
+            error,
+            diagnostics: Some(mut diagnostics),
+        } => {
+            diagnostics.command_transport_error.get_or_insert(warning);
+            SupervisedOutcome::Failed {
+                session_id,
+                error,
+                diagnostics: Some(diagnostics),
+            }
+        }
+        other => other,
     }
 }
 
@@ -1490,6 +1620,170 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn command_transport_error_after_busy_observed_continues_until_idle_and_completes() {
+        let mock = MockServer::start().await;
+
+        mount_existing_session(&mock).await;
+        mount_empty_interruptions(&mock).await;
+        Mock::given(method("GET"))
+            .and(path("/event"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(
+                        "data: {\"type\":\"message.part.updated\",\"properties\":{\"sessionID\":\"session-1\"}}\n\n",
+                    ),
+            )
+            .mount(&mock)
+            .await;
+
+        let status_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"session-1": {"type": "busy"}})),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({})),
+        ]);
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(status_seq)
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .set_delay(Duration::from_millis(50))
+                    .insert_header("location", "http://127.0.0.1:1/redirected-command"),
+            )
+            .mount(&mock)
+            .await;
+
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
+                "assistant",
+                "msg-assistant",
+                &serde_json::json!([
+                    { "type": "text", "text": "done" },
+                    { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                ]),
+            )])),
+        ]);
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let outcome = supervisor
+            .run_command_supervised(Some("session-1"), "implement_plan", Some("do it"))
+            .await
+            .expect("run should succeed");
+
+        let SupervisedOutcome::Completed { diagnostics, .. } = outcome else {
+            panic!("expected completed outcome after post-start transport error");
+        };
+        assert!(diagnostics.command_transport_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn attach_transport_warning_sets_completed_diagnostics_warning() {
+        let warning = Some("Transport error: timeout".to_string());
+        let outcome = attach_transport_warning(
+            SupervisedOutcome::Completed {
+                session_id: "session-1".to_string(),
+                diagnostics: OpenCodeDiagnostics {
+                    checked_at: "2026-01-01T00:00:00Z".to_string(),
+                    command_message_id: Some("msg-dispatch".to_string()),
+                    final_assistant_message_id: Some("msg-assistant".to_string()),
+                    final_finish_reason: Some("stop".to_string()),
+                    guard_detected: false,
+                    final_tool_error: None,
+                    command_transport_error: None,
+                },
+            },
+            warning.as_ref(),
+        );
+
+        let SupervisedOutcome::Completed { diagnostics, .. } = outcome else {
+            panic!("expected completed outcome");
+        };
+        assert_eq!(
+            diagnostics.command_transport_error.as_deref(),
+            Some("Transport error: timeout")
+        );
+    }
+
+    #[tokio::test]
+    async fn command_transport_error_before_any_start_evidence_fails_fast() {
+        let mock = MockServer::start().await;
+
+        mount_existing_session(&mock).await;
+        mount_empty_interruptions(&mock).await;
+        mount_stalled_event_stream(&mock).await;
+
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .set_delay(Duration::from_secs(2))
+                    .insert_header("location", "http://127.0.0.1:1/redirected-command"),
+            )
+            .mount(&mock)
+            .await;
+
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+        ]);
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let outcome = supervisor
+            .run_command_supervised(Some("session-1"), "implement_plan", Some("do it"))
+            .await
+            .expect("run should return classified failure");
+
+        let SupervisedOutcome::Failed {
+            error,
+            diagnostics: Some(diagnostics),
+            ..
+        } = outcome
+        else {
+            panic!("expected failed outcome without start evidence");
+        };
+        assert!(error.contains("no session start evidence observed"));
+        assert!(diagnostics.command_transport_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn command_transport_error_before_busy_but_transcript_shows_dispatch_window_continues() {
+        let messages = parse_messages(serde_json::json!([
+            transcript_message("assistant", "msg-baseline", &serde_json::json!([])),
+            transcript_message("user", "msg-dispatch-window", &serde_json::json!([])),
+        ]));
+
+        assert!(transcript_indicates_dispatch(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-missing".to_string(),
+                baseline_tail_message_id: Some("msg-baseline".to_string()),
+            },
+        ));
+    }
+
     fn test_supervisor(mock: &MockServer, directory: &Path) -> OpenCodeSupervisor {
         let child = Command::new("sleep")
             .arg("60")
@@ -1509,6 +1803,48 @@ mod tests {
             _directory: directory.to_path_buf(),
             timeouts: test_timeouts(),
         }
+    }
+
+    async fn mount_existing_session(mock: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/session/session-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "session-1",
+                "slug": "session-1",
+                "projectId": "proj-1",
+                "directory": "/tmp",
+                "path": null,
+                "title": "Test Session",
+                "version": "1.0",
+                "time": { "created": 1, "updated": 1 }
+            })))
+            .mount(mock)
+            .await;
+    }
+
+    async fn mount_empty_interruptions(mock: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/permission"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/question"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock)
+            .await;
+    }
+
+    async fn mount_stalled_event_stream(mock: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/event"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_delay(Duration::from_secs(30)),
+            )
+            .mount(mock)
+            .await;
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -701,8 +701,12 @@ struct LauncherConfig {
 fn resolve_launcher_config(base_dir: &Path) -> Result<LauncherConfig> {
     let launcher_args = parse_launcher_args();
     if !launcher_args.is_empty() {
-        let binary = std::env::var(version::OPENCODE_BINARY_ENV)
-            .map_or_else(|_| "opencode".to_string(), |value| value.trim().to_string());
+        let binary = match std::env::var(version::OPENCODE_BINARY_ENV) {
+            Ok(value) => value.trim().to_string(),
+            Err(_) => anyhow::bail!(
+                "OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is not set; set OPENCODE_BINARY to the launcher command"
+            ),
+        };
         if binary.is_empty() {
             anyhow::bail!(
                 "OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is empty; set it to the launcher command"
@@ -763,6 +767,7 @@ fn parse_launcher_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::process_state_lock;
     use std::process::Stdio;
     use tempfile::TempDir;
     use tokio::process::Command;
@@ -1016,5 +1021,129 @@ mod tests {
             _directory: directory.to_path_buf(),
             timeouts: test_timeouts(),
         }
+    }
+
+    #[test]
+    fn resolve_launcher_config_errors_when_args_set_but_binary_missing() {
+        let _guard = process_state_lock().lock().unwrap();
+        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
+        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
+
+        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+        unsafe {
+            std::env::remove_var(version::OPENCODE_BINARY_ENV);
+            std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
+        }
+
+        let err = resolve_launcher_config(Path::new("/tmp/project"))
+            .expect_err("missing launcher binary should fail");
+
+        match previous_binary {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
+            }
+        }
+        match previous_args {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
+            }
+        }
+
+        assert!(
+            err.to_string()
+                .contains("OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is not set")
+        );
+    }
+
+    #[test]
+    fn resolve_launcher_config_errors_when_args_set_but_binary_empty() {
+        let _guard = process_state_lock().lock().unwrap();
+        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
+        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
+
+        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+        unsafe {
+            std::env::set_var(version::OPENCODE_BINARY_ENV, "   ");
+            std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, "serve --help");
+        }
+
+        let err = resolve_launcher_config(Path::new("/tmp/project"))
+            .expect_err("empty launcher binary should fail");
+
+        match previous_binary {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
+            }
+        }
+        match previous_args {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
+            }
+        }
+
+        assert!(err.to_string().contains("OPENCODE_BINARY is empty"));
+    }
+
+    #[test]
+    fn resolve_launcher_config_accepts_explicit_binary_with_args() {
+        let _guard = process_state_lock().lock().unwrap();
+        let previous_binary = std::env::var_os(version::OPENCODE_BINARY_ENV);
+        let previous_args = std::env::var_os(version::OPENCODE_BINARY_ARGS_ENV);
+
+        // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+        unsafe {
+            std::env::set_var(version::OPENCODE_BINARY_ENV, "bunx");
+            std::env::set_var(
+                version::OPENCODE_BINARY_ARGS_ENV,
+                "--yes opencode-ai@1.17.4",
+            );
+        }
+
+        let config = resolve_launcher_config(Path::new("/tmp/project"))
+            .expect("explicit launcher binary should succeed");
+
+        match previous_binary {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ENV) };
+            }
+        }
+        match previous_args {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(version::OPENCODE_BINARY_ARGS_ENV, value) };
+            }
+            None => {
+                // SAFETY: this test serializes process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(version::OPENCODE_BINARY_ARGS_ENV) };
+            }
+        }
+
+        assert_eq!(config.binary, "bunx");
+        assert_eq!(config.launcher_args, vec!["--yes", "opencode-ai@1.17.4"]);
     }
 }

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -24,8 +24,6 @@ use std::time::Duration;
 
 const IDLE_GRACE: Duration = Duration::from_millis(1000);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-const SESSION_DEADLINE: Duration = Duration::from_secs(3600);
-const INACTIVITY_TIMEOUT: Duration = Duration::from_secs(300);
 const TRANSCRIPT_EMPTY_RETRY_BACKOFFS: [Duration; 2] =
     [Duration::from_millis(250), Duration::from_millis(500)];
 const NESTED_GUARD_NEEDLE: &str = "OPENCODE_ORCHESTRATOR_MANAGED";
@@ -37,6 +35,22 @@ pub struct OpenCodeSupervisor {
     _managed_server: ManagedServer,
     client: Client,
     _directory: PathBuf,
+    timeouts: OpenCodeSupervisorTimeouts,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenCodeSupervisorTimeouts {
+    pub session_deadline: Duration,
+    pub inactivity_timeout: Duration,
+}
+
+impl OpenCodeSupervisorTimeouts {
+    pub fn from_settings(settings: &crate::state::Settings) -> Self {
+        Self {
+            session_deadline: Duration::from_secs(settings.opencode_session_deadline_seconds),
+            inactivity_timeout: Duration::from_secs(settings.opencode_inactivity_timeout_seconds),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,7 +114,7 @@ enum CompletionValidation {
 }
 
 impl OpenCodeSupervisor {
-    pub async fn start(directory: &Path) -> Result<Self> {
+    pub async fn start(directory: &Path, timeouts: OpenCodeSupervisorTimeouts) -> Result<Self> {
         let cwd = directory.canonicalize().with_context(|| {
             format!(
                 "failed to canonicalize OpenCode directory {}",
@@ -151,6 +165,7 @@ impl OpenCodeSupervisor {
             _managed_server: managed,
             client,
             _directory: cwd,
+            timeouts,
         })
     }
 
@@ -225,7 +240,7 @@ impl OpenCodeSupervisor {
                 .map(|_| ())
         }));
 
-        let deadline = tokio::time::Instant::now() + SESSION_DEADLINE;
+        let deadline = tokio::time::Instant::now() + self.timeouts.session_deadline;
         let mut last_activity = tokio::time::Instant::now();
         let mut poll_interval = tokio::time::interval(POLL_INTERVAL);
         poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -236,17 +251,23 @@ impl OpenCodeSupervisor {
 
         loop {
             let now = tokio::time::Instant::now();
-            if now.duration_since(last_activity) >= INACTIVITY_TIMEOUT {
+            if now.duration_since(last_activity) >= self.timeouts.inactivity_timeout {
                 return Ok(SupervisedOutcome::Failed {
                     session_id: Some(session_id.clone()),
-                    error: "session idle timeout after 5 minutes".to_string(),
+                    error: format!(
+                        "session idle timeout after {}",
+                        describe_duration(self.timeouts.inactivity_timeout)
+                    ),
                     diagnostics: None,
                 });
             }
             if now >= deadline {
                 return Ok(SupervisedOutcome::Failed {
                     session_id: Some(session_id.clone()),
-                    error: "session execution timed out after 1 hour".to_string(),
+                    error: format!(
+                        "session execution timed out after {}",
+                        describe_duration(self.timeouts.session_deadline)
+                    ),
                     diagnostics: None,
                 });
             }
@@ -560,6 +581,19 @@ impl OpenCodeSupervisor {
     }
 }
 
+fn describe_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds.is_multiple_of(3600) {
+        let hours = seconds / 3600;
+        return format!("{hours} hour{}", if hours == 1 { "" } else { "s" });
+    }
+    if seconds.is_multiple_of(60) {
+        let minutes = seconds / 60;
+        return format!("{minutes} minute{}", if minutes == 1 { "" } else { "s" });
+    }
+    format!("{seconds} second{}", if seconds == 1 { "" } else { "s" })
+}
+
 fn generate_command_message_id() -> String {
     let tick = COMMAND_MESSAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!(
@@ -738,6 +772,13 @@ mod tests {
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
+    fn test_timeouts() -> OpenCodeSupervisorTimeouts {
+        OpenCodeSupervisorTimeouts {
+            session_deadline: Duration::from_secs(8 * 60 * 60),
+            inactivity_timeout: Duration::from_secs(5 * 60),
+        }
+    }
+
     fn transcript_message(role: &str, id: &str, parts: &serde_json::Value) -> serde_json::Value {
         serde_json::json!({
             "info": {
@@ -889,6 +930,16 @@ mod tests {
     }
 
     #[test]
+    fn describe_duration_uses_human_friendly_units() {
+        assert_eq!(
+            describe_duration(Duration::from_secs(8 * 60 * 60)),
+            "8 hours"
+        );
+        assert_eq!(describe_duration(Duration::from_secs(5 * 60)), "5 minutes");
+        assert_eq!(describe_duration(Duration::from_secs(45)), "45 seconds");
+    }
+
+    #[test]
     fn requires_assistant_message_after_dispatch_window() {
         let messages = parse_messages(serde_json::json!([
             transcript_message("assistant", "msg-before", &serde_json::json!([])),
@@ -963,6 +1014,7 @@ mod tests {
             _managed_server: managed,
             client,
             _directory: directory.to_path_buf(),
+            timeouts: test_timeouts(),
         }
     }
 }

--- a/apps/agentic-outer-dag/src/preview.rs
+++ b/apps/agentic-outer-dag/src/preview.rs
@@ -1,0 +1,208 @@
+use crate::dag::engine::PlannedAction;
+use crate::dag::engine::planned_actions_for_start;
+use crate::state;
+use crate::worktree;
+use anyhow::Result;
+use serde::Serialize;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+pub struct DryRunStartPreview {
+    pub ticket: String,
+    pub branch: String,
+    pub worktree: Option<String>,
+    pub stage: state::StageKind,
+    pub state_file: String,
+    pub would_create: bool,
+    pub blocked_without_force: bool,
+    pub planned_actions: Vec<PlannedAction>,
+}
+
+pub fn build_dry_run_start_preview(
+    ticket: &str,
+    branch: Option<&str>,
+    worktree_path: Option<&Path>,
+    force: bool,
+) -> Result<DryRunStartPreview> {
+    let plan = worktree::preview_resolve(branch, worktree_path)?;
+    let state_file = format!(
+        "./thoughts/{}/artifacts/{}",
+        plan.branch,
+        state::STATE_FILENAME
+    );
+    let blocked_without_force = state_file_path(&plan, worktree_path)?.exists() && !force;
+
+    Ok(DryRunStartPreview {
+        ticket: ticket.to_string(),
+        branch: plan.branch,
+        worktree: plan.path.as_ref().map(|path| path.display().to_string()),
+        stage: state::StageKind::FreshnessBeforeTicketToPr,
+        state_file,
+        would_create: plan.would_create,
+        blocked_without_force,
+        planned_actions: planned_actions_for_start(),
+    })
+}
+
+fn state_file_path(
+    plan: &worktree::WorktreePreview,
+    worktree_path: Option<&Path>,
+) -> Result<PathBuf> {
+    let anchor = if let Some(path) = plan.path.as_ref() {
+        path.clone()
+    } else if let Some(path) = worktree_path {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?
+    };
+
+    Ok(anchor
+        .join("thoughts")
+        .join(&plan.branch)
+        .join("artifacts")
+        .join(state::STATE_FILENAME))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::env;
+    use std::fs;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+    use tempfile::TempDir;
+
+    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn serializes_nullable_worktree_field_as_null() {
+        let preview = DryRunStartPreview {
+            ticket: "ENG-992".to_string(),
+            branch: "feature/eng-992".to_string(),
+            worktree: None,
+            stage: state::StageKind::FreshnessBeforeTicketToPr,
+            state_file: "./thoughts/feature/eng-992/artifacts/agentic-outer-dag-state.json"
+                .to_string(),
+            would_create: true,
+            blocked_without_force: false,
+            planned_actions: planned_actions_for_start(),
+        };
+
+        let json = serde_json::to_value(&preview).unwrap();
+
+        assert!(json.get("worktree").unwrap().is_null());
+        assert_eq!(
+            json.get("stage").unwrap(),
+            &serde_json::Value::String("freshness_before_ticket_to_pr".to_string())
+        );
+    }
+
+    #[test]
+    fn reports_blocked_without_force_when_state_file_exists() {
+        let fixture = GitFixture::new().unwrap();
+        let branch = fixture.current_branch().unwrap();
+        let state_dir = fixture
+            .repo
+            .join("thoughts")
+            .join(&branch)
+            .join("artifacts");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(state_dir.join(state::STATE_FILENAME), "{}\n").unwrap();
+
+        let preview =
+            build_dry_run_start_preview("ENG-992", Some(&branch), Some(&fixture.repo), false)
+                .unwrap();
+
+        assert!(preview.blocked_without_force);
+        assert!(!preview.would_create);
+        assert_eq!(
+            preview.state_file,
+            format!("./thoughts/{branch}/artifacts/{}", state::STATE_FILENAME)
+        );
+    }
+
+    #[test]
+    fn reports_would_create_for_branch_without_existing_worktree() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.repo).unwrap();
+
+        let preview =
+            build_dry_run_start_preview("ENG-992", Some("feature/preview-only"), None, false)
+                .unwrap();
+
+        env::set_current_dir(saved).unwrap();
+
+        assert!(preview.would_create);
+        assert_eq!(preview.branch, "feature/preview-only");
+        assert_eq!(
+            preview.planned_actions.first().map(|action| action.id),
+            Some("worktree.resolve")
+        );
+    }
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        CWD_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct GitFixture {
+        _temp: TempDir,
+        repo: PathBuf,
+    }
+
+    impl GitFixture {
+        fn new() -> Result<Self> {
+            let temp = TempDir::new()?;
+            let repo = temp.path().join("repo");
+
+            run_git(temp.path(), ["init", repo.to_str().unwrap()])?;
+            run_git(&repo, ["config", "user.name", "Test User"])?;
+            run_git(&repo, ["config", "user.email", "test@example.com"])?;
+            fs::write(repo.join("README.md"), "base\n")?;
+            run_git(&repo, ["add", "README.md"])?;
+            run_git(&repo, ["commit", "-m", "initial"])?;
+            run_git(&repo, ["branch", "feature/preview-only"])?;
+
+            Ok(Self { _temp: temp, repo })
+        }
+
+        fn current_branch(&self) -> Result<String> {
+            git_output(&self.repo, ["branch", "--show-current"])
+        }
+    }
+
+    fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<()> {
+        let output = std::process::Command::new("git")
+            .current_dir(cwd)
+            .args(args)
+            .output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    fn git_output<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
+        let output = std::process::Command::new("git")
+            .current_dir(cwd)
+            .args(args)
+            .output()?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+}

--- a/apps/agentic-outer-dag/src/preview.rs
+++ b/apps/agentic-outer-dag/src/preview.rs
@@ -67,14 +67,12 @@ fn state_file_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::CwdGuard;
+    use crate::test_support::process_state_lock;
     use anyhow::Result;
     use std::env;
     use std::fs;
-    use std::sync::Mutex;
-    use std::sync::OnceLock;
     use tempfile::TempDir;
-
-    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[test]
     fn serializes_nullable_worktree_field_as_null() {
@@ -125,16 +123,13 @@ mod tests {
 
     #[test]
     fn reports_would_create_for_branch_without_existing_worktree() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.repo).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
 
         let preview =
             build_dry_run_start_preview("ENG-992", Some("feature/preview-only"), None, false)
                 .unwrap();
-
-        env::set_current_dir(saved).unwrap();
 
         assert!(preview.would_create);
         assert_eq!(preview.branch, "feature/preview-only");
@@ -144,8 +139,19 @@ mod tests {
         );
     }
 
-    fn cwd_lock() -> &'static Mutex<()> {
-        CWD_LOCK.get_or_init(|| Mutex::new(()))
+    #[test]
+    fn cwd_guard_restores_on_panic() {
+        let _guard = process_state_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let saved = env::current_dir().unwrap();
+
+        let panic = std::panic::catch_unwind(|| {
+            let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
+            panic!("intentional panic to test cwd restoration");
+        });
+
+        assert!(panic.is_err());
+        assert_eq!(env::current_dir().unwrap(), saved);
     }
 
     struct GitFixture {

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -12,6 +12,8 @@ use std::sync::atomic::Ordering;
 pub const STATE_FILENAME: &str = "agentic-outer-dag-state.json";
 pub const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 30;
 pub const DEFAULT_CODERABBIT_TIMEOUT_SECONDS: u64 = 3600;
+pub const DEFAULT_OPENCODE_SESSION_DEADLINE_SECONDS: u64 = 8 * 60 * 60;
+pub const DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS: u64 = 5 * 60;
 const SCHEMA_VERSION: u32 = 1;
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -52,6 +54,10 @@ pub struct Settings {
     pub dry_run: bool,
     pub poll_interval_seconds: u64,
     pub coderabbit_timeout_seconds: u64,
+    #[serde(default = "default_opencode_session_deadline_seconds")]
+    pub opencode_session_deadline_seconds: u64,
+    #[serde(default = "default_opencode_inactivity_timeout_seconds")]
+    pub opencode_inactivity_timeout_seconds: u64,
     pub max_review_cycles: u32,
     #[serde(default = "default_linear_handoff_enabled")]
     pub linear_handoff_enabled: bool,
@@ -217,6 +223,8 @@ impl RunState {
                 dry_run,
                 poll_interval_seconds: DEFAULT_POLL_INTERVAL_SECONDS,
                 coderabbit_timeout_seconds: DEFAULT_CODERABBIT_TIMEOUT_SECONDS,
+                opencode_session_deadline_seconds: DEFAULT_OPENCODE_SESSION_DEADLINE_SECONDS,
+                opencode_inactivity_timeout_seconds: DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS,
                 max_review_cycles: 5,
                 linear_handoff_enabled: default_linear_handoff_enabled(),
                 opencode_dispatch_enabled: default_opencode_dispatch_enabled(),
@@ -246,6 +254,14 @@ const fn default_linear_handoff_enabled() -> bool {
 
 const fn default_opencode_dispatch_enabled() -> bool {
     true
+}
+
+const fn default_opencode_session_deadline_seconds() -> u64 {
+    DEFAULT_OPENCODE_SESSION_DEADLINE_SECONDS
+}
+
+const fn default_opencode_inactivity_timeout_seconds() -> u64 {
+    DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS
 }
 
 fn generate_run_id() -> String {
@@ -421,6 +437,14 @@ mod tests {
 
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
+        assert_eq!(
+            roundtrip.settings.opencode_session_deadline_seconds,
+            DEFAULT_OPENCODE_SESSION_DEADLINE_SECONDS
+        );
+        assert_eq!(
+            roundtrip.settings.opencode_inactivity_timeout_seconds,
+            DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS
+        );
         assert!(roundtrip.opencode.last_diagnostics.is_none());
     }
 
@@ -459,6 +483,14 @@ mod tests {
         assert_eq!(
             state.settings.coderabbit_timeout_seconds,
             DEFAULT_CODERABBIT_TIMEOUT_SECONDS
+        );
+        assert_eq!(
+            state.settings.opencode_session_deadline_seconds,
+            DEFAULT_OPENCODE_SESSION_DEADLINE_SECONDS
+        );
+        assert_eq!(
+            state.settings.opencode_inactivity_timeout_seconds,
+            DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS
         );
     }
 

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -89,12 +89,40 @@ pub enum StageKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OpenCodeState {
+    #[serde(default)]
     pub active_session_id: Option<String>,
+    #[serde(default)]
     pub last_command: Option<String>,
     pub dispatch_attempt: u32,
+    #[serde(default)]
     pub resume_stage: Option<StageKind>,
+    #[serde(default)]
     pub pending_permission: Option<PendingPermission>,
+    #[serde(default)]
     pub pending_question: Option<PendingQuestion>,
+    #[serde(default)]
+    pub last_diagnostics: Option<OpenCodeDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenCodeDiagnostics {
+    pub checked_at: String,
+    #[serde(default)]
+    pub command_message_id: Option<String>,
+    #[serde(default)]
+    pub final_assistant_message_id: Option<String>,
+    #[serde(default)]
+    pub final_finish_reason: Option<String>,
+    #[serde(default)]
+    pub guard_detected: bool,
+    #[serde(default)]
+    pub final_tool_error: Option<OpenCodeToolErrorDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenCodeToolErrorDiagnostics {
+    pub tool: String,
+    pub error: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -285,6 +313,17 @@ mod tests {
             request_id: "question-1".to_string(),
             prompt: "Continue?".to_string(),
         });
+        state.opencode.last_diagnostics = Some(OpenCodeDiagnostics {
+            checked_at: "2026-01-01T00:00:00Z".to_string(),
+            command_message_id: Some("msg-outer-dag-1".to_string()),
+            final_assistant_message_id: Some("msg-assistant-1".to_string()),
+            final_finish_reason: Some("stop".to_string()),
+            guard_detected: false,
+            final_tool_error: Some(OpenCodeToolErrorDiagnostics {
+                tool: "read".to_string(),
+                error: "permission denied".to_string(),
+            }),
+        });
         state.stage.kind = StageKind::StoppedQuestionRequired;
 
         let json = serde_json::to_string_pretty(&state).unwrap();
@@ -303,6 +342,15 @@ mod tests {
         assert_eq!(
             roundtrip.opencode.pending_question.as_ref().unwrap().prompt,
             "Continue?"
+        );
+        assert_eq!(
+            roundtrip
+                .opencode
+                .last_diagnostics
+                .as_ref()
+                .and_then(|diagnostics| diagnostics.final_tool_error.as_ref())
+                .map(|diagnostics| diagnostics.tool.as_str()),
+            Some("read")
         );
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
@@ -340,7 +388,8 @@ mod tests {
                 "dispatch_attempt": 0,
                 "resume_stage": null,
                 "pending_permission": null,
-                "pending_question": null
+                "pending_question": null,
+                "last_diagnostics": null
             },
             "pr": {
                 "number": null,
@@ -372,6 +421,22 @@ mod tests {
 
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
+        assert!(roundtrip.opencode.last_diagnostics.is_none());
+    }
+
+    #[test]
+    fn opencode_diagnostics_default_new_fields_for_legacy_state() {
+        let opencode: OpenCodeState = serde_json::from_value(serde_json::json!({
+            "active_session_id": null,
+            "last_command": null,
+            "dispatch_attempt": 0,
+            "resume_stage": null,
+            "pending_permission": null,
+            "pending_question": null
+        }))
+        .unwrap();
+
+        assert!(opencode.last_diagnostics.is_none());
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -90,6 +90,7 @@ pub enum StageKind {
     StoppedReviewSkipped,
     StoppedTimedOut,
     StoppedReadyForHumanReview,
+    StoppedTicketToPrNoPrHandoff,
     StoppedFailed,
 }
 
@@ -123,6 +124,8 @@ pub struct OpenCodeDiagnostics {
     pub guard_detected: bool,
     #[serde(default)]
     pub final_tool_error: Option<OpenCodeToolErrorDiagnostics>,
+    #[serde(default)]
+    pub command_transport_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -314,6 +317,7 @@ mod tests {
             StageKind::StoppedReviewSkipped,
             StageKind::StoppedTimedOut,
             StageKind::StoppedReadyForHumanReview,
+            StageKind::StoppedTicketToPrNoPrHandoff,
             StageKind::StoppedFailed,
         ]
     }
@@ -358,6 +362,7 @@ mod tests {
                 tool: "read".to_string(),
                 error: "permission denied".to_string(),
             }),
+            command_transport_error: None,
         });
         state.stage.kind = StageKind::StoppedQuestionRequired;
 

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -125,6 +125,10 @@ pub struct PrLookupDiagnostics {
     pub current_branch: Option<String>,
     pub repo_owner: String,
     pub repo_name: String,
+    #[serde(default)]
+    pub token_source: Option<String>,
+    #[serde(default)]
+    pub empty_result_reason: Option<String>,
     pub outcome: String,
 }
 
@@ -366,5 +370,22 @@ mod tests {
 
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
+    }
+
+    #[test]
+    fn pr_lookup_diagnostics_default_new_fields_for_legacy_state() {
+        let diagnostics: PrLookupDiagnostics = serde_json::from_value(serde_json::json!({
+            "checked_at": "2026-01-01T00:00:00Z",
+            "stage": "dispatching_ticket_to_pr",
+            "requested_branch": "feature/eng-992",
+            "current_branch": "feature/eng-992",
+            "repo_owner": "allisoneer",
+            "repo_name": "agentic_auxilary",
+            "outcome": "not_found"
+        }))
+        .unwrap();
+
+        assert_eq!(diagnostics.token_source, None);
+        assert_eq!(diagnostics.empty_result_reason, None);
     }
 }

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -150,7 +150,11 @@ pub struct PrState {
     pub head_sha: Option<String>,
     pub last_observed_head_sha: Option<String>,
     #[serde(default)]
+    pub is_draft: Option<bool>,
+    #[serde(default)]
     pub last_lookup: Option<PrLookupDiagnostics>,
+    #[serde(default)]
+    pub ready_for_review: ReadyForReviewState,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -165,7 +169,22 @@ pub struct PrLookupDiagnostics {
     pub token_source: Option<String>,
     #[serde(default)]
     pub empty_result_reason: Option<String>,
+    #[serde(default)]
+    pub pr_number: Option<u64>,
+    #[serde(default)]
+    pub pr_is_draft: Option<bool>,
     pub outcome: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReadyForReviewState {
+    pub attempts: u32,
+    #[serde(default)]
+    pub last_attempted_at: Option<String>,
+    #[serde(default)]
+    pub last_result: Option<String>,
+    #[serde(default)]
+    pub coderabbit_draft_skip_recovered: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -370,6 +389,13 @@ mod tests {
         );
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
+        assert_eq!(roundtrip.pr.ready_for_review.attempts, 0);
+        assert!(
+            !roundtrip
+                .pr
+                .ready_for_review
+                .coderabbit_draft_skip_recovered
+        );
     }
 
     #[test]
@@ -446,6 +472,14 @@ mod tests {
             DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS
         );
         assert!(roundtrip.opencode.last_diagnostics.is_none());
+        assert_eq!(roundtrip.pr.is_draft, None);
+        assert_eq!(roundtrip.pr.ready_for_review.attempts, 0);
+        assert!(
+            !roundtrip
+                .pr
+                .ready_for_review
+                .coderabbit_draft_skip_recovered
+        );
     }
 
     #[test]
@@ -509,5 +543,7 @@ mod tests {
 
         assert_eq!(diagnostics.token_source, None);
         assert_eq!(diagnostics.empty_result_reason, None);
+        assert_eq!(diagnostics.pr_number, None);
+        assert_eq!(diagnostics.pr_is_draft, None);
     }
 }

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -51,6 +51,8 @@ pub struct Settings {
     pub poll_interval_seconds: u64,
     pub coderabbit_timeout_seconds: u64,
     pub max_review_cycles: u32,
+    #[serde(default = "default_linear_handoff_enabled")]
+    pub linear_handoff_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,8 +61,9 @@ pub struct Stage {
     pub details: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[value(rename_all = "snake_case")]
 pub enum StageKind {
     Init,
     FreshnessBeforeTicketToPr,
@@ -166,6 +169,7 @@ impl RunState {
                 poll_interval_seconds: 30,
                 coderabbit_timeout_seconds: 3600,
                 max_review_cycles: 5,
+                linear_handoff_enabled: default_linear_handoff_enabled(),
             },
             stage: Stage {
                 kind: StageKind::FreshnessBeforeTicketToPr,
@@ -184,6 +188,10 @@ impl RunState {
     pub fn touch(&mut self) {
         self.updated_at = Utc::now().to_rfc3339();
     }
+}
+
+const fn default_linear_handoff_enabled() -> bool {
+    true
 }
 
 fn generate_run_id() -> String {
@@ -270,5 +278,71 @@ mod tests {
             roundtrip.opencode.pending_question.as_ref().unwrap().prompt,
             "Continue?"
         );
+        assert!(roundtrip.settings.linear_handoff_enabled);
+    }
+
+    #[test]
+    fn settings_default_linear_handoff_enabled_for_legacy_state_files() {
+        let value = serde_json::json!({
+            "schema_version": 1,
+            "run_id": "outer-dag-test",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "ticket": {
+                "linear_key": "ENG-992",
+                "linear_url": null
+            },
+            "worktree": {
+                "path": "/tmp/worktree",
+                "branch": "feature/eng-992",
+                "base_ref": "origin/main"
+            },
+            "settings": {
+                "dry_run": false,
+                "poll_interval_seconds": 30,
+                "coderabbit_timeout_seconds": 3600,
+                "max_review_cycles": 5
+            },
+            "stage": {
+                "kind": "freshness_before_ticket_to_pr",
+                "details": null
+            },
+            "opencode": {
+                "active_session_id": null,
+                "last_command": null,
+                "dispatch_attempt": 0,
+                "resume_stage": null,
+                "pending_permission": null,
+                "pending_question": null
+            },
+            "pr": {
+                "number": null,
+                "url": null,
+                "head_sha": null,
+                "last_observed_head_sha": null
+            },
+            "freshness": {
+                "last_checked_at": null,
+                "last_result": null
+            },
+            "coderabbit": {
+                "current_cycle": 0,
+                "cycles": []
+            },
+            "handoff": {
+                "linear_comment_posted": false,
+                "linear_comment_body_sha256": null,
+                "posted_at": null
+            },
+            "counters": {
+                "ticket_to_pr_runs": 0,
+                "resolve_comments_runs": 0
+            },
+            "last_error": null
+        });
+
+        let roundtrip: RunState = serde_json::from_value(value).unwrap();
+
+        assert!(roundtrip.settings.linear_handoff_enabled);
     }
 }

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -53,6 +53,8 @@ pub struct Settings {
     pub max_review_cycles: u32,
     #[serde(default = "default_linear_handoff_enabled")]
     pub linear_handoff_enabled: bool,
+    #[serde(default = "default_opencode_dispatch_enabled")]
+    pub opencode_dispatch_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,6 +113,19 @@ pub struct PrState {
     pub url: Option<String>,
     pub head_sha: Option<String>,
     pub last_observed_head_sha: Option<String>,
+    #[serde(default)]
+    pub last_lookup: Option<PrLookupDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrLookupDiagnostics {
+    pub checked_at: String,
+    pub stage: StageKind,
+    pub requested_branch: String,
+    pub current_branch: Option<String>,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub outcome: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -170,6 +185,7 @@ impl RunState {
                 coderabbit_timeout_seconds: 3600,
                 max_review_cycles: 5,
                 linear_handoff_enabled: default_linear_handoff_enabled(),
+                opencode_dispatch_enabled: default_opencode_dispatch_enabled(),
             },
             stage: Stage {
                 kind: StageKind::FreshnessBeforeTicketToPr,
@@ -191,6 +207,10 @@ impl RunState {
 }
 
 const fn default_linear_handoff_enabled() -> bool {
+    true
+}
+
+const fn default_opencode_dispatch_enabled() -> bool {
     true
 }
 
@@ -279,10 +299,11 @@ mod tests {
             "Continue?"
         );
         assert!(roundtrip.settings.linear_handoff_enabled);
+        assert!(roundtrip.settings.opencode_dispatch_enabled);
     }
 
     #[test]
-    fn settings_default_linear_handoff_enabled_for_legacy_state_files() {
+    fn settings_default_safety_flags_enabled_for_legacy_state_files() {
         let value = serde_json::json!({
             "schema_version": 1,
             "run_id": "outer-dag-test",
@@ -344,5 +365,6 @@ mod tests {
         let roundtrip: RunState = serde_json::from_value(value).unwrap();
 
         assert!(roundtrip.settings.linear_handoff_enabled);
+        assert!(roundtrip.settings.opencode_dispatch_enabled);
     }
 }

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -1,0 +1,274 @@
+pub mod store;
+
+use crate::worktree::TargetWorktree;
+use anyhow::Result;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use std::process;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+pub const STATE_FILENAME: &str = "agentic-outer-dag-state.json";
+const SCHEMA_VERSION: u32 = 1;
+static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunState {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub ticket: TicketRef,
+    pub worktree: WorktreeRef,
+    pub settings: Settings,
+    pub stage: Stage,
+    pub opencode: OpenCodeState,
+    pub pr: PrState,
+    pub freshness: FreshnessState,
+    pub coderabbit: CodeRabbitState,
+    pub handoff: HandoffState,
+    pub counters: Counters,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TicketRef {
+    pub linear_key: String,
+    pub linear_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeRef {
+    pub path: String,
+    pub branch: String,
+    pub base_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Settings {
+    pub dry_run: bool,
+    pub poll_interval_seconds: u64,
+    pub coderabbit_timeout_seconds: u64,
+    pub max_review_cycles: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Stage {
+    pub kind: StageKind,
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StageKind {
+    Init,
+    FreshnessBeforeTicketToPr,
+    DispatchingTicketToPr,
+    DetectingPr,
+    FreshnessBeforeCoderabbitWait,
+    WaitingForCoderabbit,
+    DispatchingResolvePrComments,
+    StoppedPermissionRequired,
+    StoppedQuestionRequired,
+    StoppedDirtyTree,
+    StoppedRebaseConflict,
+    StoppedManualHandoff,
+    StoppedReviewSkipped,
+    StoppedTimedOut,
+    StoppedReadyForHumanReview,
+    StoppedFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenCodeState {
+    pub active_session_id: Option<String>,
+    pub last_command: Option<String>,
+    pub dispatch_attempt: u32,
+    pub resume_stage: Option<StageKind>,
+    pub pending_permission: Option<PendingPermission>,
+    pub pending_question: Option<PendingQuestion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingPermission {
+    pub request_id: String,
+    pub permission_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingQuestion {
+    pub request_id: String,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PrState {
+    pub number: Option<u64>,
+    pub url: Option<String>,
+    pub head_sha: Option<String>,
+    pub last_observed_head_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FreshnessState {
+    pub last_checked_at: Option<String>,
+    pub last_result: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodeRabbitState {
+    pub current_cycle: u32,
+    pub cycles: Vec<CodeRabbitCycle>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeRabbitCycle {
+    pub cycle: u32,
+    pub head_sha: String,
+    pub started_at: String,
+    pub status: String,
+    pub observed: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HandoffState {
+    pub linear_comment_posted: bool,
+    pub linear_comment_body_sha256: Option<String>,
+    pub posted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Counters {
+    pub ticket_to_pr_runs: u32,
+    pub resolve_comments_runs: u32,
+}
+
+impl RunState {
+    pub fn for_start(ticket: &str, worktree: &TargetWorktree, dry_run: bool) -> Result<Self> {
+        let now = Utc::now().to_rfc3339();
+        Ok(Self {
+            schema_version: SCHEMA_VERSION,
+            run_id: generate_run_id(),
+            created_at: now.clone(),
+            updated_at: now,
+            ticket: TicketRef {
+                linear_key: ticket.to_string(),
+                linear_url: None,
+            },
+            worktree: WorktreeRef {
+                path: worktree.path.canonicalize()?.display().to_string(),
+                branch: worktree.branch.clone(),
+                base_ref: worktree.base_ref.clone(),
+            },
+            settings: Settings {
+                dry_run,
+                poll_interval_seconds: 30,
+                coderabbit_timeout_seconds: 3600,
+                max_review_cycles: 5,
+            },
+            stage: Stage {
+                kind: StageKind::FreshnessBeforeTicketToPr,
+                details: None,
+            },
+            opencode: OpenCodeState::default(),
+            pr: PrState::default(),
+            freshness: FreshnessState::default(),
+            coderabbit: CodeRabbitState::default(),
+            handoff: HandoffState::default(),
+            counters: Counters::default(),
+            last_error: None,
+        })
+    }
+
+    pub fn touch(&mut self) {
+        self.updated_at = Utc::now().to_rfc3339();
+    }
+}
+
+fn generate_run_id() -> String {
+    let tick = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "outer-dag-{}-{}-{}",
+        Utc::now().timestamp_nanos_opt().unwrap_or_default(),
+        process::id(),
+        tick
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stage_kinds() -> Vec<StageKind> {
+        vec![
+            StageKind::Init,
+            StageKind::FreshnessBeforeTicketToPr,
+            StageKind::DispatchingTicketToPr,
+            StageKind::DetectingPr,
+            StageKind::FreshnessBeforeCoderabbitWait,
+            StageKind::WaitingForCoderabbit,
+            StageKind::DispatchingResolvePrComments,
+            StageKind::StoppedPermissionRequired,
+            StageKind::StoppedQuestionRequired,
+            StageKind::StoppedDirtyTree,
+            StageKind::StoppedRebaseConflict,
+            StageKind::StoppedManualHandoff,
+            StageKind::StoppedReviewSkipped,
+            StageKind::StoppedTimedOut,
+            StageKind::StoppedReadyForHumanReview,
+            StageKind::StoppedFailed,
+        ]
+    }
+
+    #[test]
+    fn stage_kind_roundtrips_through_serde() {
+        for kind in stage_kinds() {
+            let json = serde_json::to_string(&kind).unwrap();
+            let roundtrip: StageKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, kind);
+        }
+    }
+
+    #[test]
+    fn run_state_roundtrips_with_pending_interruptions() {
+        let mut state = RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().unwrap(),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            true,
+        )
+        .unwrap();
+
+        state.opencode.pending_permission = Some(PendingPermission {
+            request_id: "perm-1".to_string(),
+            permission_type: "file.write".to_string(),
+        });
+        state.opencode.pending_question = Some(PendingQuestion {
+            request_id: "question-1".to_string(),
+            prompt: "Continue?".to_string(),
+        });
+        state.stage.kind = StageKind::StoppedQuestionRequired;
+
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        let roundtrip: RunState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(roundtrip.stage.kind, StageKind::StoppedQuestionRequired);
+        assert_eq!(
+            roundtrip
+                .opencode
+                .pending_permission
+                .as_ref()
+                .unwrap()
+                .permission_type,
+            "file.write"
+        );
+        assert_eq!(
+            roundtrip.opencode.pending_question.as_ref().unwrap().prompt,
+            "Continue?"
+        );
+    }
+}

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 pub const STATE_FILENAME: &str = "agentic-outer-dag-state.json";
+pub const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 30;
+pub const DEFAULT_CODERABBIT_TIMEOUT_SECONDS: u64 = 3600;
 const SCHEMA_VERSION: u32 = 1;
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -185,8 +187,8 @@ impl RunState {
             },
             settings: Settings {
                 dry_run,
-                poll_interval_seconds: 30,
-                coderabbit_timeout_seconds: 3600,
+                poll_interval_seconds: DEFAULT_POLL_INTERVAL_SECONDS,
+                coderabbit_timeout_seconds: DEFAULT_CODERABBIT_TIMEOUT_SECONDS,
                 max_review_cycles: 5,
                 linear_handoff_enabled: default_linear_handoff_enabled(),
                 opencode_dispatch_enabled: default_opencode_dispatch_enabled(),
@@ -370,6 +372,29 @@ mod tests {
 
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
+    }
+
+    #[test]
+    fn run_state_for_start_uses_default_timing_settings() {
+        let state = RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().unwrap(),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            state.settings.poll_interval_seconds,
+            DEFAULT_POLL_INTERVAL_SECONDS
+        );
+        assert_eq!(
+            state.settings.coderabbit_timeout_seconds,
+            DEFAULT_CODERABBIT_TIMEOUT_SECONDS
+        );
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/state/store.rs
+++ b/apps/agentic-outer-dag/src/state/store.rs
@@ -21,6 +21,7 @@ impl ThoughtsStateStore {
             .with_context(|| format!("failed to read state file at {}", path.display()))?;
         let state = serde_json::from_str(&json)
             .with_context(|| format!("failed to deserialize state file at {}", path.display()))?;
+        validate_schema_version(&state, &path)?;
         Ok(Some(state))
     }
 
@@ -43,5 +44,55 @@ impl ThoughtsStateStore {
                 .with_context(|| format!("failed to remove state file at {}", path.display()))?;
         }
         Ok(())
+    }
+}
+
+fn validate_schema_version(state: &RunState, path: &std::path::Path) -> Result<()> {
+    anyhow::ensure!(
+        state.schema_version == crate::state::SCHEMA_VERSION,
+        "outer DAG state schema_version mismatch at {}: expected {}, found {}. Run `agentic-outer-dag reset --yes` to delete the stale state file.",
+        path.display(),
+        crate::state::SCHEMA_VERSION,
+        state.schema_version
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_schema_version;
+    use crate::state;
+    use crate::worktree::TargetWorktree;
+
+    fn sample_state() -> state::RunState {
+        state::RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().unwrap(),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn validate_schema_version_accepts_current_version() {
+        let state = sample_state();
+        validate_schema_version(&state, std::path::Path::new("state.json")).unwrap();
+    }
+
+    #[test]
+    fn validate_schema_version_rejects_mismatch_with_reset_guidance() {
+        let mut state = sample_state();
+        state.schema_version = state.schema_version.saturating_add(1);
+
+        let err = validate_schema_version(&state, std::path::Path::new("state.json"))
+            .expect_err("schema mismatch should fail");
+        let text = err.to_string();
+        assert!(text.contains("state.json"));
+        assert!(text.contains("schema_version mismatch"));
+        assert!(text.contains("reset --yes"));
     }
 }

--- a/apps/agentic-outer-dag/src/state/store.rs
+++ b/apps/agentic-outer-dag/src/state/store.rs
@@ -1,0 +1,47 @@
+use crate::state::RunState;
+use crate::state::STATE_FILENAME;
+use anyhow::Context;
+use anyhow::Result;
+use std::fs;
+use thoughts_tool::DocumentType;
+
+pub struct ThoughtsStateStore;
+
+impl ThoughtsStateStore {
+    pub fn load() -> Result<Option<RunState>> {
+        let active = thoughts_tool::workspace::ensure_active_work().context(
+            "failed to resolve active thoughts workspace; chdir into a feature worktree first",
+        )?;
+        let path = active.artifacts.join(STATE_FILENAME);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let json = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read state file at {}", path.display()))?;
+        let state = serde_json::from_str(&json)
+            .with_context(|| format!("failed to deserialize state file at {}", path.display()))?;
+        Ok(Some(state))
+    }
+
+    pub fn save(state: &RunState) -> Result<()> {
+        let mut state = state.clone();
+        state.touch();
+        let json = serde_json::to_string_pretty(&state)?;
+        thoughts_tool::write_document(&DocumentType::Artifact, STATE_FILENAME, &json)
+            .context("failed to persist branch-scoped outer DAG state")?;
+        Ok(())
+    }
+
+    pub fn delete() -> Result<()> {
+        let active = thoughts_tool::workspace::ensure_active_work().context(
+            "failed to resolve active thoughts workspace; chdir into a feature worktree first",
+        )?;
+        let path = active.artifacts.join(STATE_FILENAME);
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("failed to remove state file at {}", path.display()))?;
+        }
+        Ok(())
+    }
+}

--- a/apps/agentic-outer-dag/src/state/store.rs
+++ b/apps/agentic-outer-dag/src/state/store.rs
@@ -62,13 +62,14 @@ fn validate_schema_version(state: &RunState, path: &std::path::Path) -> Result<(
 mod tests {
     use super::validate_schema_version;
     use crate::state;
+    use crate::test_support::process_state_lock;
     use crate::worktree::TargetWorktree;
 
-    fn sample_state() -> state::RunState {
+    fn sample_state(cwd: std::path::PathBuf) -> state::RunState {
         state::RunState::for_start(
             "ENG-992",
             &TargetWorktree {
-                path: std::env::current_dir().unwrap(),
+                path: cwd,
                 branch: "feature/eng-992".to_string(),
                 base_ref: "origin/main".to_string(),
             },
@@ -79,13 +80,15 @@ mod tests {
 
     #[test]
     fn validate_schema_version_accepts_current_version() {
-        let state = sample_state();
+        let _guard = process_state_lock().lock().unwrap();
+        let state = sample_state(std::env::current_dir().unwrap());
         validate_schema_version(&state, std::path::Path::new("state.json")).unwrap();
     }
 
     #[test]
     fn validate_schema_version_rejects_mismatch_with_reset_guidance() {
-        let mut state = sample_state();
+        let _guard = process_state_lock().lock().unwrap();
+        let mut state = sample_state(std::env::current_dir().unwrap());
         state.schema_version = state.schema_version.saturating_add(1);
 
         let err = validate_schema_version(&state, std::path::Path::new("state.json"))

--- a/apps/agentic-outer-dag/src/test_support.rs
+++ b/apps/agentic-outer-dag/src/test_support.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -24,5 +25,44 @@ impl CwdGuard {
 impl Drop for CwdGuard {
     fn drop(&mut self) {
         let _ = std::env::set_current_dir(&self.previous);
+    }
+}
+
+#[cfg(test)]
+pub struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+#[cfg(test)]
+impl EnvVarGuard {
+    pub fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: test callers serialize process-wide env mutation with process_state_lock.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+
+    pub fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: test callers serialize process-wide env mutation with process_state_lock.
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.as_ref() {
+            Some(value) => {
+                // SAFETY: test callers serialize process-wide env mutation with process_state_lock.
+                unsafe { std::env::set_var(self.key, value) };
+            }
+            None => {
+                // SAFETY: test callers serialize process-wide env mutation with process_state_lock.
+                unsafe { std::env::remove_var(self.key) };
+            }
+        }
     }
 }

--- a/apps/agentic-outer-dag/src/test_support.rs
+++ b/apps/agentic-outer-dag/src/test_support.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+static PROCESS_STATE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub fn process_state_lock() -> &'static Mutex<()> {
+    PROCESS_STATE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub struct CwdGuard {
+    previous: PathBuf,
+}
+
+impl CwdGuard {
+    pub fn pushd(path: &Path) -> std::io::Result<Self> {
+        let previous = std::env::current_dir()?;
+        std::env::set_current_dir(path)?;
+        Ok(Self { previous })
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.previous);
+    }
+}

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -141,6 +141,20 @@ mod tests {
     }
 
     #[test]
+    fn dirty_tree_blocks_freshness_even_in_dry_run() {
+        let _guard = process_state_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
+        fixture.write_shared_file("uncommitted change\n").unwrap();
+
+        let outcome = run("origin/main", false).unwrap();
+        let dry_run_outcome = run("origin/main", true).unwrap();
+
+        assert_eq!(outcome, FreshnessOutcome::DirtyTree);
+        assert_eq!(dry_run_outcome, FreshnessOutcome::DirtyTree);
+    }
+
+    #[test]
     fn returns_conflict_when_rebase_hits_merge_conflict() {
         let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -125,6 +125,20 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_returns_up_to_date_when_origin_main_moves_forward() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.advance_main("main update\n").unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.feature_clone).unwrap();
+
+        let outcome = run("origin/main", true).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(outcome, FreshnessOutcome::UpToDate);
+    }
+
+    #[test]
     fn returns_conflict_when_rebase_hits_merge_conflict() {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -31,6 +31,7 @@ pub fn run(base_ref: &str, dry_run: bool) -> Result<FreshnessOutcome> {
     let old_head = rev_parse("HEAD")?;
     let status = git_status(["rebase", base_ref])?;
     if !status.success() {
+        git(["rebase", "--abort"])?;
         return Ok(FreshnessOutcome::Conflict);
     }
     let new_head = rev_parse("HEAD")?;
@@ -135,8 +136,12 @@ mod tests {
 
         let outcome = run("origin/main", false).unwrap();
 
+        assert!(!fixture.rebase_in_progress().unwrap());
+        let rerun_outcome = run("origin/main", false).unwrap();
+
         env::set_current_dir(saved).unwrap();
         assert_eq!(outcome, FreshnessOutcome::Conflict);
+        assert_eq!(rerun_outcome, FreshnessOutcome::Conflict);
     }
 
     fn cwd_lock() -> &'static Mutex<()> {
@@ -209,6 +214,12 @@ mod tests {
             run_git(&self.feature_clone, ["commit", "-m", message])?;
             Ok(())
         }
+
+        fn rebase_in_progress(&self) -> Result<bool> {
+            let git_dir = git_output(&self.feature_clone, ["rev-parse", "--git-dir"])?;
+            let git_dir = self.feature_clone.join(git_dir);
+            Ok(git_dir.join("rebase-apply").exists() || git_dir.join("rebase-merge").exists())
+        }
     }
 
     fn configure_repo(path: &Path) -> Result<()> {
@@ -221,6 +232,19 @@ mod tests {
         let output = Command::new("git").current_dir(cwd).args(args).output()?;
         if output.status.success() {
             Ok(())
+        } else {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    fn git_output<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
+        let output = Command::new("git").current_dir(cwd).args(args).output()?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
         } else {
             anyhow::bail!(
                 "git {} failed: {}",

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 use git2::Repository;
 use gwt_worktree::worktree::is_worktree_dirty;
 use std::process::Command;
-use std::process::ExitStatus;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FreshnessOutcome {
@@ -46,8 +45,23 @@ fn is_dirty() -> Result<bool> {
 }
 
 fn needs_rebase(base_ref: &str) -> Result<bool> {
-    let status = git_status(["merge-base", "--is-ancestor", base_ref, "HEAD"])?;
-    Ok(!status.success())
+    let output = Command::new("git")
+        .args(["merge-base", "--is-ancestor", base_ref, "HEAD"])
+        .output()
+        .with_context(|| format!("failed to run git merge-base --is-ancestor {base_ref} HEAD"))?;
+
+    match output.status.code() {
+        Some(0) => Ok(false),
+        Some(1) => Ok(true),
+        Some(code) => anyhow::bail!(
+            "git merge-base --is-ancestor {base_ref} HEAD failed (exit={code}): {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+        None => anyhow::bail!(
+            "git merge-base --is-ancestor {base_ref} HEAD terminated unexpectedly: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    }
 }
 
 fn rev_parse(rev: &str) -> Result<String> {
@@ -74,7 +88,7 @@ fn git<const N: usize>(args: [&str; N]) -> Result<()> {
     }
 }
 
-fn git_status<const N: usize>(args: [&str; N]) -> Result<ExitStatus> {
+fn git_status<const N: usize>(args: [&str; N]) -> Result<std::process::ExitStatus> {
     Command::new("git")
         .args(args)
         .status()
@@ -84,40 +98,31 @@ fn git_status<const N: usize>(args: [&str; N]) -> Result<ExitStatus> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use crate::test_support::CwdGuard;
+    use crate::test_support::process_state_lock;
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
-    use std::sync::Mutex;
-    use std::sync::OnceLock;
     use tempfile::TempDir;
-
-    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[test]
     fn returns_up_to_date_when_branch_is_current() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.feature_clone).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
         let outcome = run("origin/main", false).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         assert_eq!(outcome, FreshnessOutcome::UpToDate);
     }
 
     #[test]
     fn rebases_when_origin_main_moves_forward() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.advance_main("main update\n").unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.feature_clone).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
         let outcome = run("origin/main", false).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         match outcome {
             FreshnessOutcome::Rebases { old_head, new_head } => assert_ne!(old_head, new_head),
             other => panic!("expected rebase outcome, got {other:?}"),
@@ -126,40 +131,43 @@ mod tests {
 
     #[test]
     fn dry_run_returns_up_to_date_when_origin_main_moves_forward() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.advance_main("main update\n").unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.feature_clone).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
         let outcome = run("origin/main", true).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         assert_eq!(outcome, FreshnessOutcome::UpToDate);
     }
 
     #[test]
     fn returns_conflict_when_rebase_hits_merge_conflict() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.write_shared_file("feature change\n").unwrap();
         fixture.commit_feature("feature change").unwrap();
         fixture.advance_main("main change\n").unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.feature_clone).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
         let outcome = run("origin/main", false).unwrap();
 
         assert!(!fixture.rebase_in_progress().unwrap());
         let rerun_outcome = run("origin/main", false).unwrap();
 
-        env::set_current_dir(saved).unwrap();
         assert_eq!(outcome, FreshnessOutcome::Conflict);
         assert_eq!(rerun_outcome, FreshnessOutcome::Conflict);
     }
 
-    fn cwd_lock() -> &'static Mutex<()> {
-        CWD_LOCK.get_or_init(|| Mutex::new(()))
+    #[test]
+    fn invalid_base_ref_returns_err() {
+        let _guard = process_state_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
+
+        let err = run("origin/does-not-exist", false).expect_err("invalid base ref should fail");
+        let text = err.to_string();
+        assert!(text.contains("merge-base --is-ancestor origin/does-not-exist HEAD failed"));
+        assert!(text.contains("Not a valid object name origin/does-not-exist"));
     }
 
     struct GitFixture {

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -1,0 +1,232 @@
+use anyhow::Context;
+use anyhow::Result;
+use git2::Repository;
+use gwt_worktree::worktree::is_worktree_dirty;
+use std::process::Command;
+use std::process::ExitStatus;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FreshnessOutcome {
+    UpToDate,
+    Rebases { old_head: String, new_head: String },
+    Conflict,
+    DirtyTree,
+}
+
+pub fn run(base_ref: &str, dry_run: bool) -> Result<FreshnessOutcome> {
+    if is_dirty()? {
+        return Ok(FreshnessOutcome::DirtyTree);
+    }
+
+    if dry_run {
+        return Ok(FreshnessOutcome::UpToDate);
+    }
+
+    git(["fetch", "origin", "--prune"])?;
+
+    if !needs_rebase(base_ref)? {
+        return Ok(FreshnessOutcome::UpToDate);
+    }
+
+    let old_head = rev_parse("HEAD")?;
+    let status = git_status(["rebase", base_ref])?;
+    if !status.success() {
+        return Ok(FreshnessOutcome::Conflict);
+    }
+    let new_head = rev_parse("HEAD")?;
+
+    Ok(FreshnessOutcome::Rebases { old_head, new_head })
+}
+
+fn is_dirty() -> Result<bool> {
+    let repo =
+        Repository::discover(".").context("failed to discover repository for freshness check")?;
+    is_worktree_dirty(&repo).context("failed to inspect worktree dirtiness")
+}
+
+fn needs_rebase(base_ref: &str) -> Result<bool> {
+    let status = git_status(["merge-base", "--is-ancestor", base_ref, "HEAD"])?;
+    Ok(!status.success())
+}
+
+fn rev_parse(rev: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", rev])
+        .output()
+        .with_context(|| format!("failed to run git rev-parse for {rev}"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git rev-parse failed for {rev}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git<const N: usize>(args: [&str; N]) -> Result<()> {
+    let status = git_status(args)?;
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!("git command failed: git {}", args.join(" "))
+    }
+}
+
+fn git_status<const N: usize>(args: [&str; N]) -> Result<ExitStatus> {
+    Command::new("git")
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+    use tempfile::TempDir;
+
+    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn returns_up_to_date_when_branch_is_current() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.feature_clone).unwrap();
+
+        let outcome = run("origin/main", false).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(outcome, FreshnessOutcome::UpToDate);
+    }
+
+    #[test]
+    fn rebases_when_origin_main_moves_forward() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.advance_main("main update\n").unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.feature_clone).unwrap();
+
+        let outcome = run("origin/main", false).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        match outcome {
+            FreshnessOutcome::Rebases { old_head, new_head } => assert_ne!(old_head, new_head),
+            other => panic!("expected rebase outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn returns_conflict_when_rebase_hits_merge_conflict() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.write_shared_file("feature change\n").unwrap();
+        fixture.commit_feature("feature change").unwrap();
+        fixture.advance_main("main change\n").unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.feature_clone).unwrap();
+
+        let outcome = run("origin/main", false).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(outcome, FreshnessOutcome::Conflict);
+    }
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        CWD_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct GitFixture {
+        _temp: TempDir,
+        main_clone: PathBuf,
+        feature_clone: PathBuf,
+    }
+
+    impl GitFixture {
+        fn new() -> Result<Self> {
+            let temp = TempDir::new()?;
+            let origin = temp.path().join("origin.git");
+            let main_clone = temp.path().join("main");
+            let feature_clone = temp.path().join("feature");
+
+            run_git(temp.path(), ["init", "--bare", origin.to_str().unwrap()])?;
+            run_git(&origin, ["symbolic-ref", "HEAD", "refs/heads/main"])?;
+            run_git(
+                temp.path(),
+                [
+                    "clone",
+                    origin.to_str().unwrap(),
+                    main_clone.to_str().unwrap(),
+                ],
+            )?;
+            configure_repo(&main_clone)?;
+            run_git(&main_clone, ["checkout", "-b", "main"])?;
+            fs::write(main_clone.join("shared.txt"), "base\n")?;
+            run_git(&main_clone, ["add", "shared.txt"])?;
+            run_git(&main_clone, ["commit", "-m", "initial"])?;
+            run_git(&main_clone, ["push", "-u", "origin", "main"])?;
+
+            run_git(
+                temp.path(),
+                [
+                    "clone",
+                    origin.to_str().unwrap(),
+                    feature_clone.to_str().unwrap(),
+                ],
+            )?;
+            configure_repo(&feature_clone)?;
+            run_git(&feature_clone, ["checkout", "-b", "feature/test"])?;
+
+            Ok(Self {
+                _temp: temp,
+                main_clone,
+                feature_clone,
+            })
+        }
+
+        fn advance_main(&self, contents: &str) -> Result<()> {
+            fs::write(self.main_clone.join("shared.txt"), contents)?;
+            run_git(&self.main_clone, ["add", "shared.txt"])?;
+            run_git(&self.main_clone, ["commit", "-m", "main update"])?;
+            run_git(&self.main_clone, ["push", "origin", "main"])?;
+            Ok(())
+        }
+
+        fn write_shared_file(&self, contents: &str) -> Result<()> {
+            fs::write(self.feature_clone.join("shared.txt"), contents)?;
+            Ok(())
+        }
+
+        fn commit_feature(&self, message: &str) -> Result<()> {
+            run_git(&self.feature_clone, ["add", "shared.txt"])?;
+            run_git(&self.feature_clone, ["commit", "-m", message])?;
+            Ok(())
+        }
+    }
+
+    fn configure_repo(path: &Path) -> Result<()> {
+        run_git(path, ["config", "user.name", "Test User"])?;
+        run_git(path, ["config", "user.email", "test@example.com"])?;
+        Ok(())
+    }
+
+    fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<()> {
+        let output = Command::new("git").current_dir(cwd).args(args).output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+}

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -3,6 +3,9 @@ pub mod freshness;
 use anyhow::Context;
 use anyhow::Result;
 use git2::Repository;
+use gwt_worktree::command::CommandSpec;
+use gwt_worktree::config::GwtConfig;
+use gwt_worktree::config::RepoConfig;
 use gwt_worktree::plan::switch::SwitchPlan;
 use gwt_worktree::plan::switch::SwitchPlanKind;
 use gwt_worktree::plan::switch::SwitchRequest;
@@ -13,6 +16,7 @@ use gwt_worktree::types::BranchName;
 use gwt_worktree::worktree::list_worktrees;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct TargetWorktree {
@@ -123,8 +127,13 @@ fn resolve_from_branch(branch: &str, create_if_missing: bool) -> Result<TargetWo
         anyhow::bail!("no worktree found for branch '{branch}'");
     }
 
-    let plan = plan_for_branch(&control, branch)?;
+    let repo_config = load_repo_config(&control);
+    let plan = plan_for_branch(&control, branch, repo_config.as_ref())?;
+    let would_create = plan_would_create(&plan);
     let execution = gwt_worktree::exec::switch::execute_switch_plan(&control, &plan, None)?;
+    if would_create {
+        run_post_create_commands(&execution.path, &execution.post_create_commands);
+    }
     let repo = Repository::open(&control.common_dir)?;
 
     Ok(TargetWorktree {
@@ -153,7 +162,8 @@ fn preview_from_branch(branch: &str) -> Result<WorktreePreview> {
         });
     }
 
-    let plan = plan_for_branch(&control, branch)?;
+    let repo_config = load_repo_config(&control);
+    let plan = plan_for_branch(&control, branch, repo_config.as_ref())?;
     Ok(WorktreePreview {
         path: Some(plan.target_path.clone()),
         branch: branch.to_string(),
@@ -161,7 +171,11 @@ fn preview_from_branch(branch: &str) -> Result<WorktreePreview> {
     })
 }
 
-fn plan_for_branch(control: &ControlRepo, branch: &str) -> Result<SwitchPlan> {
+fn plan_for_branch(
+    control: &ControlRepo,
+    branch: &str,
+    repo_config: Option<&RepoConfig>,
+) -> Result<SwitchPlan> {
     let branch_name = BranchName::new(branch.to_string())?;
     plan_switch(
         control,
@@ -172,7 +186,7 @@ fn plan_for_branch(control: &ControlRepo, branch: &str) -> Result<SwitchPlan> {
             start_point: None,
             guess_remote: false,
         },
-        None,
+        repo_config,
     )
     .or_else(|error| {
         if matches!(error, gwt_worktree::Error::BranchNotFound(_)) {
@@ -185,7 +199,7 @@ fn plan_for_branch(control: &ControlRepo, branch: &str) -> Result<SwitchPlan> {
                     start_point: None,
                     guess_remote: false,
                 },
-                None,
+                repo_config,
             )
         } else {
             Err(error)
@@ -199,6 +213,57 @@ fn plan_would_create(plan: &SwitchPlan) -> bool {
         plan.kind,
         SwitchPlanKind::Main | SwitchPlanKind::ExistingWorktree
     )
+}
+
+fn load_repo_config(control: &ControlRepo) -> Option<RepoConfig> {
+    match GwtConfig::load() {
+        Ok(config) => config.repos.get(&control.git_dir_key).cloned(),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                git_dir_key = %control.git_dir_key,
+                "failed to load gwt config; continuing without post-create commands"
+            );
+            None
+        }
+    }
+}
+
+fn run_post_create_commands(worktree_path: &Path, commands: &[CommandSpec]) {
+    for command in commands {
+        match Command::new("sh")
+            .arg("-c")
+            .arg(command.as_str())
+            .current_dir(worktree_path)
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                tracing::info!(
+                    command = %command,
+                    cwd = %worktree_path.display(),
+                    "completed gwt post-create command"
+                );
+            }
+            Ok(output) => {
+                tracing::warn!(
+                    command = %command,
+                    cwd = %worktree_path.display(),
+                    status = ?output.status.code(),
+                    stdout = %String::from_utf8_lossy(&output.stdout).trim(),
+                    stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                    "gwt post-create command failed; continuing"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    command = %command,
+                    cwd = %worktree_path.display(),
+                    error = %error,
+                    "failed to start gwt post-create command; continuing"
+                );
+            }
+        }
+    }
 }
 
 fn current_branch(repo: &Repository) -> Result<String> {
@@ -228,6 +293,7 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use std::env;
+    use std::ffi::OsString;
     use std::fs;
     use std::path::Path;
     use std::sync::Mutex;
@@ -254,6 +320,85 @@ mod tests {
         assert_eq!(preview.branch, "feature/preview-only");
     }
 
+    #[test]
+    fn resolve_runs_post_create_commands_for_new_worktree() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.branch("feature/post-create").unwrap();
+        let config_home = TempDir::new().unwrap();
+        write_gwt_config(
+            config_home.path(),
+            &fixture.repo_git_dir(),
+            &["echo ready > created.txt"],
+        )
+        .unwrap();
+        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.repo).unwrap();
+
+        let target = resolve(Some("feature/post-create"), None, true).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(
+            fs::read_to_string(target.path.join("created.txt")).unwrap(),
+            "ready\n"
+        );
+    }
+
+    #[test]
+    fn resolve_does_not_rerun_post_create_commands_for_existing_worktree() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.branch("feature/no-rerun").unwrap();
+        let config_home = TempDir::new().unwrap();
+        write_gwt_config(
+            config_home.path(),
+            &fixture.repo_git_dir(),
+            &["echo run >> run-count.txt"],
+        )
+        .unwrap();
+        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.repo).unwrap();
+
+        let first = resolve(Some("feature/no-rerun"), None, true).unwrap();
+        let second = resolve(Some("feature/no-rerun"), None, true).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(first.path, second.path);
+        assert_eq!(
+            fs::read_to_string(first.path.join("run-count.txt")).unwrap(),
+            "run\n"
+        );
+    }
+
+    #[test]
+    fn resolve_runs_post_create_commands_from_worktree_cwd() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        fixture.branch("feature/cwd-check").unwrap();
+        let config_home = TempDir::new().unwrap();
+        write_gwt_config(
+            config_home.path(),
+            &fixture.repo_git_dir(),
+            &["pwd > cwd.txt"],
+        )
+        .unwrap();
+        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.repo).unwrap();
+
+        let target = resolve(Some("feature/cwd-check"), None, true).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(
+            fs::read_to_string(target.path.join("cwd.txt"))
+                .unwrap()
+                .trim(),
+            target.path.display().to_string()
+        );
+    }
+
     fn cwd_lock() -> &'static Mutex<()> {
         CWD_LOCK.get_or_init(|| Mutex::new(()))
     }
@@ -277,11 +422,70 @@ mod tests {
 
             Ok(Self { _temp: temp, repo })
         }
+
+        fn branch(&self, name: &str) -> Result<()> {
+            run_git(&self.repo, ["branch", name])
+        }
+
+        fn repo_git_dir(&self) -> String {
+            self.repo.join(".git").display().to_string()
+        }
+    }
+
+    struct ConfigHomeGuard {
+        previous: Option<OsString>,
+    }
+
+    impl ConfigHomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = env::var_os("XDG_CONFIG_HOME");
+            // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+            unsafe {
+                env::set_var("XDG_CONFIG_HOME", path);
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for ConfigHomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(previous) => {
+                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    unsafe {
+                        env::set_var("XDG_CONFIG_HOME", previous);
+                    }
+                }
+                None => {
+                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    unsafe {
+                        env::remove_var("XDG_CONFIG_HOME");
+                    }
+                }
+            }
+        }
     }
 
     fn configure_repo(path: &Path) -> Result<()> {
         run_git(path, ["config", "user.name", "Test User"])?;
         run_git(path, ["config", "user.email", "test@example.com"])?;
+        Ok(())
+    }
+
+    fn write_gwt_config(config_home: &Path, repo_git_dir: &str, commands: &[&str]) -> Result<()> {
+        let gwt_dir = config_home.join("gwt");
+        fs::create_dir_all(&gwt_dir)?;
+        let serialized_commands = commands
+            .iter()
+            .map(|command| format!("    {command:?}"))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        fs::write(
+            gwt_dir.join("config.toml"),
+            format!(
+                "[repos.{repo_git_dir:?}]\npost_create_commands = [\n{serialized_commands}\n]\n"
+            ),
+        )?;
         Ok(())
     }
 
@@ -315,6 +519,4 @@ mod tests {
             )
         }
     }
-
-    use std::process::Command;
 }

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -291,29 +291,25 @@ fn default_base_ref(repo: &Repository) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::CwdGuard;
+    use crate::test_support::process_state_lock;
     use anyhow::Result;
     use std::env;
     use std::ffi::OsString;
     use std::fs;
     use std::path::Path;
-    use std::sync::Mutex;
-    use std::sync::OnceLock;
     use tempfile::TempDir;
-
-    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[test]
     fn preview_resolve_does_not_create_missing_branch_worktree() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.repo).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
 
         let before = worktree_paths(&fixture.repo).unwrap();
         let preview = preview_resolve(Some("feature/preview-only"), None).unwrap();
         let after = worktree_paths(&fixture.repo).unwrap();
 
-        env::set_current_dir(saved).unwrap();
         assert_eq!(before, after);
         assert!(preview.would_create);
         assert!(preview.path.is_some());
@@ -322,7 +318,7 @@ mod tests {
 
     #[test]
     fn resolve_runs_post_create_commands_for_new_worktree() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/post-create").unwrap();
         let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
@@ -331,12 +327,9 @@ mod tests {
             write_gwt_config(&repo_git_dir_key, &["echo ready > created.txt"]).unwrap();
         assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
         assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.repo).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
 
         let target = resolve(Some("feature/post-create"), None, true).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         assert_eq!(
             fs::read_to_string(target.path.join("created.txt")).unwrap(),
             "ready\n"
@@ -345,7 +338,7 @@ mod tests {
 
     #[test]
     fn resolve_does_not_rerun_post_create_commands_for_existing_worktree() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/no-rerun").unwrap();
         let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
@@ -354,13 +347,10 @@ mod tests {
             write_gwt_config(&repo_git_dir_key, &["echo run >> run-count.txt"]).unwrap();
         assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
         assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.repo).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
 
         let first = resolve(Some("feature/no-rerun"), None, true).unwrap();
         let second = resolve(Some("feature/no-rerun"), None, true).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         assert_eq!(first.path, second.path);
         assert_eq!(
             fs::read_to_string(first.path.join("run-count.txt")).unwrap(),
@@ -370,7 +360,7 @@ mod tests {
 
     #[test]
     fn resolve_runs_post_create_commands_from_worktree_cwd() {
-        let _guard = cwd_lock().lock().unwrap();
+        let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/cwd-check").unwrap();
         let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
@@ -378,22 +368,15 @@ mod tests {
         let config_path = write_gwt_config(&repo_git_dir_key, &["pwd > cwd.txt"]).unwrap();
         assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
         assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
-        let saved = env::current_dir().unwrap();
-        env::set_current_dir(&fixture.repo).unwrap();
+        let _cwd = CwdGuard::pushd(&fixture.repo).unwrap();
 
         let target = resolve(Some("feature/cwd-check"), None, true).unwrap();
-
-        env::set_current_dir(saved).unwrap();
         assert_eq!(
             fs::read_to_string(target.path.join("cwd.txt"))
                 .unwrap()
                 .trim(),
             target.path.display().to_string()
         );
-    }
-
-    fn cwd_lock() -> &'static Mutex<()> {
-        CWD_LOCK.get_or_init(|| Mutex::new(()))
     }
 
     struct GitFixture {
@@ -444,7 +427,7 @@ mod tests {
             fs::create_dir_all(&home)?;
             let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
             let previous_home = env::var_os("HOME");
-            // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+            // SAFETY: tests serialize cwd/env mutation with crate::test_support::process_state_lock and restore it on drop.
             unsafe {
                 env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
                 env::set_var("HOME", &home);
@@ -461,13 +444,13 @@ mod tests {
         fn drop(&mut self) {
             match &self.previous_xdg_config_home {
                 Some(previous) => {
-                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    // SAFETY: tests serialize cwd/env mutation with crate::test_support::process_state_lock and restore it on drop.
                     unsafe {
                         env::set_var("XDG_CONFIG_HOME", previous);
                     }
                 }
                 None => {
-                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    // SAFETY: tests serialize cwd/env mutation with crate::test_support::process_state_lock and restore it on drop.
                     unsafe {
                         env::remove_var("XDG_CONFIG_HOME");
                     }
@@ -476,13 +459,13 @@ mod tests {
 
             match &self.previous_home {
                 Some(previous) => {
-                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    // SAFETY: tests serialize cwd/env mutation with crate::test_support::process_state_lock and restore it on drop.
                     unsafe {
                         env::set_var("HOME", previous);
                     }
                 }
                 None => {
-                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    // SAFETY: tests serialize cwd/env mutation with crate::test_support::process_state_lock and restore it on drop.
                     unsafe {
                         env::remove_var("HOME");
                     }

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -1,0 +1,154 @@
+pub mod freshness;
+
+use anyhow::Context;
+use anyhow::Result;
+use git2::Repository;
+use gwt_worktree::plan::switch::SwitchRequest;
+use gwt_worktree::plan::switch::plan_switch;
+use gwt_worktree::repo::ControlRepo;
+use gwt_worktree::repo::ResolveControlRepoOptions;
+use gwt_worktree::types::BranchName;
+use gwt_worktree::worktree::list_worktrees;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct TargetWorktree {
+    pub path: PathBuf,
+    pub branch: String,
+    pub base_ref: String,
+}
+
+pub fn chdir_to(target: &TargetWorktree) -> Result<()> {
+    std::env::set_current_dir(&target.path)
+        .with_context(|| format!("failed to chdir into {}", target.path.display()))?;
+    Ok(())
+}
+
+pub fn resolve(
+    branch: Option<&str>,
+    worktree: Option<&Path>,
+    create_if_missing: bool,
+) -> Result<TargetWorktree> {
+    if let Some(path) = worktree {
+        return resolve_from_path(path, branch);
+    }
+
+    if let Some(branch) = branch {
+        return resolve_from_branch(branch, create_if_missing);
+    }
+
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    resolve_from_path(&cwd, None)
+}
+
+fn resolve_from_path(path: &Path, expected_branch: Option<&str>) -> Result<TargetWorktree> {
+    let repo = Repository::discover(path)
+        .with_context(|| format!("failed to discover git repository from {}", path.display()))?;
+    let workdir = repo.workdir().map(Path::to_path_buf).ok_or_else(|| {
+        anyhow::anyhow!("repository at {} has no working directory", path.display())
+    })?;
+    let branch = current_branch(&repo)?;
+
+    if let Some(expected_branch) = expected_branch
+        && branch != expected_branch
+    {
+        anyhow::bail!(
+            "worktree branch mismatch: expected '{}', found '{}' at {}",
+            expected_branch,
+            branch,
+            workdir.display()
+        );
+    }
+
+    Ok(TargetWorktree {
+        path: workdir,
+        branch,
+        base_ref: default_base_ref(&repo),
+    })
+}
+
+fn resolve_from_branch(branch: &str, create_if_missing: bool) -> Result<TargetWorktree> {
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    let control = ControlRepo::resolve(&ResolveControlRepoOptions {
+        cwd: Some(&cwd),
+        ..ResolveControlRepoOptions::default()
+    })
+    .context("failed to resolve gwt control repository")?;
+
+    if let Some(existing) = list_worktrees(&control)?
+        .into_iter()
+        .find(|item| item.branch.as_deref() == Some(branch) && item.path.exists())
+    {
+        return Ok(TargetWorktree {
+            path: existing.path,
+            branch: branch.to_string(),
+            base_ref: default_base_ref(&Repository::open(&control.common_dir)?),
+        });
+    }
+
+    if !create_if_missing {
+        anyhow::bail!("no worktree found for branch '{branch}'");
+    }
+
+    let branch_name = BranchName::new(branch.to_string())?;
+    let plan = plan_switch(
+        &control,
+        &SwitchRequest {
+            branch: branch_name.clone(),
+            create: false,
+            force_create: false,
+            start_point: None,
+            guess_remote: false,
+        },
+        None,
+    )
+    .or_else(|error| {
+        if matches!(error, gwt_worktree::Error::BranchNotFound(_)) {
+            plan_switch(
+                &control,
+                &SwitchRequest {
+                    branch: branch_name,
+                    create: true,
+                    force_create: false,
+                    start_point: None,
+                    guess_remote: false,
+                },
+                None,
+            )
+        } else {
+            Err(error)
+        }
+    })?;
+
+    let execution = gwt_worktree::exec::switch::execute_switch_plan(&control, &plan, None)?;
+    let repo = Repository::open(&control.common_dir)?;
+
+    Ok(TargetWorktree {
+        path: execution.path,
+        branch: branch.to_string(),
+        base_ref: default_base_ref(&repo),
+    })
+}
+
+fn current_branch(repo: &Repository) -> Result<String> {
+    let head = repo.head().context("failed to read HEAD")?;
+    let branch = head
+        .shorthand()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("repository is detached; branch is required"))?;
+    Ok(branch)
+}
+
+fn default_base_ref(repo: &Repository) -> String {
+    for candidate in ["origin/main", "origin/master"] {
+        if repo
+            .find_reference(&format!("refs/remotes/{candidate}"))
+            .is_ok()
+        {
+            return candidate.to_string();
+        }
+    }
+
+    "origin/main".to_string()
+}

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -325,14 +325,10 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/post-create").unwrap();
-        let config_home = TempDir::new().unwrap();
-        write_gwt_config(
-            config_home.path(),
-            &fixture.repo_git_dir(),
-            &["echo ready > created.txt"],
-        )
-        .unwrap();
-        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let _config_guard = ConfigHomeGuard::new().unwrap();
+        let config_path =
+            write_gwt_config(&fixture.repo_git_dir(), &["echo ready > created.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -350,14 +346,10 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/no-rerun").unwrap();
-        let config_home = TempDir::new().unwrap();
-        write_gwt_config(
-            config_home.path(),
-            &fixture.repo_git_dir(),
-            &["echo run >> run-count.txt"],
-        )
-        .unwrap();
-        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let _config_guard = ConfigHomeGuard::new().unwrap();
+        let config_path =
+            write_gwt_config(&fixture.repo_git_dir(), &["echo run >> run-count.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -377,14 +369,9 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/cwd-check").unwrap();
-        let config_home = TempDir::new().unwrap();
-        write_gwt_config(
-            config_home.path(),
-            &fixture.repo_git_dir(),
-            &["pwd > cwd.txt"],
-        )
-        .unwrap();
-        let _config_guard = ConfigHomeGuard::set(config_home.path());
+        let _config_guard = ConfigHomeGuard::new().unwrap();
+        let config_path = write_gwt_config(&fixture.repo_git_dir(), &["pwd > cwd.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -433,23 +420,36 @@ mod tests {
     }
 
     struct ConfigHomeGuard {
-        previous: Option<OsString>,
+        _temp: TempDir,
+        previous_xdg_config_home: Option<OsString>,
+        previous_home: Option<OsString>,
     }
 
     impl ConfigHomeGuard {
-        fn set(path: &Path) -> Self {
-            let previous = env::var_os("XDG_CONFIG_HOME");
+        fn new() -> Result<Self> {
+            let temp = TempDir::new()?;
+            let xdg_config_home = temp.path().join("xdg-config");
+            let home = temp.path().join("home");
+            fs::create_dir_all(&xdg_config_home)?;
+            fs::create_dir_all(&home)?;
+            let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+            let previous_home = env::var_os("HOME");
             // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
             unsafe {
-                env::set_var("XDG_CONFIG_HOME", path);
+                env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+                env::set_var("HOME", &home);
             }
-            Self { previous }
+            Ok(Self {
+                _temp: temp,
+                previous_xdg_config_home,
+                previous_home,
+            })
         }
     }
 
     impl Drop for ConfigHomeGuard {
         fn drop(&mut self) {
-            match &self.previous {
+            match &self.previous_xdg_config_home {
                 Some(previous) => {
                     // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
                     unsafe {
@@ -463,6 +463,21 @@ mod tests {
                     }
                 }
             }
+
+            match &self.previous_home {
+                Some(previous) => {
+                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    unsafe {
+                        env::set_var("HOME", previous);
+                    }
+                }
+                None => {
+                    // SAFETY: tests serialize cwd/env mutation with a global mutex and restore it on drop.
+                    unsafe {
+                        env::remove_var("HOME");
+                    }
+                }
+            }
         }
     }
 
@@ -472,21 +487,30 @@ mod tests {
         Ok(())
     }
 
-    fn write_gwt_config(config_home: &Path, repo_git_dir: &str, commands: &[&str]) -> Result<()> {
-        let gwt_dir = config_home.join("gwt");
-        fs::create_dir_all(&gwt_dir)?;
+    fn write_gwt_config(repo_git_dir: &str, commands: &[&str]) -> Result<PathBuf> {
+        let config_path = gwt_worktree::config::config_path()?;
+        let Some(gwt_dir) = config_path.parent() else {
+            anyhow::bail!("gwt config path has no parent directory");
+        };
+        fs::create_dir_all(gwt_dir)?;
         let serialized_commands = commands
             .iter()
             .map(|command| format!("    {command:?}"))
             .collect::<Vec<_>>()
             .join(",\n");
         fs::write(
-            gwt_dir.join("config.toml"),
+            &config_path,
             format!(
                 "[repos.{repo_git_dir:?}]\npost_create_commands = [\n{serialized_commands}\n]\n"
             ),
         )?;
-        Ok(())
+        Ok(config_path)
+    }
+
+    fn assert_gwt_config_loads_repo(config_path: &Path, repo_git_dir: &str) {
+        assert!(config_path.exists());
+        let loaded = GwtConfig::load().unwrap();
+        assert!(loaded.repos.contains_key(repo_git_dir));
     }
 
     fn worktree_paths(cwd: &Path) -> Result<Vec<String>> {

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -3,6 +3,8 @@ pub mod freshness;
 use anyhow::Context;
 use anyhow::Result;
 use git2::Repository;
+use gwt_worktree::plan::switch::SwitchPlan;
+use gwt_worktree::plan::switch::SwitchPlanKind;
 use gwt_worktree::plan::switch::SwitchRequest;
 use gwt_worktree::plan::switch::plan_switch;
 use gwt_worktree::repo::ControlRepo;
@@ -17,6 +19,13 @@ pub struct TargetWorktree {
     pub path: PathBuf,
     pub branch: String,
     pub base_ref: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreePreview {
+    pub path: Option<PathBuf>,
+    pub branch: String,
+    pub would_create: bool,
 }
 
 pub fn chdir_to(target: &TargetWorktree) -> Result<()> {
@@ -40,6 +49,29 @@ pub fn resolve(
 
     let cwd = std::env::current_dir().context("failed to resolve current directory")?;
     resolve_from_path(&cwd, None)
+}
+
+pub fn preview_resolve(branch: Option<&str>, worktree: Option<&Path>) -> Result<WorktreePreview> {
+    if let Some(path) = worktree {
+        let target = resolve_from_path(path, branch)?;
+        return Ok(WorktreePreview {
+            path: Some(target.path),
+            branch: target.branch,
+            would_create: false,
+        });
+    }
+
+    if let Some(branch) = branch {
+        return preview_from_branch(branch);
+    }
+
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    let target = resolve_from_path(&cwd, None)?;
+    Ok(WorktreePreview {
+        path: Some(target.path),
+        branch: target.branch,
+        would_create: false,
+    })
 }
 
 fn resolve_from_path(path: &Path, expected_branch: Option<&str>) -> Result<TargetWorktree> {
@@ -91,9 +123,48 @@ fn resolve_from_branch(branch: &str, create_if_missing: bool) -> Result<TargetWo
         anyhow::bail!("no worktree found for branch '{branch}'");
     }
 
+    let plan = plan_for_branch(&control, branch)?;
+    let execution = gwt_worktree::exec::switch::execute_switch_plan(&control, &plan, None)?;
+    let repo = Repository::open(&control.common_dir)?;
+
+    Ok(TargetWorktree {
+        path: execution.path,
+        branch: branch.to_string(),
+        base_ref: default_base_ref(&repo),
+    })
+}
+
+fn preview_from_branch(branch: &str) -> Result<WorktreePreview> {
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    let control = ControlRepo::resolve(&ResolveControlRepoOptions {
+        cwd: Some(&cwd),
+        ..ResolveControlRepoOptions::default()
+    })
+    .context("failed to resolve gwt control repository")?;
+
+    if let Some(existing) = list_worktrees(&control)?
+        .into_iter()
+        .find(|item| item.branch.as_deref() == Some(branch) && item.path.exists())
+    {
+        return Ok(WorktreePreview {
+            path: Some(existing.path),
+            branch: branch.to_string(),
+            would_create: false,
+        });
+    }
+
+    let plan = plan_for_branch(&control, branch)?;
+    Ok(WorktreePreview {
+        path: Some(plan.target_path.clone()),
+        branch: branch.to_string(),
+        would_create: plan_would_create(&plan),
+    })
+}
+
+fn plan_for_branch(control: &ControlRepo, branch: &str) -> Result<SwitchPlan> {
     let branch_name = BranchName::new(branch.to_string())?;
-    let plan = plan_switch(
-        &control,
+    plan_switch(
+        control,
         &SwitchRequest {
             branch: branch_name.clone(),
             create: false,
@@ -106,7 +177,7 @@ fn resolve_from_branch(branch: &str, create_if_missing: bool) -> Result<TargetWo
     .or_else(|error| {
         if matches!(error, gwt_worktree::Error::BranchNotFound(_)) {
             plan_switch(
-                &control,
+                control,
                 &SwitchRequest {
                     branch: branch_name,
                     create: true,
@@ -119,16 +190,15 @@ fn resolve_from_branch(branch: &str, create_if_missing: bool) -> Result<TargetWo
         } else {
             Err(error)
         }
-    })?;
-
-    let execution = gwt_worktree::exec::switch::execute_switch_plan(&control, &plan, None)?;
-    let repo = Repository::open(&control.common_dir)?;
-
-    Ok(TargetWorktree {
-        path: execution.path,
-        branch: branch.to_string(),
-        base_ref: default_base_ref(&repo),
     })
+    .map_err(Into::into)
+}
+
+fn plan_would_create(plan: &SwitchPlan) -> bool {
+    !matches!(
+        plan.kind,
+        SwitchPlanKind::Main | SwitchPlanKind::ExistingWorktree
+    )
 }
 
 fn current_branch(repo: &Repository) -> Result<String> {
@@ -151,4 +221,100 @@ fn default_base_ref(repo: &Repository) -> String {
     }
 
     "origin/main".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::env;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+    use tempfile::TempDir;
+
+    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn preview_resolve_does_not_create_missing_branch_worktree() {
+        let _guard = cwd_lock().lock().unwrap();
+        let fixture = GitFixture::new().unwrap();
+        let saved = env::current_dir().unwrap();
+        env::set_current_dir(&fixture.repo).unwrap();
+
+        let before = worktree_paths(&fixture.repo).unwrap();
+        let preview = preview_resolve(Some("feature/preview-only"), None).unwrap();
+        let after = worktree_paths(&fixture.repo).unwrap();
+
+        env::set_current_dir(saved).unwrap();
+        assert_eq!(before, after);
+        assert!(preview.would_create);
+        assert!(preview.path.is_some());
+        assert_eq!(preview.branch, "feature/preview-only");
+    }
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        CWD_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct GitFixture {
+        _temp: TempDir,
+        repo: PathBuf,
+    }
+
+    impl GitFixture {
+        fn new() -> Result<Self> {
+            let temp = TempDir::new()?;
+            let repo = temp.path().join("repo");
+
+            run_git(temp.path(), ["init", repo.to_str().unwrap()])?;
+            configure_repo(&repo)?;
+            fs::write(repo.join("README.md"), "base\n")?;
+            run_git(&repo, ["add", "README.md"])?;
+            run_git(&repo, ["commit", "-m", "initial"])?;
+            run_git(&repo, ["branch", "feature/preview-only"])?;
+
+            Ok(Self { _temp: temp, repo })
+        }
+    }
+
+    fn configure_repo(path: &Path) -> Result<()> {
+        run_git(path, ["config", "user.name", "Test User"])?;
+        run_git(path, ["config", "user.email", "test@example.com"])?;
+        Ok(())
+    }
+
+    fn worktree_paths(cwd: &Path) -> Result<Vec<String>> {
+        let output = Command::new("git")
+            .current_dir(cwd)
+            .args(["worktree", "list", "--porcelain"])
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git worktree list failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| line.strip_prefix("worktree ").map(str::to_string))
+            .collect())
+    }
+
+    fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<()> {
+        let output = Command::new("git").current_dir(cwd).args(args).output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    use std::process::Command;
 }

--- a/apps/agentic-outer-dag/src/worktree/mod.rs
+++ b/apps/agentic-outer-dag/src/worktree/mod.rs
@@ -325,10 +325,12 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/post-create").unwrap();
+        let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
         let _config_guard = ConfigHomeGuard::new().unwrap();
         let config_path =
-            write_gwt_config(&fixture.repo_git_dir(), &["echo ready > created.txt"]).unwrap();
-        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
+            write_gwt_config(&repo_git_dir_key, &["echo ready > created.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
+        assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -346,10 +348,12 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/no-rerun").unwrap();
+        let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
         let _config_guard = ConfigHomeGuard::new().unwrap();
         let config_path =
-            write_gwt_config(&fixture.repo_git_dir(), &["echo run >> run-count.txt"]).unwrap();
-        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
+            write_gwt_config(&repo_git_dir_key, &["echo run >> run-count.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
+        assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -369,9 +373,11 @@ mod tests {
         let _guard = cwd_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.branch("feature/cwd-check").unwrap();
+        let repo_git_dir_key = fixture.control_git_dir_key().unwrap();
         let _config_guard = ConfigHomeGuard::new().unwrap();
-        let config_path = write_gwt_config(&fixture.repo_git_dir(), &["pwd > cwd.txt"]).unwrap();
-        assert_gwt_config_loads_repo(&config_path, &fixture.repo_git_dir());
+        let config_path = write_gwt_config(&repo_git_dir_key, &["pwd > cwd.txt"]).unwrap();
+        assert_gwt_config_loads_repo(&config_path, &repo_git_dir_key);
+        assert_load_repo_config_uses_resolved_key(&fixture, &repo_git_dir_key);
         let saved = env::current_dir().unwrap();
         env::set_current_dir(&fixture.repo).unwrap();
 
@@ -414,8 +420,12 @@ mod tests {
             run_git(&self.repo, ["branch", name])
         }
 
-        fn repo_git_dir(&self) -> String {
-            self.repo.join(".git").display().to_string()
+        fn control_git_dir_key(&self) -> Result<String> {
+            Ok(ControlRepo::resolve(&ResolveControlRepoOptions {
+                cwd: Some(&self.repo),
+                ..ResolveControlRepoOptions::default()
+            })?
+            .git_dir_key)
         }
     }
 
@@ -511,6 +521,16 @@ mod tests {
         assert!(config_path.exists());
         let loaded = GwtConfig::load().unwrap();
         assert!(loaded.repos.contains_key(repo_git_dir));
+    }
+
+    fn assert_load_repo_config_uses_resolved_key(fixture: &GitFixture, repo_git_dir_key: &str) {
+        let control = ControlRepo::resolve(&ResolveControlRepoOptions {
+            cwd: Some(&fixture.repo),
+            ..ResolveControlRepoOptions::default()
+        })
+        .unwrap();
+        assert_eq!(control.git_dir_key, repo_git_dir_key);
+        assert!(load_repo_config(&control).is_some());
     }
 
     fn worktree_paths(cwd: &Path) -> Result<Vec<String>> {

--- a/apps/agentic/CLAUDE.md
+++ b/apps/agentic/CLAUDE.md
@@ -17,14 +17,13 @@ CLI application for managing `agentic.toml` configuration files. Provides comman
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-bin -- --check
-cargo clippy -p agentic-bin --all-targets -- -D warnings
+just crate-check agentic-bin
 
 # Tests
-cargo test -p agentic-bin
+just crate-test agentic-bin
 
 # Build
-cargo build -p agentic-bin
+just crate-build agentic-bin
 ```
 <!-- END:xtask:autogen -->
 

--- a/apps/message-optimizer/CLAUDE.md
+++ b/apps/message-optimizer/CLAUDE.md
@@ -17,14 +17,13 @@ Thin CLI for optimizing a single message into GPT-5.4 prompt components. Pass th
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p message-optimizer-bin -- --check
-cargo clippy -p message-optimizer-bin --all-targets -- -D warnings
+just crate-check message-optimizer-bin
 
 # Tests
-cargo test -p message-optimizer-bin
+just crate-test message-optimizer-bin
 
 # Build
-cargo build -p message-optimizer-bin
+just crate-build message-optimizer-bin
 ```
 <!-- END:xtask:autogen -->
 

--- a/apps/opencode-orchestrator-mcp/CLAUDE.md
+++ b/apps/opencode-orchestrator-mcp/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p opencode-orchestrator-mcp -- --check
-cargo clippy -p opencode-orchestrator-mcp --all-targets -- -D warnings
+just crate-check opencode-orchestrator-mcp
 
 # Tests
-cargo test -p opencode-orchestrator-mcp
+just crate-test opencode-orchestrator-mcp
 
 # Build
-cargo build -p opencode-orchestrator-mcp
+just crate-build opencode-orchestrator-mcp
 ```
 <!-- END:xtask:autogen -->
 

--- a/apps/opencode-orchestrator-mcp/src/version.rs
+++ b/apps/opencode-orchestrator-mcp/src/version.rs
@@ -93,8 +93,15 @@ pub fn resolve_launcher_config(base_dir: &Path) -> anyhow::Result<LauncherConfig
     if !launcher_args.is_empty() {
         // Launcher mode: binary is expected to be in PATH (e.g., bunx, npx)
         // Don't canonicalize - it's not a file path, it's a command
-        let binary = std::env::var(OPENCODE_BINARY_ENV)
-            .map_or_else(|_| "opencode".to_string(), |v| v.trim().to_string());
+        let binary = match std::env::var(OPENCODE_BINARY_ENV) {
+            Ok(v) => v.trim().to_string(),
+            Err(_) => {
+                return Err(anyhow!(
+                    "OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is not set.
+                     When using launcher args, set OPENCODE_BINARY to the launcher command (e.g., 'bunx')."
+                ));
+            }
+        };
 
         if binary.is_empty() {
             return Err(anyhow!(
@@ -227,6 +234,32 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("OPENCODE_BINARY is empty")
+        );
+
+        // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
+        unsafe {
+            std::env::remove_var(OPENCODE_BINARY_ENV);
+            std::env::remove_var(OPENCODE_BINARY_ARGS_ENV);
+        }
+    }
+
+    #[test]
+    #[serial(env)]
+    fn resolve_launcher_config_errors_when_args_set_but_binary_missing() {
+        // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.
+        unsafe {
+            std::env::remove_var(OPENCODE_BINARY_ENV);
+            std::env::set_var(OPENCODE_BINARY_ARGS_ENV, "opencode-ai@1.17.4");
+        }
+
+        let base = Path::new("/tmp/project");
+        let result = resolve_launcher_config(base);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("OPENCODE_BINARY_ARGS is set but OPENCODE_BINARY is not set")
         );
 
         // SAFETY: Test serialized by #[serial(env)], preventing concurrent env access.

--- a/apps/thoughts/CLAUDE.md
+++ b/apps/thoughts/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p thoughts-bin -- --check
-cargo clippy -p thoughts-bin --all-targets -- -D warnings
+just crate-check thoughts-bin
 
 # Tests
-cargo test -p thoughts-bin
+just crate-test thoughts-bin
 
 # Build
-cargo build -p thoughts-bin
+just crate-build thoughts-bin
 ```
 <!-- END:xtask:autogen -->
 

--- a/bindings/node/agentic-tools-napi/CLAUDE.md
+++ b/bindings/node/agentic-tools-napi/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-napi -- --check
-cargo clippy -p agentic-tools-napi --all-targets -- -D warnings
+just crate-check agentic-tools-napi
 
 # Tests
-cargo test -p agentic-tools-napi
+just crate-test agentic-tools-napi
 
 # Build
-cargo build -p agentic-tools-napi
+just crate-build agentic-tools-napi
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/agentic-tools/core/CLAUDE.md
+++ b/crates/agentic-tools/core/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-core -- --check
-cargo clippy -p agentic-tools-core --all-targets -- -D warnings
+just crate-check agentic-tools-core
 
 # Tests
-cargo test -p agentic-tools-core
+just crate-test agentic-tools-core
 
 # Build
-cargo build -p agentic-tools-core
+just crate-build agentic-tools-core
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/agentic-tools/macros/CLAUDE.md
+++ b/crates/agentic-tools/macros/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-macros -- --check
-cargo clippy -p agentic-tools-macros --all-targets -- -D warnings
+just crate-check agentic-tools-macros
 
 # Tests
-cargo test -p agentic-tools-macros
+just crate-test agentic-tools-macros
 
 # Build
-cargo build -p agentic-tools-macros
+just crate-build agentic-tools-macros
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/agentic-tools/mcp/CLAUDE.md
+++ b/crates/agentic-tools/mcp/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-mcp -- --check
-cargo clippy -p agentic-tools-mcp --all-targets -- -D warnings
+just crate-check agentic-tools-mcp
 
 # Tests
-cargo test -p agentic-tools-mcp
+just crate-test agentic-tools-mcp
 
 # Build
-cargo build -p agentic-tools-mcp
+just crate-build agentic-tools-mcp
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/agentic-tools/registry/CLAUDE.md
+++ b/crates/agentic-tools/registry/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-registry -- --check
-cargo clippy -p agentic-tools-registry --all-targets -- -D warnings
+just crate-check agentic-tools-registry
 
 # Tests
-cargo test -p agentic-tools-registry
+just crate-test agentic-tools-registry
 
 # Build
-cargo build -p agentic-tools-registry
+just crate-build agentic-tools-registry
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/agentic-tools/utils/CLAUDE.md
+++ b/crates/agentic-tools/utils/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-tools-utils -- --check
-cargo clippy -p agentic-tools-utils --all-targets -- -D warnings
+just crate-check agentic-tools-utils
 
 # Tests
-cargo test -p agentic-tools-utils
+just crate-test agentic-tools-utils
 
 # Build
-cargo build -p agentic-tools-utils
+just crate-build agentic-tools-utils
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/agentic-config/CLAUDE.md
+++ b/crates/infra/agentic-config/CLAUDE.md
@@ -17,14 +17,13 @@ Unified configuration system for the agentic tools ecosystem. Handles loading, m
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-config -- --check
-cargo clippy -p agentic-config --all-targets -- -D warnings
+just crate-check agentic-config
 
 # Tests
-cargo test -p agentic-config
+just crate-test agentic-config
 
 # Build
-cargo build -p agentic-config
+just crate-build agentic-config
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/agentic-logging/CLAUDE.md
+++ b/crates/infra/agentic-logging/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic_logging -- --check
-cargo clippy -p agentic_logging --all-targets -- -D warnings
+just crate-check agentic_logging
 
 # Tests
-cargo test -p agentic_logging
+just crate-test agentic_logging
 
 # Build
-cargo build -p agentic_logging
+just crate-build agentic_logging
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/gwt-worktree/CLAUDE.md
+++ b/crates/infra/gwt-worktree/CLAUDE.md
@@ -17,14 +17,13 @@ Programmatic, gwt-compatible git worktree management library for typed listing, 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p gwt-worktree -- --check
-cargo clippy -p gwt-worktree --all-targets -- -D warnings
+just crate-check gwt-worktree
 
 # Tests
-cargo test -p gwt-worktree
+just crate-test gwt-worktree
 
 # Build
-cargo build -p gwt-worktree
+just crate-build gwt-worktree
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/infra/thoughts-core/CLAUDE.md
+++ b/crates/infra/thoughts-core/CLAUDE.md
@@ -255,13 +255,12 @@ The tool now fully supports git worktrees through automatic detection and smart 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p thoughts-tool -- --check
-cargo clippy -p thoughts-tool --all-targets -- -D warnings
+just crate-check thoughts-tool
 
 # Tests
-cargo test -p thoughts-tool
+just crate-test thoughts-tool
 
 # Build
-cargo build -p thoughts-tool
+just crate-build thoughts-tool
 ```
 <!-- END:xtask:autogen -->

--- a/crates/legacy/universal-tool-core/CLAUDE.md
+++ b/crates/legacy/universal-tool-core/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p universal-tool-core -- --check
-cargo clippy -p universal-tool-core --all-targets -- -D warnings
+just crate-check universal-tool-core
 
 # Tests
-cargo test -p universal-tool-core
+just crate-test universal-tool-core
 
 # Build
-cargo build -p universal-tool-core
+just crate-build universal-tool-core
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/legacy/universal-tool-integration-tests/CLAUDE.md
+++ b/crates/legacy/universal-tool-integration-tests/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p universal-tool-integration-tests -- --check
-cargo clippy -p universal-tool-integration-tests --all-targets -- -D warnings
+just crate-check universal-tool-integration-tests
 
 # Tests
-cargo test -p universal-tool-integration-tests
+just crate-test universal-tool-integration-tests
 
 # Build
-cargo build -p universal-tool-integration-tests
+just crate-build universal-tool-integration-tests
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/legacy/universal-tool-macros/CLAUDE.md
+++ b/crates/legacy/universal-tool-macros/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p universal-tool-macros -- --check
-cargo clippy -p universal-tool-macros --all-targets -- -D warnings
+just crate-check universal-tool-macros
 
 # Tests
-cargo test -p universal-tool-macros
+just crate-test universal-tool-macros
 
 # Build
-cargo build -p universal-tool-macros
+just crate-build universal-tool-macros
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/linear/queries/CLAUDE.md
+++ b/crates/linear/queries/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p linear-queries -- --check
-cargo clippy -p linear-queries --all-targets -- -D warnings
+just crate-check linear-queries
 
 # Tests
-cargo test -p linear-queries
+just crate-test linear-queries
 
 # Build
-cargo build -p linear-queries
+just crate-build linear-queries
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/linear/schema/CLAUDE.md
+++ b/crates/linear/schema/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p linear-schema -- --check
-cargo clippy -p linear-schema --all-targets -- -D warnings
+just crate-check linear-schema
 
 # Tests
-cargo test -p linear-schema
+just crate-test linear-schema
 
 # Build
-cargo build -p linear-schema
+just crate-build linear-schema
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/linear/tools/CLAUDE.md
+++ b/crates/linear/tools/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p linear-tools -- --check
-cargo clippy -p linear-tools --all-targets -- -D warnings
+just crate-check linear-tools
 
 # Tests
-cargo test -p linear-tools
+just crate-test linear-tools
 
 # Build
-cargo build -p linear-tools
+just crate-build linear-tools
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/meta/xtask/CLAUDE.md
+++ b/crates/meta/xtask/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p xtask -- --check
-cargo clippy -p xtask --all-targets -- -D warnings
+just crate-check xtask
 
 # Tests
-cargo test -p xtask
+just crate-test xtask
 
 # Build
-cargo build -p xtask
+just crate-build xtask
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/meta/xtask/src/claude.rs
+++ b/crates/meta/xtask/src/claude.rs
@@ -184,16 +184,15 @@ fn sync_single_crate_claude(
     let commands = format!(
         r"```bash
 # Lint & Clippy
-cargo fmt -p {} -- --check
-cargo clippy -p {} --all-targets -- -D warnings
+just crate-check {}
 
 # Tests
-cargo test -p {}
+just crate-test {}
 
 # Build
-cargo build -p {}
+just crate-build {}
 ```",
-        pkg.name, pkg.name, pkg.name, pkg.name
+        pkg.name, pkg.name, pkg.name
     );
 
     // Read or create file

--- a/crates/services/anthropic-async/CLAUDE.md
+++ b/crates/services/anthropic-async/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p anthropic-async -- --check
-cargo clippy -p anthropic-async --all-targets -- -D warnings
+just crate-check anthropic-async
 
 # Tests
-cargo test -p anthropic-async
+just crate-test anthropic-async
 
 # Build
-cargo build -p anthropic-async
+just crate-build anthropic-async
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/services/claudecode-rs/CLAUDE.md
+++ b/crates/services/claudecode-rs/CLAUDE.md
@@ -123,13 +123,12 @@ cargo run --example streaming_debug
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p claudecode -- --check
-cargo clippy -p claudecode --all-targets -- -D warnings
+just crate-check claudecode
 
 # Tests
-cargo test -p claudecode
+just crate-test claudecode
 
 # Build
-cargo build -p claudecode
+just crate-build claudecode
 ```
 <!-- END:xtask:autogen -->

--- a/crates/services/exa-async/CLAUDE.md
+++ b/crates/services/exa-async/CLAUDE.md
@@ -20,14 +20,13 @@ Async Rust client for the Exa API.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p exa-async -- --check
-cargo clippy -p exa-async --all-targets -- -D warnings
+just crate-check exa-async
 
 # Tests
-cargo test -p exa-async
+just crate-test exa-async
 
 # Build
-cargo build -p exa-async
+just crate-build exa-async
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/services/opencode-rs/CLAUDE.md
+++ b/crates/services/opencode-rs/CLAUDE.md
@@ -67,13 +67,12 @@ cargo test --features http
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p opencode_rs -- --check
-cargo clippy -p opencode_rs --all-targets -- -D warnings
+just crate-check opencode_rs
 
 # Tests
-cargo test -p opencode_rs
+just crate-test opencode_rs
 
 # Build
-cargo build -p opencode_rs
+just crate-build opencode_rs
 ```
 <!-- END:xtask:autogen -->

--- a/crates/services/opencode-rs/src/http/messages.rs
+++ b/crates/services/opencode-rs/src/http/messages.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides methods for message endpoints (6 total).
 
+use crate::OpencodeError;
 use crate::error::Result;
 use crate::http::HttpClient;
 use crate::http::encode_path_segment;
@@ -13,6 +14,7 @@ use crate::types::message::Message;
 use crate::types::message::PromptRequest;
 use crate::types::message::ShellRequest;
 use reqwest::Method;
+use std::time::Duration;
 
 /// Messages API client.
 #[derive(Clone)]
@@ -86,24 +88,48 @@ impl MessagesApi {
 
     /// Execute a command in a session.
     ///
-    /// Uses transport-level retry for transient network failures (connect/timeout).
-    ///
-    /// Live verification against `OpenCode` 1.17.4 must confirm whether command
-    /// dispatch dedupes by `messageID`. Until that contract is revalidated,
-    /// callers should treat this endpoint as at-least-once, not exactly-once:
-    /// if the server has already started executing the command before a
-    /// retryable network failure occurs (for example, a connection drop
-    /// mid-response), a retry can trigger duplicate command execution.
+    /// This endpoint is completion-coupled in upstream `OpenCode` v1.17.x,
+    /// so callers must treat the HTTP request as dispatch initiation only.
+    /// To reduce duplicate-dispatch risk, this method does not retry timeout
+    /// or generic request transport failures after the request may have reached
+    /// the server. At most, it retries a connect failure before any response.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails after retries.
+    /// Returns an error if the request fails.
     pub async fn command(&self, session_id: &str, req: &CommandRequest) -> Result<CommandResponse> {
+        const MAX_ATTEMPTS: usize = 2;
+        const BACKOFF_MS: u64 = 50;
+
         let sid = encode_path_segment(session_id);
         let body = serde_json::to_value(req)?;
-        self.http
-            .post_json_with_retry(&format!("/session/{sid}/command"), Some(body))
-            .await
+        let path = format!("/session/{sid}/command");
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            match self
+                .http
+                .request_json(Method::POST, &path, Some(body.clone()))
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let connect_only_retry = matches!(
+                        &err,
+                        OpencodeError::Transport(inner) if inner.is_connect()
+                    );
+
+                    if connect_only_retry && attempt < MAX_ATTEMPTS {
+                        tracing::debug!(attempt, error = %err, "connect error on /command; retrying");
+                        tokio::time::sleep(Duration::from_millis(BACKOFF_MS)).await;
+                        continue;
+                    }
+
+                    return Err(err);
+                }
+            }
+        }
+
+        unreachable!("loop returns on success or error")
     }
 
     /// Execute a shell command in a session.
@@ -306,6 +332,52 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.status, Some("executed".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_command_does_not_retry_on_timeout() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/session/s1/command"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(200))
+                    .set_body_json(serde_json::json!({"status": "executed"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            workspace: None,
+            timeout: Duration::from_millis(50),
+        })
+        .unwrap();
+
+        let messages = MessagesApi::new(http);
+        let result = messages
+            .command(
+                "s1",
+                &CommandRequest {
+                    command: "test_command".to_string(),
+                    arguments: String::new(),
+                    message_id: None,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(OpencodeError::Transport(_))));
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let command_requests = requests
+            .into_iter()
+            .filter(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/session/s1/command"
+            })
+            .count();
+        assert_eq!(command_requests, 1);
     }
 
     #[tokio::test]

--- a/crates/services/opencode-rs/src/http/mod.rs
+++ b/crates/services/opencode-rs/src/http/mod.rs
@@ -391,7 +391,7 @@ impl HttpClient {
             match build().send().await {
                 Ok(resp) => return Ok(resp),
                 Err(e) => {
-                    // Retry only on transport-level errors (before HTTP response received)
+                    // Retry only on transport-level errors (connect/timeout/request) before HTTP response received.
                     let retryable = e.is_connect() || e.is_timeout() || e.is_request();
                     if retryable && attempt < MAX_ATTEMPTS {
                         tracing::debug!(

--- a/crates/services/opencode-rs/src/server.rs
+++ b/crates/services/opencode-rs/src/server.rs
@@ -73,6 +73,11 @@ pub struct ServerOptions {
     /// Use this to pass custom configuration, secrets, or feature flags
     /// without modifying the system environment.
     pub env_vars: HashMap<String, String>,
+    /// Whether to force `OPENCODE_ORCHESTRATOR_MANAGED=1` in the child process.
+    ///
+    /// When disabled, the child process explicitly removes the variable so any
+    /// inherited parent value is cleared.
+    pub inject_orchestrator_managed_env: bool,
 }
 
 impl Default for ServerOptions {
@@ -86,6 +91,7 @@ impl Default for ServerOptions {
             binary: "opencode".to_string(),
             launcher_args: Vec::new(),
             env_vars: HashMap::new(),
+            inject_orchestrator_managed_env: true,
         }
     }
 }
@@ -162,6 +168,21 @@ impl ServerOptions {
             .collect();
         self
     }
+
+    /// Control whether `OPENCODE_ORCHESTRATOR_MANAGED=1` is forced into the child.
+    #[must_use]
+    pub fn inject_orchestrator_managed_env(mut self, enabled: bool) -> Self {
+        self.inject_orchestrator_managed_env = enabled;
+        self
+    }
+}
+
+fn apply_managed_env_policy(cmd: &mut Command, opts: &ServerOptions) {
+    if opts.inject_orchestrator_managed_env {
+        cmd.env("OPENCODE_ORCHESTRATOR_MANAGED", "1");
+    } else {
+        cmd.env_remove("OPENCODE_ORCHESTRATOR_MANAGED");
+    }
 }
 
 /// A managed `OpenCode` server instance.
@@ -224,8 +245,8 @@ impl ManagedServer {
         }
 
         // Recursion guard: any MCP servers spawned by this `opencode serve` should
-        // know they're in an orchestrator-managed context.
-        cmd.env("OPENCODE_ORCHESTRATOR_MANAGED", "1");
+        // know they're in an orchestrator-managed context unless explicitly disabled.
+        apply_managed_env_policy(&mut cmd, &opts);
 
         if let Some(cfg) = &opts.config_json {
             cmd.env("OPENCODE_CONFIG_CONTENT", cfg);
@@ -378,6 +399,7 @@ mod tests {
         assert_eq!(opts.binary, "opencode");
         assert!(opts.launcher_args.is_empty());
         assert!(opts.env_vars.is_empty());
+        assert!(opts.inject_orchestrator_managed_env);
     }
 
     #[test]
@@ -393,6 +415,7 @@ mod tests {
         assert_eq!(opts.startup_timeout_ms, 10000);
         assert_eq!(opts.binary, "/usr/local/bin/opencode");
         assert!(opts.launcher_args.is_empty());
+        assert!(opts.inject_orchestrator_managed_env);
     }
 
     #[test]
@@ -446,5 +469,40 @@ mod tests {
 
         assert_eq!(opts.env_vars.get("FOO"), Some(&"bar".to_string()));
         assert_eq!(opts.env_vars.get("BAZ"), Some(&"qux".to_string()));
+    }
+
+    #[test]
+    fn test_server_options_can_disable_managed_env_injection() {
+        let opts = ServerOptions::new().inject_orchestrator_managed_env(false);
+
+        assert!(!opts.inject_orchestrator_managed_env);
+    }
+
+    #[test]
+    fn test_apply_managed_env_policy_removes_inherited_env_when_disabled() {
+        let opts = ServerOptions::new().inject_orchestrator_managed_env(false);
+        let mut cmd = Command::new("opencode");
+        cmd.env("OPENCODE_ORCHESTRATOR_MANAGED", "parent-value");
+
+        apply_managed_env_policy(&mut cmd, &opts);
+
+        let envs: Vec<_> = cmd.as_std().get_envs().collect();
+        assert!(envs.iter().any(|(key, value)| {
+            *key == std::ffi::OsStr::new("OPENCODE_ORCHESTRATOR_MANAGED") && value.is_none()
+        }));
+    }
+
+    #[test]
+    fn test_apply_managed_env_policy_injects_guard_when_enabled() {
+        let opts = ServerOptions::new();
+        let mut cmd = Command::new("opencode");
+
+        apply_managed_env_policy(&mut cmd, &opts);
+
+        let envs: Vec<_> = cmd.as_std().get_envs().collect();
+        assert!(envs.iter().any(|(key, value)| {
+            *key == std::ffi::OsStr::new("OPENCODE_ORCHESTRATOR_MANAGED")
+                && *value == Some(std::ffi::OsStr::new("1"))
+        }));
     }
 }

--- a/crates/services/opencode-rs/tests/command_retry.rs
+++ b/crates/services/opencode-rs/tests/command_retry.rs
@@ -1,6 +1,6 @@
-//! SDK-level regression test for command dispatch retry.
+//! SDK-level regression test for command dispatch retry policy.
 //!
-//! Verifies that `messages().command()` retries on transport-level timeout.
+//! Verifies that `messages().command()` does not retry on transport-level timeout.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -13,34 +13,22 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
-/// Verify that command dispatch retries on transport timeout.
+/// Verify that command dispatch does not retry on transport timeout.
 ///
 /// Setup:
 /// - First request: 30s delay (causes timeout with 1s client timeout)
-/// - Second request: immediate success
 ///
-/// Expected: Second request succeeds after retry.
+/// Expected: Timeout is returned and only one POST attempt is made.
 #[tokio::test]
-async fn command_retries_on_timeout() {
+async fn command_does_not_retry_on_timeout() {
     let server = MockServer::start().await;
 
-    // First request: timeout (30s delay > 1s client timeout)
     Mock::given(method("POST"))
         .and(path("/session/s1/command"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(serde_json::json!({"status": "executed"}))
                 .set_delay(Duration::from_secs(30)),
-        )
-        .up_to_n_times(1)
-        .mount(&server)
-        .await;
-
-    // Second request: immediate success
-    Mock::given(method("POST"))
-        .and(path("/session/s1/command"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "executed"})),
         )
         .mount(&server)
         .await;
@@ -58,9 +46,11 @@ async fn command_retries_on_timeout() {
     };
 
     let result = client.messages().command("s1", &req).await;
-    assert!(result.is_ok(), "expected retry to succeed, got: {result:?}");
+    assert!(
+        result.is_err(),
+        "expected timeout transport error, got: {result:?}"
+    );
 
-    // Verify 2 requests made (1 timeout + 1 success)
     let received = server.received_requests().await.unwrap();
     let command_requests: Vec<_> = received
         .iter()
@@ -68,15 +58,9 @@ async fn command_retries_on_timeout() {
         .collect();
     assert_eq!(
         command_requests.len(),
-        2,
-        "expected 2 command requests (1 timeout + 1 success), got {}",
+        1,
+        "expected 1 command request (no timeout retry), got {}",
         command_requests.len()
-    );
-
-    // Verify both retry attempts reused the exact same serialized body bytes.
-    assert_eq!(
-        command_requests[0].body, command_requests[1].body,
-        "expected identical request bodies across retries"
     );
 
     let body: serde_json::Value = serde_json::from_slice(&command_requests[0].body).unwrap();

--- a/crates/tools/coding-agent-tools/CLAUDE.md
+++ b/crates/tools/coding-agent-tools/CLAUDE.md
@@ -36,13 +36,12 @@ just fmt          # Format code
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p coding_agent_tools -- --check
-cargo clippy -p coding_agent_tools --all-targets -- -D warnings
+just crate-check coding_agent_tools
 
 # Tests
-cargo test -p coding_agent_tools
+just crate-test coding_agent_tools
 
 # Build
-cargo build -p coding_agent_tools
+just crate-build coding_agent_tools
 ```
 <!-- END:xtask:autogen -->

--- a/crates/tools/gpt5-reasoner/CLAUDE.md
+++ b/crates/tools/gpt5-reasoner/CLAUDE.md
@@ -131,13 +131,12 @@ fn my_env_test() {
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p gpt5_reasoner -- --check
-cargo clippy -p gpt5_reasoner --all-targets -- -D warnings
+just crate-check gpt5_reasoner
 
 # Tests
-cargo test -p gpt5_reasoner
+just crate-test gpt5_reasoner
 
 # Build
-cargo build -p gpt5_reasoner
+just crate-build gpt5_reasoner
 ```
 <!-- END:xtask:autogen -->

--- a/crates/tools/message-optimizer/CLAUDE.md
+++ b/crates/tools/message-optimizer/CLAUDE.md
@@ -17,14 +17,13 @@ Standalone Anthropic-backed library for optimizing a raw message into GPT-5.4 pr
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p message_optimizer -- --check
-cargo clippy -p message_optimizer --all-targets -- -D warnings
+just crate-check message_optimizer
 
 # Tests
-cargo test -p message_optimizer
+just crate-test message_optimizer
 
 # Build
-cargo build -p message_optimizer
+just crate-build message_optimizer
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/tools/pr-comments/CLAUDE.md
+++ b/crates/tools/pr-comments/CLAUDE.md
@@ -162,13 +162,12 @@ CLI returns JSON for programmatic use. MCP interface returns formatted text for 
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p pr_comments -- --check
-cargo clippy -p pr_comments --all-targets -- -D warnings
+just crate-check pr_comments
 
 # Tests
-cargo test -p pr_comments
+just crate-test pr_comments
 
 # Build
-cargo build -p pr_comments
+just crate-build pr_comments
 ```
 <!-- END:xtask:autogen -->

--- a/crates/tools/pr-comments/Cargo.toml
+++ b/crates/tools/pr-comments/Cargo.toml
@@ -20,7 +20,7 @@ agentic-tools-utils = { workspace = true }
 futures = "0.3"
 
 # Async runtime
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true }
 
 # GitHub API client
 octocrab = { version = "0.49", default-features = false, features = [
@@ -66,7 +66,9 @@ url = "2"
 [dev-dependencies]
 # Testing
 mockito = "1"
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/tools/pr-comments/Cargo.toml
+++ b/crates/tools/pr-comments/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 keywords = ["github", "pull-requests", "comments", "cli", "mcp"]
 categories = ["command-line-utilities", "development-tools"]
 
-
 [dependencies]
 # Agentic tools framework
 agentic-config = { workspace = true }
@@ -21,7 +20,7 @@ agentic-tools-utils = { workspace = true }
 futures = "0.3"
 
 # Async runtime
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 # GitHub API client
 octocrab = { version = "0.49", default-features = false, features = [
@@ -35,6 +34,10 @@ octocrab = { version = "0.49", default-features = false, features = [
   "tracing",
 ] }
 gh-config = "0.5.1"
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 
 # Git operations
 git2 = { version = "0.20", features = ["vendored-openssl"] }

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -20,11 +20,14 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
 
+const REST_PER_PAGE: usize = 100;
+
 pub struct GitHubClient {
     client: Octocrab,
     http: reqwest::Client,
     owner: String,
     repo: String,
+    rest_base_url: String,
 }
 
 impl GitHubClient {
@@ -68,7 +71,14 @@ impl GitHubClient {
             http,
             owner,
             repo,
+            rest_base_url: "https://api.github.com".to_string(),
         })
+    }
+
+    #[cfg(test)]
+    fn with_rest_base_url(mut self, rest_base_url: String) -> Self {
+        self.rest_base_url = rest_base_url;
+        self
     }
 
     pub async fn get_pr_from_branch(&self, branch: &str) -> Result<Option<u64>> {
@@ -128,37 +138,76 @@ impl GitHubClient {
     }
 
     pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
-        let path = format!(
+        let base_path = format!(
             "/repos/{}/{}/commits/{sha}/check-suites",
             self.owner, self.repo
         );
-        let value = self.rest_get(&path).await?;
-        parse_check_suites_response(value)
+        let mut suites = Vec::new();
+        let mut page = 1u32;
+        loop {
+            let value = self
+                .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
+                .await?;
+            let page_suites = parse_check_suites_response(value)?;
+            let page_len = page_suites.len();
+            suites.extend(page_suites);
+            if page_len < REST_PER_PAGE {
+                break;
+            }
+            page += 1;
+        }
+        Ok(suites)
     }
 
     pub async fn list_pull_request_reviews(
         &self,
         pr_number: u64,
     ) -> Result<Vec<PullRequestReviewSummary>> {
-        let path = format!(
+        let base_path = format!(
             "/repos/{}/{}/pulls/{pr_number}/reviews",
             self.owner, self.repo
         );
-        let value = self.rest_get(&path).await?;
-        parse_reviews_response(value)
+        let mut reviews = Vec::new();
+        let mut page = 1u32;
+        loop {
+            let value = self
+                .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
+                .await?;
+            let page_reviews = parse_reviews_response(value)?;
+            let page_len = page_reviews.len();
+            reviews.extend(page_reviews);
+            if page_len < REST_PER_PAGE {
+                break;
+            }
+            page += 1;
+        }
+        Ok(reviews)
     }
 
     pub async fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueCommentSummary>> {
-        let path = format!(
+        let base_path = format!(
             "/repos/{}/{}/issues/{issue_number}/comments",
             self.owner, self.repo
         );
-        let value = self.rest_get(&path).await?;
-        parse_issue_comments_response(value)
+        let mut comments = Vec::new();
+        let mut page = 1u32;
+        loop {
+            let value = self
+                .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
+                .await?;
+            let page_comments = parse_issue_comments_response(value)?;
+            let page_len = page_comments.len();
+            comments.extend(page_comments);
+            if page_len < REST_PER_PAGE {
+                break;
+            }
+            page += 1;
+        }
+        Ok(comments)
     }
 
     async fn rest_get(&self, path: &str) -> Result<serde_json::Value> {
-        let url = format!("https://api.github.com{path}");
+        let url = format!("{}{path}", self.rest_base_url);
         let response = self
             .http
             .get(&url)
@@ -687,6 +736,179 @@ fn parse_issue_comments_response(value: serde_json::Value) -> Result<Vec<IssueCo
             created_at: entry.created_at,
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GitHubClient;
+    use super::REST_PER_PAGE;
+    use mockito::Matcher;
+    use serde_json::json;
+    use std::sync::Once;
+
+    fn install_rustls_provider() {
+        static INSTALL: Once = Once::new();
+        INSTALL.call_once(|| {
+            rustls::crypto::aws_lc_rs::default_provider()
+                .install_default()
+                .expect("rustls provider should install once");
+        });
+    }
+
+    fn client(base_url: String) -> GitHubClient {
+        install_rustls_provider();
+        GitHubClient::new("owner".to_string(), "repo".to_string(), None)
+            .expect("client should build")
+            .with_rest_base_url(base_url)
+    }
+
+    fn check_suites_response(count: usize) -> serde_json::Value {
+        json!({
+            "check_suites": (0..count)
+                .map(|index| json!({
+                    "id": index + 1,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": { "slug": "coderabbitai" },
+                    "updated_at": "2026-01-01T00:00:00Z"
+                }))
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn reviews_response(count: usize) -> serde_json::Value {
+        json!(
+            (0..count)
+                .map(|index| json!({
+                    "id": index + 1,
+                    "state": "COMMENTED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                    "user": {
+                        "login": format!("coderabbit-{index}"),
+                        "type": "Bot"
+                    }
+                }))
+                .collect::<Vec<_>>()
+        )
+    }
+
+    fn issue_comments_response(count: usize) -> serde_json::Value {
+        json!(
+            (0..count)
+                .map(|index| json!({
+                    "id": index + 1,
+                    "body": format!("comment {index}"),
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "user": {
+                        "login": format!("coderabbit-{index}"),
+                        "type": "Bot"
+                    }
+                }))
+                .collect::<Vec<_>>()
+        )
+    }
+
+    #[tokio::test]
+    async fn list_check_suites_for_ref_aggregates_multiple_pages() {
+        let mut server = mockito::Server::new_async().await;
+        let page1 = server
+            .mock("GET", "/repos/owner/repo/commits/abc/check-suites")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(check_suites_response(REST_PER_PAGE).to_string())
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/repos/owner/repo/commits/abc/check-suites")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "2".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(check_suites_response(1).to_string())
+            .create_async()
+            .await;
+
+        let suites = client(server.url())
+            .list_check_suites_for_ref("abc")
+            .await
+            .expect("pagination should succeed");
+
+        assert_eq!(suites.len(), REST_PER_PAGE + 1);
+        page1.assert_async().await;
+        page2.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_pull_request_reviews_aggregates_multiple_pages() {
+        let mut server = mockito::Server::new_async().await;
+        let page1 = server
+            .mock("GET", "/repos/owner/repo/pulls/7/reviews")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(reviews_response(REST_PER_PAGE).to_string())
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/repos/owner/repo/pulls/7/reviews")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "2".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(reviews_response(1).to_string())
+            .create_async()
+            .await;
+
+        let reviews = client(server.url())
+            .list_pull_request_reviews(7)
+            .await
+            .expect("pagination should succeed");
+
+        assert_eq!(reviews.len(), REST_PER_PAGE + 1);
+        page1.assert_async().await;
+        page2.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_issue_comments_aggregates_multiple_pages() {
+        let mut server = mockito::Server::new_async().await;
+        let page1 = server
+            .mock("GET", "/repos/owner/repo/issues/9/comments")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(issue_comments_response(REST_PER_PAGE).to_string())
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/repos/owner/repo/issues/9/comments")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "2".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(issue_comments_response(1).to_string())
+            .create_async()
+            .await;
+
+        let comments = client(server.url())
+            .list_issue_comments(9)
+            .await
+            .expect("pagination should succeed");
+
+        assert_eq!(comments.len(), REST_PER_PAGE + 1);
+        page1.assert_async().await;
+        page2.assert_async().await;
+    }
 }
 
 // Test helper module - public for integration tests

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -1,7 +1,6 @@
 use crate::OpenPrRefLookupResult;
 use crate::models::CheckSuiteSummary;
 use crate::models::CommentSourceType;
-use crate::models::GraphQLResponse;
 use crate::models::IssueCommentSummary;
 use crate::models::OpenPrRefData;
 use crate::models::PrRef;
@@ -115,7 +114,7 @@ impl GitHubClient {
             "repo": self.repo,
             "branch": branch,
         });
-        let response: GraphQLResponse<OpenPrRefData> = self
+        let response: OpenPrRefData = self
             .client
             .graphql(&serde_json::json!({
                 "query": query,
@@ -124,43 +123,23 @@ impl GitHubClient {
             .await
             .map_err(|e| anyhow::anyhow!("GraphQL query failed: {e}"))?;
 
-        parse_open_pr_ref_lookup_response(response)
+        Ok(parse_open_pr_ref_lookup_response(response))
     }
 }
 
-fn parse_open_pr_ref_lookup_response(
-    response: GraphQLResponse<OpenPrRefData>,
-) -> Result<OpenPrRefLookupResult> {
-    if let Some(errors) = response.errors
-        && !errors.is_empty()
-    {
-        let messages = errors
-            .iter()
-            .map(|error| error.message.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
-        anyhow::bail!("GraphQL errors: {messages}");
-    }
-
-    let Some(data) = response.data else {
-        return Ok(OpenPrRefLookupResult {
-            pr: None,
-            empty_result_reason: Some("graphql_response_missing_data".to_string()),
-        });
-    };
-
-    let nodes = data.repository.pull_requests.nodes;
+fn parse_open_pr_ref_lookup_response(response: OpenPrRefData) -> OpenPrRefLookupResult {
+    let nodes = response.repository.pull_requests.nodes;
     let pr = nodes.into_iter().next().map(|node| PrRef {
         number: node.number,
         url: node.url,
         head_sha: node.head_ref_oid,
     });
 
-    Ok(OpenPrRefLookupResult {
+    OpenPrRefLookupResult {
         empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string())
             .filter(|_| pr.is_none()),
         pr,
-    })
+    }
 }
 
 impl GitHubClient {
@@ -522,7 +501,7 @@ impl GitHubClient {
                 "cursor": cursor,
             });
 
-            let response: GraphQLResponse<PullRequestData> = self
+            let response: PullRequestData = self
                 .client
                 .graphql(&serde_json::json!({
                     "query": query,
@@ -531,21 +510,7 @@ impl GitHubClient {
                 .await
                 .map_err(|e| anyhow::anyhow!("GraphQL query failed: {e}"))?;
 
-            if let Some(errors) = response.errors
-                && !errors.is_empty()
-            {
-                let messages = errors
-                    .iter()
-                    .map(|e| e.message.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                return Err(anyhow::anyhow!("GraphQL errors: {messages}"));
-            }
-
-            let data = response
-                .data
-                .ok_or_else(|| anyhow::anyhow!("No data in GraphQL response"))?;
-            let threads = &data.repository.pull_request.review_threads;
+            let threads = &response.repository.pull_request.review_threads;
 
             // Build map of comment ID -> resolution status
             for thread in &threads.nodes {
@@ -770,7 +735,6 @@ mod tests {
     use super::GitHubClient;
     use super::REST_PER_PAGE;
     use super::parse_open_pr_ref_lookup_response;
-    use crate::models::GraphQLResponse;
     use crate::models::OpenPrRefData;
     use mockito::Matcher;
     use serde_json::json;
@@ -941,43 +905,53 @@ mod tests {
     }
 
     #[test]
-    fn parse_open_pr_ref_lookup_response_reports_missing_data() {
-        let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(json!({
-            "data": null,
-            "errors": null
-        }))
-        .expect("response should deserialize");
-
-        let lookup = parse_open_pr_ref_lookup_response(response).expect("parse should succeed");
-
-        assert!(lookup.pr.is_none());
-        assert_eq!(
-            lookup.empty_result_reason.as_deref(),
-            Some("graphql_response_missing_data")
-        );
-    }
-
-    #[test]
     fn parse_open_pr_ref_lookup_response_reports_empty_nodes() {
-        let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(json!({
-            "data": {
-                "repository": {
-                    "pullRequests": {
-                        "nodes": []
-                    }
+        let response: OpenPrRefData = serde_json::from_value(json!({
+            "repository": {
+                "pullRequests": {
+                    "nodes": []
                 }
-            },
-            "errors": null
+            }
         }))
         .expect("response should deserialize");
 
-        let lookup = parse_open_pr_ref_lookup_response(response).expect("parse should succeed");
+        let lookup = parse_open_pr_ref_lookup_response(response);
 
         assert!(lookup.pr.is_none());
         assert_eq!(
             lookup.empty_result_reason.as_deref(),
             Some("no_open_pull_requests_matched_branch")
         );
+    }
+
+    #[test]
+    fn parse_open_pr_ref_lookup_response_reads_inner_graphql_data_shape() {
+        let response: OpenPrRefData = serde_json::from_value(json!({
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 258,
+                            "url": "https://github.com/allisoneer/agentic_auxilary/pull/258",
+                            "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                        }
+                    ]
+                }
+            }
+        }))
+        .expect("response should deserialize");
+
+        let lookup = parse_open_pr_ref_lookup_response(response);
+
+        assert_eq!(
+            lookup.pr,
+            Some(crate::models::PrRef {
+                number: 258,
+                url: "https://github.com/allisoneer/agentic_auxilary/pull/258".to_string(),
+                head_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            })
+        );
+        assert_eq!(lookup.empty_result_reason, None);
     }
 }
 

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -1,7 +1,9 @@
 use crate::OpenPrRefLookupResult;
 use crate::models::CheckSuiteSummary;
 use crate::models::CommentSourceType;
+use crate::models::GraphqlResponse;
 use crate::models::IssueCommentSummary;
+use crate::models::MarkPullRequestReadyForReviewData;
 use crate::models::OpenPrRefData;
 use crate::models::PrRef;
 use crate::models::PrSummary;
@@ -27,7 +29,7 @@ pub struct GitHubClient {
     http: reqwest::Client,
     owner: String,
     repo: String,
-    rest_base_url: String,
+    api_base_url: String,
 }
 
 impl GitHubClient {
@@ -71,13 +73,13 @@ impl GitHubClient {
             http,
             owner,
             repo,
-            rest_base_url: "https://api.github.com".to_string(),
+            api_base_url: "https://api.github.com".to_string(),
         })
     }
 
     #[cfg(test)]
-    fn with_rest_base_url(mut self, rest_base_url: String) -> Self {
-        self.rest_base_url = rest_base_url;
+    fn with_api_base_url(mut self, api_base_url: String) -> Self {
+        self.api_base_url = api_base_url;
         self
     }
 
@@ -101,9 +103,11 @@ impl GitHubClient {
                 repository(owner: $owner, name: $repo) {
                     pullRequests(states: OPEN, headRefName: $branch, first: 1) {
                         nodes {
+                            id
                             number
                             url
                             headRefOid
+                            isDraft
                         }
                     }
                 }
@@ -114,31 +118,55 @@ impl GitHubClient {
             "repo": self.repo,
             "branch": branch,
         });
-        let response: OpenPrRefData = self
-            .client
-            .graphql(&serde_json::json!({
-                "query": query,
-                "variables": variables,
-            }))
-            .await
-            .map_err(|e| anyhow::anyhow!("GraphQL query failed: {e}"))?;
+        let response: OpenPrRefData = self.graphql_post(query, variables).await?;
 
         Ok(parse_open_pr_ref_lookup_response(response))
+    }
+
+    pub async fn mark_pr_ready_for_review(&self, pull_request_id: &str) -> Result<PrRef> {
+        let query = r"
+            mutation($pullRequestId: ID!) {
+                markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest {
+                        id
+                        number
+                        url
+                        headRefOid
+                        isDraft
+                    }
+                }
+            }
+        ";
+        let variables = serde_json::json!({
+            "pullRequestId": pull_request_id,
+        });
+        let response: MarkPullRequestReadyForReviewData =
+            self.graphql_post(query, variables).await?;
+
+        Ok(pr_ref_from_open_pr_node(
+            response.mark_pull_request_ready_for_review.pull_request,
+        ))
     }
 }
 
 fn parse_open_pr_ref_lookup_response(response: OpenPrRefData) -> OpenPrRefLookupResult {
     let nodes = response.repository.pull_requests.nodes;
-    let pr = nodes.into_iter().next().map(|node| PrRef {
-        number: node.number,
-        url: node.url,
-        head_sha: node.head_ref_oid,
-    });
+    let pr = nodes.into_iter().next().map(pr_ref_from_open_pr_node);
 
     OpenPrRefLookupResult {
         empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string())
             .filter(|_| pr.is_none()),
         pr,
+    }
+}
+
+fn pr_ref_from_open_pr_node(node: crate::models::OpenPrRefNode) -> PrRef {
+    PrRef {
+        number: node.number,
+        url: node.url,
+        head_sha: node.head_ref_oid,
+        node_id: node.id,
+        is_draft: node.is_draft,
     }
 }
 
@@ -213,7 +241,7 @@ impl GitHubClient {
     }
 
     async fn rest_get(&self, path: &str) -> Result<serde_json::Value> {
-        let url = format!("{}{path}", self.rest_base_url);
+        let url = format!("{}{path}", self.api_base_url);
         let response = self
             .http
             .get(&url)
@@ -226,6 +254,31 @@ impl GitHubClient {
             .json()
             .await
             .map_err(|e| anyhow::anyhow!("GitHub REST JSON parse failed: {e}"))
+    }
+
+    async fn graphql_post<T>(&self, query: &str, variables: serde_json::Value) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}/graphql", self.api_base_url);
+        let response = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "query": query,
+                "variables": variables,
+            }))
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("GitHub GraphQL request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow::anyhow!("GitHub GraphQL request failed: {e}"))?;
+
+        let body: GraphqlResponse<T> = response
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("GitHub GraphQL JSON parse failed: {e}"))?;
+        Ok(body.data)
     }
 
     pub fn parse_check_suites_fixture(value: serde_json::Value) -> Result<Vec<CheckSuiteSummary>> {
@@ -753,7 +806,7 @@ mod tests {
         install_rustls_provider();
         GitHubClient::new("owner".to_string(), "repo".to_string(), None)
             .expect("client should build")
-            .with_rest_base_url(base_url)
+            .with_api_base_url(base_url)
     }
 
     fn check_suites_response(count: usize) -> serde_json::Value {
@@ -931,9 +984,11 @@ mod tests {
                 "pullRequests": {
                     "nodes": [
                         {
+                            "id": "PR_kwDOAA",
                             "number": 258,
                             "url": "https://github.com/allisoneer/agentic_auxilary/pull/258",
-                            "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                            "headRefOid": "0123456789abcdef0123456789abcdef01234567",
+                            "isDraft": true
                         }
                     ]
                 }
@@ -949,9 +1004,99 @@ mod tests {
                 number: 258,
                 url: "https://github.com/allisoneer/agentic_auxilary/pull/258".to_string(),
                 head_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                node_id: "PR_kwDOAA".to_string(),
+                is_draft: true,
             })
         );
         assert_eq!(lookup.empty_result_reason, None);
+    }
+
+    #[tokio::test]
+    async fn get_open_pr_ref_from_branch_detailed_posts_graphql_request_with_draft_fields() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/graphql")
+            .match_body(Matcher::PartialJson(json!({
+                "variables": {
+                    "owner": "owner",
+                    "repo": "repo",
+                    "branch": "feature/eng-992"
+                }
+            })))
+            .match_body(Matcher::Regex("id".to_string()))
+            .match_body(Matcher::Regex("isDraft".to_string()))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "data": {
+                        "repository": {
+                            "pullRequests": {
+                                "nodes": [
+                                    {
+                                        "id": "PR_123",
+                                        "number": 42,
+                                        "url": "https://example.invalid/pr/42",
+                                        "headRefOid": "abc123",
+                                        "isDraft": false
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let lookup = client(server.url())
+            .get_open_pr_ref_from_branch_detailed("feature/eng-992")
+            .await
+            .expect("graphql request should succeed");
+
+        assert_eq!(lookup.pr.as_ref().map(|pr| pr.number), Some(42));
+        assert_eq!(lookup.pr.as_ref().map(|pr| pr.is_draft), Some(false));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn mark_pr_ready_for_review_posts_graphql_mutation() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/graphql")
+            .match_body(Matcher::PartialJson(json!({
+                "variables": {
+                    "pullRequestId": "PR_123"
+                }
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "data": {
+                        "markPullRequestReadyForReview": {
+                            "pullRequest": {
+                                "id": "PR_123",
+                                "number": 42,
+                                "url": "https://example.invalid/pr/42",
+                                "headRefOid": "abc123",
+                                "isDraft": false
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let pr = client(server.url())
+            .mark_pr_ready_for_review("PR_123")
+            .await
+            .expect("mutation should succeed");
+
+        assert_eq!(pr.number, 42);
+        assert!(!pr.is_draft);
+        mock.assert_async().await;
     }
 }
 

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -1,7 +1,7 @@
 use crate::OpenPrRefLookupResult;
 use crate::models::CheckSuiteSummary;
 use crate::models::CommentSourceType;
-use crate::models::GraphqlResponse;
+use crate::models::GraphQLResponse;
 use crate::models::IssueCommentSummary;
 use crate::models::MarkPullRequestReadyForReviewData;
 use crate::models::OpenPrRefData;
@@ -274,11 +274,22 @@ impl GitHubClient {
             .error_for_status()
             .map_err(|e| anyhow::anyhow!("GitHub GraphQL request failed: {e}"))?;
 
-        let body: GraphqlResponse<T> = response
+        let body: GraphQLResponse<T> = response
             .json()
             .await
             .map_err(|e| anyhow::anyhow!("GitHub GraphQL JSON parse failed: {e}"))?;
-        Ok(body.data)
+
+        if let Some(errors) = body.errors.as_ref().filter(|errors| !errors.is_empty()) {
+            let messages = errors
+                .iter()
+                .map(|error| error.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::bail!("GitHub GraphQL response contained errors: {messages}");
+        }
+
+        body.data
+            .ok_or_else(|| anyhow::anyhow!("GitHub GraphQL response missing data"))
     }
 
     pub fn parse_check_suites_fixture(value: serde_json::Value) -> Result<Vec<CheckSuiteSummary>> {
@@ -719,6 +730,8 @@ struct ReviewEntry {
     id: u64,
     state: String,
     submitted_at: Option<String>,
+    #[serde(default)]
+    commit_id: Option<String>,
     user: ReviewUser,
 }
 
@@ -764,6 +777,7 @@ fn parse_reviews_response(value: serde_json::Value) -> Result<Vec<PullRequestRev
             user_type: entry.user.user_type,
             state: entry.state,
             submitted_at: entry.submitted_at,
+            commit_id: entry.commit_id,
         })
         .collect())
 }
@@ -830,6 +844,7 @@ mod tests {
                     "id": index + 1,
                     "state": "COMMENTED",
                     "submitted_at": "2026-01-01T00:00:00Z",
+                    "commit_id": format!("sha-{index}"),
                     "user": {
                         "login": format!("coderabbit-{index}"),
                         "type": "Bot"
@@ -919,6 +934,7 @@ mod tests {
             .expect("pagination should succeed");
 
         assert_eq!(reviews.len(), REST_PER_PAGE + 1);
+        assert_eq!(reviews[0].commit_id.as_deref(), Some("sha-0"));
         page1.assert_async().await;
         page2.assert_async().await;
     }
@@ -1056,6 +1072,65 @@ mod tests {
 
         assert_eq!(lookup.pr.as_ref().map(|pr| pr.number), Some(42));
         assert_eq!(lookup.pr.as_ref().map(|pr| pr.is_draft), Some(false));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn graphql_post_fails_when_http_200_contains_errors() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "data": {
+                        "repository": {
+                            "pullRequests": {
+                                "nodes": []
+                            }
+                        }
+                    },
+                    "errors": [
+                        { "message": "boom" },
+                        { "message": "bad news" }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = client(server.url())
+            .get_open_pr_ref_from_branch_detailed("feature/eng-992")
+            .await
+            .expect_err("graphql errors should fail the request");
+
+        assert!(
+            err.to_string()
+                .contains("GitHub GraphQL response contained errors: boom; bad news")
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn graphql_post_fails_when_http_200_omits_data() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_body(json!({ "data": null }).to_string())
+            .create_async()
+            .await;
+
+        let err = client(server.url())
+            .get_open_pr_ref_from_branch_detailed("feature/eng-992")
+            .await
+            .expect_err("missing data should fail the request");
+
+        assert!(
+            err.to_string()
+                .contains("GitHub GraphQL response missing data")
+        );
         mock.assert_async().await;
     }
 

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -1,3 +1,4 @@
+use crate::OpenPrRefLookupResult;
 use crate::models::CheckSuiteSummary;
 use crate::models::CommentSourceType;
 use crate::models::GraphQLResponse;
@@ -89,6 +90,13 @@ impl GitHubClient {
     }
 
     pub async fn get_open_pr_ref_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+        Ok(self.get_open_pr_ref_from_branch_detailed(branch).await?.pr)
+    }
+
+    pub async fn get_open_pr_ref_from_branch_detailed(
+        &self,
+        branch: &str,
+    ) -> Result<OpenPrRefLookupResult> {
         let query = r"
             query($owner: String!, $repo: String!, $branch: String!) {
                 repository(owner: $owner, name: $repo) {
@@ -116,27 +124,46 @@ impl GitHubClient {
             .await
             .map_err(|e| anyhow::anyhow!("GraphQL query failed: {e}"))?;
 
-        if let Some(errors) = response.errors
-            && !errors.is_empty()
-        {
-            let messages = errors
-                .iter()
-                .map(|error| error.message.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            anyhow::bail!("GraphQL errors: {messages}");
-        }
+        parse_open_pr_ref_lookup_response(response)
+    }
+}
 
-        Ok(response
-            .data
-            .and_then(|data| data.repository.pull_requests.nodes.into_iter().next())
-            .map(|node| PrRef {
-                number: node.number,
-                url: node.url,
-                head_sha: node.head_ref_oid,
-            }))
+fn parse_open_pr_ref_lookup_response(
+    response: GraphQLResponse<OpenPrRefData>,
+) -> Result<OpenPrRefLookupResult> {
+    if let Some(errors) = response.errors
+        && !errors.is_empty()
+    {
+        let messages = errors
+            .iter()
+            .map(|error| error.message.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!("GraphQL errors: {messages}");
     }
 
+    let Some(data) = response.data else {
+        return Ok(OpenPrRefLookupResult {
+            pr: None,
+            empty_result_reason: Some("graphql_response_missing_data".to_string()),
+        });
+    };
+
+    let nodes = data.repository.pull_requests.nodes;
+    let pr = nodes.into_iter().next().map(|node| PrRef {
+        number: node.number,
+        url: node.url,
+        head_sha: node.head_ref_oid,
+    });
+
+    Ok(OpenPrRefLookupResult {
+        empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string())
+            .filter(|_| pr.is_none()),
+        pr,
+    })
+}
+
+impl GitHubClient {
     pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
         let base_path = format!(
             "/repos/{}/{}/commits/{sha}/check-suites",
@@ -742,6 +769,9 @@ fn parse_issue_comments_response(value: serde_json::Value) -> Result<Vec<IssueCo
 mod tests {
     use super::GitHubClient;
     use super::REST_PER_PAGE;
+    use super::parse_open_pr_ref_lookup_response;
+    use crate::models::GraphQLResponse;
+    use crate::models::OpenPrRefData;
     use mockito::Matcher;
     use serde_json::json;
     use std::sync::Once;
@@ -908,6 +938,46 @@ mod tests {
         assert_eq!(comments.len(), REST_PER_PAGE + 1);
         page1.assert_async().await;
         page2.assert_async().await;
+    }
+
+    #[test]
+    fn parse_open_pr_ref_lookup_response_reports_missing_data() {
+        let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(json!({
+            "data": null,
+            "errors": null
+        }))
+        .expect("response should deserialize");
+
+        let lookup = parse_open_pr_ref_lookup_response(response).expect("parse should succeed");
+
+        assert!(lookup.pr.is_none());
+        assert_eq!(
+            lookup.empty_result_reason.as_deref(),
+            Some("graphql_response_missing_data")
+        );
+    }
+
+    #[test]
+    fn parse_open_pr_ref_lookup_response_reports_empty_nodes() {
+        let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(json!({
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": []
+                    }
+                }
+            },
+            "errors": null
+        }))
+        .expect("response should deserialize");
+
+        let lookup = parse_open_pr_ref_lookup_response(response).expect("parse should succeed");
+
+        assert!(lookup.pr.is_none());
+        assert_eq!(
+            lookup.empty_result_reason.as_deref(),
+            Some("no_open_pull_requests_matched_branch")
+        );
     }
 }
 

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -176,21 +176,8 @@ impl GitHubClient {
             "/repos/{}/{}/commits/{sha}/check-suites",
             self.owner, self.repo
         );
-        let mut suites = Vec::new();
-        let mut page = 1u32;
-        loop {
-            let value = self
-                .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
-                .await?;
-            let page_suites = parse_check_suites_response(value)?;
-            let page_len = page_suites.len();
-            suites.extend(page_suites);
-            if page_len < REST_PER_PAGE {
-                break;
-            }
-            page += 1;
-        }
-        Ok(suites)
+        self.rest_get_paginated(&base_path, parse_check_suites_response)
+            .await
     }
 
     pub async fn list_pull_request_reviews(
@@ -201,21 +188,8 @@ impl GitHubClient {
             "/repos/{}/{}/pulls/{pr_number}/reviews",
             self.owner, self.repo
         );
-        let mut reviews = Vec::new();
-        let mut page = 1u32;
-        loop {
-            let value = self
-                .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
-                .await?;
-            let page_reviews = parse_reviews_response(value)?;
-            let page_len = page_reviews.len();
-            reviews.extend(page_reviews);
-            if page_len < REST_PER_PAGE {
-                break;
-            }
-            page += 1;
-        }
-        Ok(reviews)
+        self.rest_get_paginated(&base_path, parse_reviews_response)
+            .await
     }
 
     pub async fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueCommentSummary>> {
@@ -223,21 +197,29 @@ impl GitHubClient {
             "/repos/{}/{}/issues/{issue_number}/comments",
             self.owner, self.repo
         );
-        let mut comments = Vec::new();
+        self.rest_get_paginated(&base_path, parse_issue_comments_response)
+            .await
+    }
+
+    async fn rest_get_paginated<T, F>(&self, base_path: &str, parse_page: F) -> Result<Vec<T>>
+    where
+        F: Fn(serde_json::Value) -> Result<Vec<T>>,
+    {
+        let mut items = Vec::new();
         let mut page = 1u32;
         loop {
             let value = self
                 .rest_get(&format!("{base_path}?page={page}&per_page={REST_PER_PAGE}"))
                 .await?;
-            let page_comments = parse_issue_comments_response(value)?;
-            let page_len = page_comments.len();
-            comments.extend(page_comments);
+            let page_items = parse_page(value)?;
+            let page_len = page_items.len();
+            items.extend(page_items);
             if page_len < REST_PER_PAGE {
                 break;
             }
             page += 1;
         }
-        Ok(comments)
+        Ok(items)
     }
 
     async fn rest_get(&self, path: &str) -> Result<serde_json::Value> {
@@ -971,6 +953,58 @@ mod tests {
         assert_eq!(comments.len(), REST_PER_PAGE + 1);
         page1.assert_async().await;
         page2.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rest_get_reports_http_status_failures() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/repos/owner/repo/commits/missing/check-suites")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(500)
+            .with_body("server error")
+            .create_async()
+            .await;
+
+        let err = client(server.url())
+            .list_check_suites_for_ref("missing")
+            .await
+            .expect_err("http status failure should bubble up");
+
+        assert!(
+            err.to_string().contains("GitHub REST request failed:"),
+            "unexpected error: {err}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rest_get_reports_json_parse_failures() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/repos/owner/repo/issues/9/comments")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(200)
+            .with_body("{not-json")
+            .create_async()
+            .await;
+
+        let err = client(server.url())
+            .list_issue_comments(9)
+            .await
+            .expect_err("malformed json should bubble up");
+
+        assert!(
+            err.to_string().contains("GitHub REST JSON parse failed:"),
+            "unexpected error: {err}"
+        );
+        mock.assert_async().await;
     }
 
     #[test]

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -1,23 +1,35 @@
+use crate::models::CheckSuiteSummary;
 use crate::models::CommentSourceType;
 use crate::models::GraphQLResponse;
+use crate::models::IssueCommentSummary;
+use crate::models::OpenPrRefData;
+use crate::models::PrRef;
 use crate::models::PrSummary;
 use crate::models::PullRequestData;
+use crate::models::PullRequestReviewSummary;
 use crate::models::ReviewComment;
 use crate::models::Thread;
 use anyhow::Result;
 use octocrab::Octocrab;
+use reqwest::header::ACCEPT;
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderValue;
+use reqwest::header::USER_AGENT;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
 
 pub struct GitHubClient {
     client: Octocrab,
+    http: reqwest::Client,
     owner: String,
     repo: String,
 }
 
 impl GitHubClient {
     pub fn new(owner: String, repo: String, token: Option<String>) -> Result<Self> {
+        let header_token = token.clone();
         let builder = Octocrab::builder()
             .set_connect_timeout(Some(Duration::from_secs(10)))
             .set_read_timeout(Some(Duration::from_secs(30)))
@@ -33,38 +45,152 @@ impl GitHubClient {
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to create GitHub client: {e:?}"))?;
 
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("pr_comments"));
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        if let Some(token) = header_token.as_deref() {
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| anyhow::anyhow!("Invalid GitHub token header: {e}"))?;
+            headers.insert(AUTHORIZATION, value);
+        }
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to create GitHub REST client: {e}"))?;
+
         Ok(Self {
             client,
+            http,
             owner,
             repo,
         })
     }
 
     pub async fn get_pr_from_branch(&self, branch: &str) -> Result<Option<u64>> {
-        // Search for open PRs with this head branch
-        let pulls = self
-            .client
-            .pulls(&self.owner, &self.repo)
-            .list()
-            .state(octocrab::params::State::Open)
-            .send()
-            .await
-            .map_err(|e| {
-                let owner = self.owner.as_str();
-                let repo = self.repo.as_str();
-                anyhow::anyhow!("Failed to list open pull requests for {owner}/{repo}: {e:?}")
-            })?;
+        Ok(self
+            .get_open_pr_ref_from_branch(branch)
+            .await?
+            .map(|pr| pr.number))
+    }
 
-        for pr in pulls {
-            if pr.head.ref_field == branch {
-                return Ok(Some(pr.number));
+    pub async fn get_open_pr_ref_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+        let query = r"
+            query($owner: String!, $repo: String!, $branch: String!) {
+                repository(owner: $owner, name: $repo) {
+                    pullRequests(states: OPEN, headRefName: $branch, first: 1) {
+                        nodes {
+                            number
+                            url
+                            headRefOid
+                        }
+                    }
+                }
             }
+        ";
+        let variables = serde_json::json!({
+            "owner": self.owner,
+            "repo": self.repo,
+            "branch": branch,
+        });
+        let response: GraphQLResponse<OpenPrRefData> = self
+            .client
+            .graphql(&serde_json::json!({
+                "query": query,
+                "variables": variables,
+            }))
+            .await
+            .map_err(|e| anyhow::anyhow!("GraphQL query failed: {e}"))?;
+
+        if let Some(errors) = response.errors
+            && !errors.is_empty()
+        {
+            let messages = errors
+                .iter()
+                .map(|error| error.message.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!("GraphQL errors: {messages}");
         }
 
-        Ok(None)
+        Ok(response
+            .data
+            .and_then(|data| data.repository.pull_requests.nodes.into_iter().next())
+            .map(|node| PrRef {
+                number: node.number,
+                url: node.url,
+                head_sha: node.head_ref_oid,
+            }))
+    }
+
+    pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
+        let path = format!(
+            "/repos/{}/{}/commits/{sha}/check-suites",
+            self.owner, self.repo
+        );
+        let value = self.rest_get(&path).await?;
+        parse_check_suites_response(value)
+    }
+
+    pub async fn list_pull_request_reviews(
+        &self,
+        pr_number: u64,
+    ) -> Result<Vec<PullRequestReviewSummary>> {
+        let path = format!(
+            "/repos/{}/{}/pulls/{pr_number}/reviews",
+            self.owner, self.repo
+        );
+        let value = self.rest_get(&path).await?;
+        parse_reviews_response(value)
+    }
+
+    pub async fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueCommentSummary>> {
+        let path = format!(
+            "/repos/{}/{}/issues/{issue_number}/comments",
+            self.owner, self.repo
+        );
+        let value = self.rest_get(&path).await?;
+        parse_issue_comments_response(value)
+    }
+
+    async fn rest_get(&self, path: &str) -> Result<serde_json::Value> {
+        let url = format!("https://api.github.com{path}");
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("GitHub REST request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow::anyhow!("GitHub REST request failed: {e}"))?;
+        response
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("GitHub REST JSON parse failed: {e}"))
+    }
+
+    pub fn parse_check_suites_fixture(value: serde_json::Value) -> Result<Vec<CheckSuiteSummary>> {
+        parse_check_suites_response(value)
+    }
+
+    pub fn parse_reviews_fixture(
+        value: serde_json::Value,
+    ) -> Result<Vec<PullRequestReviewSummary>> {
+        parse_reviews_response(value)
+    }
+
+    pub fn parse_issue_comments_fixture(
+        value: serde_json::Value,
+    ) -> Result<Vec<IssueCommentSummary>> {
+        parse_issue_comments_response(value)
     }
 
     pub async fn get_review_comments(
+        // Search for open PRs with this head branch
         &self,
         pr_number: u64,
         include_resolved: Option<bool>,
@@ -473,6 +599,94 @@ impl GitHubClient {
 
         Ok(ReviewComment::from_review_comment(comment))
     }
+}
+
+#[derive(serde::Deserialize)]
+struct CheckSuitesEnvelope {
+    check_suites: Vec<CheckSuiteEntry>,
+}
+
+#[derive(serde::Deserialize)]
+struct CheckSuiteEntry {
+    id: u64,
+    status: String,
+    conclusion: Option<String>,
+    app: Option<CheckSuiteApp>,
+    updated_at: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CheckSuiteApp {
+    slug: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct ReviewEntry {
+    id: u64,
+    state: String,
+    submitted_at: Option<String>,
+    user: ReviewUser,
+}
+
+#[derive(serde::Deserialize)]
+struct ReviewUser {
+    login: String,
+    #[serde(rename = "type")]
+    user_type: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct IssueCommentEntry {
+    id: u64,
+    body: String,
+    created_at: String,
+    user: ReviewUser,
+}
+
+fn parse_check_suites_response(value: serde_json::Value) -> Result<Vec<CheckSuiteSummary>> {
+    let envelope: CheckSuitesEnvelope = serde_json::from_value(value)
+        .map_err(|e| anyhow::anyhow!("Failed to parse check suites response: {e}"))?;
+    Ok(envelope
+        .check_suites
+        .into_iter()
+        .map(|suite| CheckSuiteSummary {
+            id: suite.id,
+            status: suite.status,
+            conclusion: suite.conclusion,
+            app_slug: suite.app.and_then(|app| app.slug),
+            updated_at: suite.updated_at,
+        })
+        .collect())
+}
+
+fn parse_reviews_response(value: serde_json::Value) -> Result<Vec<PullRequestReviewSummary>> {
+    let entries: Vec<ReviewEntry> = serde_json::from_value(value)
+        .map_err(|e| anyhow::anyhow!("Failed to parse reviews response: {e}"))?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| PullRequestReviewSummary {
+            id: entry.id,
+            user_login: entry.user.login,
+            user_type: entry.user.user_type,
+            state: entry.state,
+            submitted_at: entry.submitted_at,
+        })
+        .collect())
+}
+
+fn parse_issue_comments_response(value: serde_json::Value) -> Result<Vec<IssueCommentSummary>> {
+    let entries: Vec<IssueCommentEntry> = serde_json::from_value(value)
+        .map_err(|e| anyhow::anyhow!("Failed to parse issue comments response: {e}"))?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| IssueCommentSummary {
+            id: entry.id,
+            user_login: entry.user.login,
+            user_type: entry.user.user_type,
+            body: entry.body,
+            created_at: entry.created_at,
+        })
+        .collect())
 }
 
 // Test helper module - public for integration tests

--- a/crates/tools/pr-comments/src/lib.rs
+++ b/crates/tools/pr-comments/src/lib.rs
@@ -26,6 +26,9 @@ use pagination::paginate_slice;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(test)]
+use std::ffi::OsString;
+
 // Re-export agentic-tools types for MCP server usage
 pub use tools::build_registry;
 
@@ -241,6 +244,11 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
         anyhow::bail!(msg);
     }
 
+    fn github_client(&self) -> Result<github::GitHubClient> {
+        github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+            .context("internal: failed to create GitHub client")
+    }
+
     async fn get_pr_number(&self, pr_number: Option<u64>) -> Result<u64> {
         if let Some(pr) = pr_number {
             return Ok(pr);
@@ -252,8 +260,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
             .current_branch
             .context("Could not determine current git branch")?;
 
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())?;
+        let client = self.github_client()?;
 
         match self
             .with_github_total_timeout(
@@ -303,9 +310,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
 
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
         self.with_github_total_timeout(
             &format!("looking up open pull request ref for branch '{branch}'"),
             async { client.get_open_pr_ref_from_branch_detailed(branch).await },
@@ -321,9 +326,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
 
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
         self.with_github_total_timeout("marking pull request ready for review", async {
             client.mark_pr_ready_for_review(pull_request_id).await
         })
@@ -333,9 +336,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
     pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
         self.with_github_total_timeout(&format!("listing check suites for ref {sha}"), async {
             client.list_check_suites_for_ref(sha).await
         })
@@ -348,9 +349,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
     ) -> Result<Vec<PullRequestReviewSummary>> {
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
         self.with_github_total_timeout(&format!("listing reviews for PR #{pr_number}"), async {
             client.list_pull_request_reviews(pr_number).await
         })
@@ -360,9 +359,7 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
     pub async fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueCommentSummary>> {
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
         self.with_github_total_timeout(
             &format!("listing issue comments for issue #{issue_number}"),
             async { client.list_issue_comments(issue_number).await },
@@ -425,12 +422,7 @@ impl PrComments {
 
         // If we need to fetch, do async work without holding the lock
         if needs_fetch {
-            let client = github::GitHubClient::new(
-                self.owner.clone(),
-                self.repo.clone(),
-                self.token.clone(),
-            )
-            .context("internal: failed to create GitHub client")?;
+            let client = self.github_client()?;
 
             let (comments, resolution_map) = self
                 .with_github_total_timeout(
@@ -544,12 +536,7 @@ impl PrComments {
         };
 
         if needs_fetch {
-            let client = github::GitHubClient::new(
-                self.owner.clone(),
-                self.repo.clone(),
-                self.token.clone(),
-            )
-            .context("internal: failed to create GitHub client")?;
+            let client = self.github_client()?;
 
             let prs = self
                 .with_github_total_timeout(&format!("listing pull requests for state={state}"), async {
@@ -628,9 +615,7 @@ impl PrComments {
             .await
             .context("invalid argument: failed to determine PR number")?;
 
-        let client =
-            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
-                .context("internal: failed to create GitHub client")?;
+        let client = self.github_client()?;
 
         // Apply AI prefix to clearly identify automated responses
         let prefixed_body = with_ai_prefix(&body);
@@ -667,11 +652,62 @@ impl PrComments {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::sync::MutexGuard;
     use std::sync::OnceLock;
 
     static TOKEN_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct TokenEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous_gh: Option<OsString>,
+        previous_github: Option<OsString>,
+    }
+
+    impl TokenEnvGuard {
+        fn acquire() -> Self {
+            let lock = token_env_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Self {
+                _lock: lock,
+                previous_gh: std::env::var_os("GH_TOKEN"),
+                previous_github: std::env::var_os("GITHUB_TOKEN"),
+            }
+        }
+
+        fn set_var(key: &str, value: impl AsRef<OsStr>) {
+            // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+            unsafe { std::env::set_var(key, value) }
+        }
+
+        fn remove_var(key: &str) {
+            // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+            unsafe { std::env::remove_var(key) }
+        }
+    }
+
+    impl Drop for TokenEnvGuard {
+        fn drop(&mut self) {
+            restore_env_var("GH_TOKEN", self.previous_gh.as_ref());
+            restore_env_var("GITHUB_TOKEN", self.previous_github.as_ref());
+        }
+    }
+
+    fn restore_env_var(key: &str, value: Option<&OsString>) {
+        match value {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::set_var(key, value) }
+            }
+            None => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::remove_var(key) }
+            }
+        }
+    }
 
     fn sample_comment(id: u64) -> ReviewComment {
         ReviewComment {
@@ -859,76 +895,22 @@ mod tests {
 
     #[test]
     fn with_repo_records_safe_token_source_label() {
-        let _guard = token_env_lock().lock().expect("env lock should succeed");
-        let previous_gh = std::env::var_os("GH_TOKEN");
-        let previous_github = std::env::var_os("GITHUB_TOKEN");
-
-        // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-        unsafe {
-            std::env::set_var("GH_TOKEN", "test-token");
-            std::env::remove_var("GITHUB_TOKEN");
-        }
+        let _guard = TokenEnvGuard::acquire();
+        TokenEnvGuard::set_var("GH_TOKEN", "test-token");
+        TokenEnvGuard::remove_var("GITHUB_TOKEN");
 
         let comments = PrComments::with_repo("owner".into(), "repo".into());
-
-        match previous_gh {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::set_var("GH_TOKEN", value) }
-            }
-            None => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::remove_var("GH_TOKEN") }
-            }
-        }
-        match previous_github {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::set_var("GITHUB_TOKEN", value) }
-            }
-            None => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::remove_var("GITHUB_TOKEN") }
-            }
-        }
 
         assert_eq!(comments.token_source_label(), Some("GH_TOKEN"));
     }
 
     #[test]
     fn resolve_token_ignores_empty_gh_token_and_falls_back_to_github_token() {
-        let _guard = token_env_lock().lock().expect("env lock should succeed");
-        let previous_gh = std::env::var_os("GH_TOKEN");
-        let previous_github = std::env::var_os("GITHUB_TOKEN");
-
-        // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-        unsafe {
-            std::env::set_var("GH_TOKEN", "   ");
-            std::env::set_var("GITHUB_TOKEN", " fallback-token ");
-        }
+        let _guard = TokenEnvGuard::acquire();
+        TokenEnvGuard::set_var("GH_TOKEN", "   ");
+        TokenEnvGuard::set_var("GITHUB_TOKEN", " fallback-token ");
 
         let (token, source) = PrComments::resolve_token();
-
-        match previous_gh {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::set_var("GH_TOKEN", value) }
-            }
-            None => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::remove_var("GH_TOKEN") }
-            }
-        }
-        match previous_github {
-            Some(value) => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::set_var("GITHUB_TOKEN", value) }
-            }
-            None => {
-                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
-                unsafe { std::env::remove_var("GITHUB_TOKEN") }
-            }
-        }
 
         assert_eq!(token.as_deref(), Some("fallback-token"));
         assert_eq!(source, Some(GitHubTokenSource::GitHubToken));

--- a/crates/tools/pr-comments/src/lib.rs
+++ b/crates/tools/pr-comments/src/lib.rs
@@ -57,41 +57,68 @@ pub struct PrComments {
     owner: String,
     repo: String,
     token: Option<String>,
+    token_source: Option<GitHubTokenSource>,
     github_config: GitHubServiceConfig,
     pager: Arc<PaginationCache<Thread>>,
     pr_list_pager: Arc<PaginationCache<PrSummary>>,
     init_error: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitHubTokenSource {
+    GhToken,
+    GitHubToken,
+    GhConfig,
+}
+
+impl GitHubTokenSource {
+    pub const fn as_diagnostic_label(self) -> &'static str {
+        match self {
+            Self::GhToken => "GH_TOKEN",
+            Self::GitHubToken => "GITHUB_TOKEN",
+            Self::GhConfig => "gh-config",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenPrRefLookupResult {
+    pub pr: Option<PrRef>,
+    pub empty_result_reason: Option<String>,
+}
+
 impl PrComments {
-    fn get_token() -> Option<String> {
-        // 1) Check environment variables first (explicit override)
-        if let Ok(t) = std::env::var("GH_TOKEN").or_else(|_| std::env::var("GITHUB_TOKEN")) {
+    fn resolve_token() -> (Option<String>, Option<GitHubTokenSource>) {
+        if let Ok(t) = std::env::var("GH_TOKEN") {
             tracing::debug!("Using GitHub token from environment");
-            return Some(t);
+            return (Some(t), Some(GitHubTokenSource::GhToken));
         }
 
-        // 2) Try gh-config (hosts.yml → keyring)
+        if let Ok(t) = std::env::var("GITHUB_TOKEN") {
+            tracing::debug!("Using GitHub token from environment");
+            return (Some(t), Some(GitHubTokenSource::GitHubToken));
+        }
+
         let hosts = match gh_config::Hosts::load() {
             Ok(hosts) => hosts,
             Err(e) => {
                 tracing::debug!("gh-config unavailable: {e}");
-                return None;
+                return (None, None);
             }
         };
 
         match hosts.retrieve_token(gh_config::GITHUB_COM) {
             Ok(Some(t)) => {
                 tracing::debug!("Using GitHub token from gh-config");
-                Some(t)
+                (Some(t), Some(GitHubTokenSource::GhConfig))
             }
             Ok(None) => {
                 tracing::debug!("No token found in gh-config");
-                None
+                (None, None)
             }
             Err(e) => {
                 tracing::debug!("gh-config token retrieval failed: {e}");
-                None
+                (None, None)
             }
         }
     }
@@ -116,12 +143,13 @@ impl PrComments {
 
     pub fn with_config(github_config: GitHubServiceConfig) -> Result<Self> {
         let git_info = git::get_git_info().context("Failed to get git information")?;
-        let token = Self::get_token();
+        let (token, token_source) = Self::resolve_token();
 
         Ok(Self {
             owner: git_info.owner,
             repo: git_info.repo,
             token,
+            token_source,
             github_config,
             pager: Arc::new(PaginationCache::new()),
             pr_list_pager: Arc::new(PaginationCache::new()),
@@ -138,11 +166,12 @@ impl PrComments {
         repo: String,
         github_config: GitHubServiceConfig,
     ) -> Self {
-        let token = Self::get_token();
+        let (token, token_source) = Self::resolve_token();
         Self {
             owner,
             repo,
             token,
+            token_source,
             github_config,
             pager: Arc::new(PaginationCache::new()),
             pr_list_pager: Arc::new(PaginationCache::new()),
@@ -157,11 +186,12 @@ impl PrComments {
     }
 
     pub fn disabled_with_config(init_error: String, github_config: GitHubServiceConfig) -> Self {
-        let token = Self::get_token();
+        let (token, token_source) = Self::resolve_token();
         Self {
             owner: String::new(),
             repo: String::new(),
             token,
+            token_source,
             github_config,
             pager: Arc::new(PaginationCache::new()),
             pr_list_pager: Arc::new(PaginationCache::new()),
@@ -255,7 +285,15 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
         }
     }
 
-    pub async fn get_open_pr_ref_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+    pub fn token_source_label(&self) -> Option<&'static str> {
+        self.token_source
+            .map(GitHubTokenSource::as_diagnostic_label)
+    }
+
+    pub async fn get_open_pr_ref_from_branch_detailed(
+        &self,
+        branch: &str,
+    ) -> Result<OpenPrRefLookupResult> {
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;
 
@@ -264,9 +302,13 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
                 .context("internal: failed to create GitHub client")?;
         self.with_github_total_timeout(
             &format!("looking up open pull request ref for branch '{branch}'"),
-            async { client.get_open_pr_ref_from_branch(branch).await },
+            async { client.get_open_pr_ref_from_branch_detailed(branch).await },
         )
         .await
+    }
+
+    pub async fn get_open_pr_ref_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+        Ok(self.get_open_pr_ref_from_branch_detailed(branch).await?.pr)
     }
 
     pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
@@ -607,6 +649,10 @@ impl PrComments {
 mod tests {
     use super::*;
     use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    static TOKEN_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn sample_comment(id: u64) -> ReviewComment {
         ReviewComment {
@@ -792,6 +838,44 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn with_repo_records_safe_token_source_label() {
+        let _guard = token_env_lock().lock().expect("env lock should succeed");
+        let previous_gh = std::env::var_os("GH_TOKEN");
+        let previous_github = std::env::var_os("GITHUB_TOKEN");
+
+        // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+        unsafe {
+            std::env::set_var("GH_TOKEN", "test-token");
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+
+        let comments = PrComments::with_repo("owner".into(), "repo".into());
+
+        match previous_gh {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::set_var("GH_TOKEN", value) }
+            }
+            None => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::remove_var("GH_TOKEN") }
+            }
+        }
+        match previous_github {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::set_var("GITHUB_TOKEN", value) }
+            }
+            None => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::remove_var("GITHUB_TOKEN") }
+            }
+        }
+
+        assert_eq!(comments.token_source_label(), Some("GH_TOKEN"));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn github_total_timeout_expires_when_enabled() {
         let svc = PrComments::with_repo_and_config(
@@ -845,6 +929,10 @@ mod tests {
 
         tokio::time::advance(Duration::from_secs(5)).await;
         assert!(handle.await.unwrap().is_ok());
+    }
+
+    fn token_env_lock() -> &'static Mutex<()> {
+        TOKEN_ENV_LOCK.get_or_init(|| Mutex::new(()))
     }
 
     #[test]

--- a/crates/tools/pr-comments/src/lib.rs
+++ b/crates/tools/pr-comments/src/lib.rs
@@ -311,6 +311,19 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
         Ok(self.get_open_pr_ref_from_branch_detailed(branch).await?.pr)
     }
 
+    pub async fn mark_pr_ready_for_review(&self, pull_request_id: &str) -> Result<PrRef> {
+        self.ensure_repo_configured()
+            .context("invalid argument: missing repository context")?;
+
+        let client =
+            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+                .context("internal: failed to create GitHub client")?;
+        self.with_github_total_timeout("marking pull request ready for review", async {
+            client.mark_pr_ready_for_review(pull_request_id).await
+        })
+        .await
+    }
+
     pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
         self.ensure_repo_configured()
             .context("invalid argument: missing repository context")?;

--- a/crates/tools/pr-comments/src/lib.rs
+++ b/crates/tools/pr-comments/src/lib.rs
@@ -90,13 +90,19 @@ pub struct OpenPrRefLookupResult {
 impl PrComments {
     fn resolve_token() -> (Option<String>, Option<GitHubTokenSource>) {
         if let Ok(t) = std::env::var("GH_TOKEN") {
-            tracing::debug!("Using GitHub token from environment");
-            return (Some(t), Some(GitHubTokenSource::GhToken));
+            let t = t.trim().to_string();
+            if !t.is_empty() {
+                tracing::debug!("Using GitHub token from environment");
+                return (Some(t), Some(GitHubTokenSource::GhToken));
+            }
         }
 
         if let Ok(t) = std::env::var("GITHUB_TOKEN") {
-            tracing::debug!("Using GitHub token from environment");
-            return (Some(t), Some(GitHubTokenSource::GitHubToken));
+            let t = t.trim().to_string();
+            if !t.is_empty() {
+                tracing::debug!("Using GitHub token from environment");
+                return (Some(t), Some(GitHubTokenSource::GitHubToken));
+            }
         }
 
         let hosts = match gh_config::Hosts::load() {
@@ -887,6 +893,45 @@ mod tests {
         }
 
         assert_eq!(comments.token_source_label(), Some("GH_TOKEN"));
+    }
+
+    #[test]
+    fn resolve_token_ignores_empty_gh_token_and_falls_back_to_github_token() {
+        let _guard = token_env_lock().lock().expect("env lock should succeed");
+        let previous_gh = std::env::var_os("GH_TOKEN");
+        let previous_github = std::env::var_os("GITHUB_TOKEN");
+
+        // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+        unsafe {
+            std::env::set_var("GH_TOKEN", "   ");
+            std::env::set_var("GITHUB_TOKEN", " fallback-token ");
+        }
+
+        let (token, source) = PrComments::resolve_token();
+
+        match previous_gh {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::set_var("GH_TOKEN", value) }
+            }
+            None => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::remove_var("GH_TOKEN") }
+            }
+        }
+        match previous_github {
+            Some(value) => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::set_var("GITHUB_TOKEN", value) }
+            }
+            None => {
+                // SAFETY: this test serializes process-wide environment mutation with TOKEN_ENV_LOCK.
+                unsafe { std::env::remove_var("GITHUB_TOKEN") }
+            }
+        }
+
+        assert_eq!(token.as_deref(), Some("fallback-token"));
+        assert_eq!(source, Some(GitHubTokenSource::GitHubToken));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/tools/pr-comments/src/lib.rs
+++ b/crates/tools/pr-comments/src/lib.rs
@@ -8,9 +8,13 @@ pub mod tools;
 use agentic_config::types::GitHubServiceConfig;
 use anyhow::Context;
 use anyhow::Result;
+use models::CheckSuiteSummary;
 use models::CommentSourceType;
+use models::IssueCommentSummary;
+use models::PrRef;
 use models::PrSummary;
 use models::PrSummaryList;
+use models::PullRequestReviewSummary;
 use models::ReviewComment;
 use models::ReviewCommentList;
 use models::Thread;
@@ -249,6 +253,60 @@ This tool relies on ambient git repo detection. Run it inside a git checkout wit
                 }
             }
         }
+    }
+
+    pub async fn get_open_pr_ref_from_branch(&self, branch: &str) -> Result<Option<PrRef>> {
+        self.ensure_repo_configured()
+            .context("invalid argument: missing repository context")?;
+
+        let client =
+            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+                .context("internal: failed to create GitHub client")?;
+        self.with_github_total_timeout(
+            &format!("looking up open pull request ref for branch '{branch}'"),
+            async { client.get_open_pr_ref_from_branch(branch).await },
+        )
+        .await
+    }
+
+    pub async fn list_check_suites_for_ref(&self, sha: &str) -> Result<Vec<CheckSuiteSummary>> {
+        self.ensure_repo_configured()
+            .context("invalid argument: missing repository context")?;
+        let client =
+            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+                .context("internal: failed to create GitHub client")?;
+        self.with_github_total_timeout(&format!("listing check suites for ref {sha}"), async {
+            client.list_check_suites_for_ref(sha).await
+        })
+        .await
+    }
+
+    pub async fn list_pull_request_reviews(
+        &self,
+        pr_number: u64,
+    ) -> Result<Vec<PullRequestReviewSummary>> {
+        self.ensure_repo_configured()
+            .context("invalid argument: missing repository context")?;
+        let client =
+            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+                .context("internal: failed to create GitHub client")?;
+        self.with_github_total_timeout(&format!("listing reviews for PR #{pr_number}"), async {
+            client.list_pull_request_reviews(pr_number).await
+        })
+        .await
+    }
+
+    pub async fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueCommentSummary>> {
+        self.ensure_repo_configured()
+            .context("invalid argument: missing repository context")?;
+        let client =
+            github::GitHubClient::new(self.owner.clone(), self.repo.clone(), self.token.clone())
+                .context("internal: failed to create GitHub client")?;
+        self.with_github_total_timeout(
+            &format!("listing issue comments for issue #{issue_number}"),
+            async { client.list_issue_comments(issue_number).await },
+        )
+        .await
     }
 }
 

--- a/crates/tools/pr-comments/src/models.rs
+++ b/crates/tools/pr-comments/src/models.rs
@@ -52,6 +52,8 @@ pub struct PrRef {
     pub number: u64,
     pub url: String,
     pub head_sha: String,
+    pub node_id: String,
+    pub is_draft: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -572,10 +574,30 @@ pub struct OpenPrRefConnection {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenPrRefNode {
+    pub id: String,
     pub number: u64,
     pub url: String,
     #[serde(rename = "headRefOid")]
     pub head_ref_oid: String,
+    #[serde(rename = "isDraft")]
+    pub is_draft: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphqlResponse<T> {
+    pub data: T,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkPullRequestReadyForReviewData {
+    #[serde(rename = "markPullRequestReadyForReview")]
+    pub mark_pull_request_ready_for_review: MarkPullRequestReadyForReviewPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkPullRequestReadyForReviewPayload {
+    #[serde(rename = "pullRequest")]
+    pub pull_request: OpenPrRefNode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tools/pr-comments/src/models.rs
+++ b/crates/tools/pr-comments/src/models.rs
@@ -72,6 +72,8 @@ pub struct PullRequestReviewSummary {
     pub user_type: Option<String>,
     pub state: String,
     pub submitted_at: Option<String>,
+    #[serde(default)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -581,11 +583,6 @@ pub struct OpenPrRefNode {
     pub head_ref_oid: String,
     #[serde(rename = "isDraft")]
     pub is_draft: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GraphqlResponse<T> {
-    pub data: T,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tools/pr-comments/src/models.rs
+++ b/crates/tools/pr-comments/src/models.rs
@@ -47,6 +47,40 @@ pub struct PrSummary {
     pub review_comment_count: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct PrRef {
+    pub number: u64,
+    pub url: String,
+    pub head_sha: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct CheckSuiteSummary {
+    pub id: u64,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub app_slug: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct PullRequestReviewSummary {
+    pub id: u64,
+    pub user_login: String,
+    pub user_type: Option<String>,
+    pub state: String,
+    pub submitted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IssueCommentSummary {
+    pub id: u64,
+    pub user_login: String,
+    pub user_type: Option<String>,
+    pub body: String,
+    pub created_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReviewCommentList {
     pub owner: String,
@@ -518,6 +552,30 @@ pub struct GraphQLError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PullRequestData {
     pub repository: Repository,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenPrRefData {
+    pub repository: OpenPrRefRepository,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenPrRefRepository {
+    #[serde(rename = "pullRequests")]
+    pub pull_requests: OpenPrRefConnection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenPrRefConnection {
+    pub nodes: Vec<OpenPrRefNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenPrRefNode {
+    pub number: u64,
+    pub url: String,
+    #[serde(rename = "headRefOid")]
+    pub head_ref_oid: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tools/pr-comments/tests/github_phase4_parsing.rs
+++ b/crates/tools/pr-comments/tests/github_phase4_parsing.rs
@@ -76,11 +76,13 @@ fn parses_reviews_and_issue_comments_payloads() {
             "id": 9,
             "state": "COMMENTED",
             "submitted_at": "2026-06-24T18:05:00Z",
+            "commit_id": "abc123",
             "user": { "login": "coderabbitai[bot]", "type": "Bot" }
         }
     ]))
     .unwrap();
     assert_eq!(reviews[0].user_type.as_deref(), Some("Bot"));
+    assert_eq!(reviews[0].commit_id.as_deref(), Some("abc123"));
 
     let comments = GitHubClient::parse_issue_comments_fixture(serde_json::json!([
         {

--- a/crates/tools/pr-comments/tests/github_phase4_parsing.rs
+++ b/crates/tools/pr-comments/tests/github_phase4_parsing.rs
@@ -1,9 +1,31 @@
 use pr_comments::github::GitHubClient;
-use pr_comments::models::GraphQLResponse;
 use pr_comments::models::OpenPrRefData;
 
 #[test]
 fn parses_open_pr_ref_graphql_payload() {
+    let payload = serde_json::json!({
+        "repository": {
+            "pullRequests": {
+                "nodes": [
+                    {
+                        "number": 42,
+                        "url": "https://github.com/owner/repo/pull/42",
+                        "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                    }
+                ]
+            }
+        }
+    });
+
+    let response: OpenPrRefData = serde_json::from_value(payload).unwrap();
+    let node = &response.repository.pull_requests.nodes[0];
+
+    assert_eq!(node.number, 42);
+    assert_eq!(node.head_ref_oid.len(), 40);
+}
+
+#[test]
+fn graphql_envelope_does_not_deserialize_as_inner_open_pr_data() {
     let payload = serde_json::json!({
         "data": {
             "repository": {
@@ -20,11 +42,8 @@ fn parses_open_pr_ref_graphql_payload() {
         }
     });
 
-    let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(payload).unwrap();
-    let node = &response.data.unwrap().repository.pull_requests.nodes[0];
-
-    assert_eq!(node.number, 42);
-    assert_eq!(node.head_ref_oid.len(), 40);
+    let error = serde_json::from_value::<OpenPrRefData>(payload).unwrap_err();
+    assert!(error.to_string().contains("repository"));
 }
 
 #[test]

--- a/crates/tools/pr-comments/tests/github_phase4_parsing.rs
+++ b/crates/tools/pr-comments/tests/github_phase4_parsing.rs
@@ -1,0 +1,72 @@
+use pr_comments::github::GitHubClient;
+use pr_comments::models::GraphQLResponse;
+use pr_comments::models::OpenPrRefData;
+
+#[test]
+fn parses_open_pr_ref_graphql_payload() {
+    let payload = serde_json::json!({
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 42,
+                            "url": "https://github.com/owner/repo/pull/42",
+                            "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                        }
+                    ]
+                }
+            }
+        }
+    });
+
+    let response: GraphQLResponse<OpenPrRefData> = serde_json::from_value(payload).unwrap();
+    let node = &response.data.unwrap().repository.pull_requests.nodes[0];
+
+    assert_eq!(node.number, 42);
+    assert_eq!(node.head_ref_oid.len(), 40);
+}
+
+#[test]
+fn parses_check_suites_payload() {
+    let payload = serde_json::json!({
+        "check_suites": [
+            {
+                "id": 1,
+                "status": "completed",
+                "conclusion": "success",
+                "app": { "slug": "coderabbitai" },
+                "updated_at": "2026-06-24T18:00:00Z"
+            }
+        ]
+    });
+
+    let suites = GitHubClient::parse_check_suites_fixture(payload).unwrap();
+    assert_eq!(suites[0].app_slug.as_deref(), Some("coderabbitai"));
+    assert_eq!(suites[0].status, "completed");
+}
+
+#[test]
+fn parses_reviews_and_issue_comments_payloads() {
+    let reviews = GitHubClient::parse_reviews_fixture(serde_json::json!([
+        {
+            "id": 9,
+            "state": "COMMENTED",
+            "submitted_at": "2026-06-24T18:05:00Z",
+            "user": { "login": "coderabbitai[bot]", "type": "Bot" }
+        }
+    ]))
+    .unwrap();
+    assert_eq!(reviews[0].user_type.as_deref(), Some("Bot"));
+
+    let comments = GitHubClient::parse_issue_comments_fixture(serde_json::json!([
+        {
+            "id": 11,
+            "body": "Review skipped",
+            "created_at": "2026-06-24T18:06:00Z",
+            "user": { "login": "coderabbitai[bot]", "type": "Bot" }
+        }
+    ]))
+    .unwrap();
+    assert_eq!(comments[0].body, "Review skipped");
+}

--- a/crates/tools/pr-comments/tests/github_phase4_parsing.rs
+++ b/crates/tools/pr-comments/tests/github_phase4_parsing.rs
@@ -8,9 +8,11 @@ fn parses_open_pr_ref_graphql_payload() {
             "pullRequests": {
                 "nodes": [
                     {
+                        "id": "PR_42",
                         "number": 42,
                         "url": "https://github.com/owner/repo/pull/42",
-                        "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                        "headRefOid": "0123456789abcdef0123456789abcdef01234567",
+                        "isDraft": false
                     }
                 ]
             }
@@ -32,9 +34,11 @@ fn graphql_envelope_does_not_deserialize_as_inner_open_pr_data() {
                 "pullRequests": {
                     "nodes": [
                         {
+                            "id": "PR_42",
                             "number": 42,
                             "url": "https://github.com/owner/repo/pull/42",
-                            "headRefOid": "0123456789abcdef0123456789abcdef01234567"
+                            "headRefOid": "0123456789abcdef0123456789abcdef01234567",
+                            "isDraft": false
                         }
                     ]
                 }

--- a/crates/tools/pr-comments/tests/integration.rs
+++ b/crates/tools/pr-comments/tests/integration.rs
@@ -56,7 +56,6 @@ async fn test_model_serialization() {
 
 #[cfg(test)]
 mod resolution_tests {
-    use pr_comments::models::GraphQLResponse;
     use pr_comments::models::PullRequestData;
 
     #[test]
@@ -78,40 +77,37 @@ mod resolution_tests {
     fn test_graphql_models() {
         // Test that GraphQL response models deserialize correctly
         let json = r#"{
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [{
-                                "id": "PRRT_123",
-                                "isResolved": true,
-                                "comments": {
-                                    "nodes": [{
-                                        "id": "RC_123",
-                                        "databaseId": 456
-                                    }]
-                                }
-                            }],
-                            "pageInfo": {
-                                "hasNextPage": false,
-                                "endCursor": null
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [{
+                            "id": "PRRT_123",
+                            "isResolved": true,
+                            "comments": {
+                                "nodes": [{
+                                    "id": "RC_123",
+                                    "databaseId": 456
+                                }]
                             }
+                        }],
+                        "pageInfo": {
+                            "hasNextPage": false,
+                            "endCursor": null
                         }
                     }
                 }
             }
         }"#;
 
-        let response: GraphQLResponse<PullRequestData> = match serde_json::from_str(json) {
+        let response: PullRequestData = match serde_json::from_str(json) {
             Ok(response) => response,
-            Err(err) => panic!("GraphQLResponse should deserialize: {err}"),
+            Err(err) => panic!("PullRequestData should deserialize: {err}"),
         };
-        assert!(response.data.is_some());
-        let Some(data) = response.data else {
-            panic!("GraphQLResponse should contain data");
-        };
-        assert_eq!(data.repository.pull_request.review_threads.nodes.len(), 1);
-        assert!(data.repository.pull_request.review_threads.nodes[0].is_resolved);
+        assert_eq!(
+            response.repository.pull_request.review_threads.nodes.len(),
+            1
+        );
+        assert!(response.repository.pull_request.review_threads.nodes[0].is_resolved);
     }
 }
 

--- a/crates/tools/review-tools/CLAUDE.md
+++ b/crates/tools/review-tools/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p review_tools -- --check
-cargo clippy -p review_tools --all-targets -- -D warnings
+just crate-check review_tools
 
 # Tests
-cargo test -p review_tools
+just crate-test review_tools
 
 # Build
-cargo build -p review_tools
+just crate-build review_tools
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/tools/thoughts-mcp-tools/CLAUDE.md
+++ b/crates/tools/thoughts-mcp-tools/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p thoughts-mcp-tools -- --check
-cargo clippy -p thoughts-mcp-tools --all-targets -- -D warnings
+just crate-check thoughts-mcp-tools
 
 # Tests
-cargo test -p thoughts-mcp-tools
+just crate-test thoughts-mcp-tools
 
 # Build
-cargo build -p thoughts-mcp-tools
+just crate-build thoughts-mcp-tools
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/tools/web-retrieval/CLAUDE.md
+++ b/crates/tools/web-retrieval/CLAUDE.md
@@ -24,14 +24,13 @@ Environment:
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p web-retrieval -- --check
-cargo clippy -p web-retrieval --all-targets -- -D warnings
+just crate-check web-retrieval
 
 # Tests
-cargo test -p web-retrieval
+just crate-test web-retrieval
 
 # Build
-cargo build -p web-retrieval
+just crate-build web-retrieval
 ```
 <!-- END:xtask:autogen -->
 

--- a/crates/tools/workspace-tools/CLAUDE.md
+++ b/crates/tools/workspace-tools/CLAUDE.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt -p agentic-workspace-tools -- --check
-cargo clippy -p agentic-workspace-tools --all-targets -- -D warnings
+just crate-check agentic-workspace-tools
 
 # Tests
-cargo test -p agentic-workspace-tools
+just crate-test agentic-workspace-tools
 
 # Build
-cargo build -p agentic-workspace-tools
+just crate-build agentic-workspace-tools
 ```
 <!-- END:xtask:autogen -->
 

--- a/opencode.json
+++ b/opencode.json
@@ -268,6 +268,7 @@
       }
     }
   },
+  "snapshot": false,
   "experimental": {
     "mcp_timeout": 7200000
   }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -73,16 +73,23 @@ git_tag_enable = true
 release = true
 
 [[package]]
-name = "thoughts-bin"
-changelog_path = "apps/thoughts/CHANGELOG.md"
-git_tag_name = "thoughts-bin-v{{ version }}"
+name = "agentic-outer-dag-bin"
+changelog_path = "apps/agentic-outer-dag/CHANGELOG.md"
+git_tag_name = "agentic-outer-dag-bin-v{{ version }}"
 git_tag_enable = true
 release = true
 
 [[package]]
-name = "thoughts-tool"
-changelog_path = "crates/infra/thoughts-core/CHANGELOG.md"
-git_tag_name = "thoughts-tool-v{{ version }}"
+name = "gwt-worktree"
+changelog_path = "crates/infra/gwt-worktree/CHANGELOG.md"
+git_tag_name = "gwt-worktree-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
+name = "linear-tools"
+changelog_path = "crates/linear/tools/CHANGELOG.md"
+git_tag_name = "linear-tools-v{{ version }}"
 git_tag_enable = true
 release = true
 
@@ -94,9 +101,58 @@ git_tag_enable = false
 release = true
 
 [[package]]
+name = "agentic-tools-mcp"
+changelog_path = "crates/agentic-tools/mcp/CHANGELOG.md"
+git_tag_name = "agentic-tools-mcp-v{{ version }}"
+git_tag_enable = false
+release = true
+
+[[package]]
+name = "linear-queries"
+changelog_path = "crates/linear/queries/CHANGELOG.md"
+git_tag_name = "linear-queries-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
+name = "linear-schema"
+changelog_path = "crates/linear/schema/CHANGELOG.md"
+git_tag_name = "linear-schema-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
+name = "opencode_rs"
+changelog_path = "crates/services/opencode-rs/CHANGELOG.md"
+git_tag_name = "opencode_rs-v{{ version }}"
+git_tag_enable = false
+release = true
+
+[[package]]
+name = "pr_comments"
+changelog_path = "crates/tools/pr-comments/CHANGELOG.md"
+git_tag_name = "pr_comments-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
 name = "agentic_logging"
 changelog_path = "crates/infra/agentic-logging/CHANGELOG.md"
 git_tag_name = "agentic_logging-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
+name = "thoughts-tool"
+changelog_path = "crates/infra/thoughts-core/CHANGELOG.md"
+git_tag_name = "thoughts-tool-v{{ version }}"
+git_tag_enable = true
+release = true
+
+[[package]]
+name = "thoughts-bin"
+changelog_path = "apps/thoughts/CHANGELOG.md"
+git_tag_name = "thoughts-bin-v{{ version }}"
 git_tag_enable = true
 release = true
 
@@ -105,13 +161,6 @@ name = "agentic-mcp"
 changelog_path = "apps/agentic-mcp/CHANGELOG.md"
 git_tag_name = "agentic-mcp-v{{ version }}"
 git_tag_enable = true
-release = true
-
-[[package]]
-name = "agentic-tools-mcp"
-changelog_path = "crates/agentic-tools/mcp/CHANGELOG.md"
-git_tag_name = "agentic-tools-mcp-v{{ version }}"
-git_tag_enable = false
 release = true
 
 [[package]]
@@ -139,34 +188,6 @@ release = true
 name = "gpt5_reasoner"
 changelog_path = "crates/tools/gpt5-reasoner/CHANGELOG.md"
 git_tag_name = "gpt5_reasoner-v{{ version }}"
-git_tag_enable = true
-release = true
-
-[[package]]
-name = "linear-tools"
-changelog_path = "crates/linear/tools/CHANGELOG.md"
-git_tag_name = "linear-tools-v{{ version }}"
-git_tag_enable = true
-release = true
-
-[[package]]
-name = "linear-queries"
-changelog_path = "crates/linear/queries/CHANGELOG.md"
-git_tag_name = "linear-queries-v{{ version }}"
-git_tag_enable = true
-release = true
-
-[[package]]
-name = "linear-schema"
-changelog_path = "crates/linear/schema/CHANGELOG.md"
-git_tag_name = "linear-schema-v{{ version }}"
-git_tag_enable = true
-release = true
-
-[[package]]
-name = "pr_comments"
-changelog_path = "crates/tools/pr-comments/CHANGELOG.md"
-git_tag_name = "pr_comments-v{{ version }}"
 git_tag_enable = true
 release = true
 
@@ -203,13 +224,6 @@ name = "exa-async"
 changelog_path = "crates/services/exa-async/CHANGELOG.md"
 git_tag_name = "exa-async-v{{ version }}"
 git_tag_enable = true
-release = true
-
-[[package]]
-name = "opencode_rs"
-changelog_path = "crates/services/opencode-rs/CHANGELOG.md"
-git_tag_name = "opencode_rs-v{{ version }}"
-git_tag_enable = false
 release = true
 
 [[package]]
@@ -253,13 +267,6 @@ name = "agentic-tools-macros"
 changelog_path = "crates/agentic-tools/macros/CHANGELOG.md"
 git_tag_name = "agentic-tools-macros-v{{ version }}"
 git_tag_enable = false
-release = true
-
-[[package]]
-name = "gwt-worktree"
-changelog_path = "crates/infra/gwt-worktree/CHANGELOG.md"
-git_tag_name = "gwt-worktree-v{{ version }}"
-git_tag_enable = true
 release = true
 
 [[package]]

--- a/tools/templates/CLAUDE.template.md
+++ b/tools/templates/CLAUDE.template.md
@@ -17,14 +17,13 @@ Briefly describe the purpose of this crate and how to use it.
 <!-- BEGIN:xtask:autogen commands -->
 ```bash
 # Lint & Clippy
-cargo fmt --package {{crate.name}} --all -- --check
-cargo clippy -p {{crate.name}} --all-targets -- -D warnings
+just crate-check {{crate.name}}
 
 # Tests
-cargo test -p {{crate.name}}
+just crate-test {{crate.name}}
 
 # Build
-cargo build -p {{crate.name}}
+just crate-build {{crate.name}}
 ```
 <!-- END:xtask:autogen -->
 


### PR DESCRIPTION
## Summary
- Add durable outer DAG automation for worktree-to-PR-to-CodeRabbit flow.

## Verification
- `just crate-check agentic-outer-dag-bin` — passed
- `just crate-test agentic-outer-dag-bin` — passed
- `just crate-check pr_comments` — passed
- `just crate-test pr_comments` — passed
- `just fmt` — passed
- `just check` — passed
- `just test` — passed

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-992 needs a durable outer automation loop that can move a ticket from worktree setup through PR creation, CodeRabbit review, automated comment resolution, and final human handoff without losing state between tool invocations.

Before this change, that workflow depended on manual sequencing around worktree freshness, OpenCode command dispatch, PR discovery, CodeRabbit completion detection, permission/question interruptions, and Linear handoffs. That made the flow hard to resume safely after dirty trees, rebase conflicts, draft PRs, skipped reviews, transport failures, or long-running OpenCode sessions.

This PR also hardens the outer loop against several issues discovered during live runs:

- top-level managed OpenCode sessions must be allowed to run first-party `/linear_ticket_2_pr` and `/resolve_pr_comments` commands without tripping the nested-orchestrator guard;
- OpenCode `/session/{id}/command` calls can be completion-coupled, so transport errors after dispatch should not automatically be treated as terminal failures;
- retrying timed-out command dispatches can duplicate execution once a command may already have reached the server; and
- a successful `ticket_to_pr` run that produces no PR should stop as an explicit human handoff instead of being recorded as a failed automation run.

## What user-facing changes did I ship?

- Added a new Unix-only `agentic-outer-dag` binary that drives the worktree-to-PR-to-CodeRabbit workflow.
- Added CLI subcommands for `start`, `resume`, `status`, permission responses, question responses, manual `handoff`, and `reset`.
- Added persisted branch-scoped run state in thoughts artifacts so runs can resume after pauses or manual intervention.
- Added worktree freshness gates that detect dirty trees, fetch/rebase onto the base branch, and stop with a Linear handoff when manual action is required.
- Added explicit branch PR detection, richer PR lookup diagnostics, and a terminal no-PR handoff path for successful `ticket_to_pr` runs that do not create an open PR.
- Added CodeRabbit completion detection using check suites, PR reviews, and issue comments, including draft-PR recovery and skipped-review handling.
- Added live-test and safety controls such as preview-only dry runs, no-dispatch mode, bounded stop points, configurable poll intervals, bounded CodeRabbit waits, and configurable OpenCode session deadline/inactivity timeouts.
- Hardened OpenCode supervision so completion is only trusted after dispatch evidence exists, unresolved tool calls are detected before finalizing, and post-start transport errors are recorded as diagnostics while supervision continues.
- Hardened `opencode-rs` command retry behavior to avoid retrying timeout/request transport failures after a command may already have reached the server.
- Extended GitHub/PR helpers used by the outer DAG with open-PR lookup, ready-for-review mutation, CodeRabbit check-suite/review/comment queries, and safer token-source diagnostics.
- Updated generated crate docs/templates so CLAUDE command snippets use repository `just` wrappers.

## How I implemented it

- Registered the new `agentic-outer-dag-bin` app in the workspace and implemented its CLI entrypoints in `apps/agentic-outer-dag/src/cli.rs` and `apps/agentic-outer-dag/src/main.rs`.
- Added a durable run-state model and thoughts-backed persistence in `apps/agentic-outer-dag/src/state/` that tracks stages, PR metadata, OpenCode session state, CodeRabbit polling state, handoff deduplication, and runtime settings.
- Implemented the DAG engine in `apps/agentic-outer-dag/src/dag/engine.rs` to sequence freshness checks, ticket-to-PR dispatch, PR detection, ready-for-review recovery, CodeRabbit waiting, comment-resolution dispatch, and terminal handoff/failure states.
- Added a managed OpenCode supervisor in `apps/agentic-outer-dag/src/opencode/supervisor.rs` that starts `opencode serve`, validates the pinned version, supervises commands with SSE/status/transcript evidence, handles permission/question replies, and distinguishes pre-start dispatch failures from post-start transport warnings.
- Added completion detection guards so idle is ignored until dispatch is confirmed, transcript settling is retried while tool calls are unresolved, and nested-orchestrator guard failures are surfaced from transcript evidence.
- Added worktree resolution and freshness support in `apps/agentic-outer-dag/src/worktree/`, including branch/worktree selection, optional creation through `gwt-worktree`, post-create command execution, dirty-tree checks, fetch, rebase, and conflict classification.
- Added idempotent Linear handoff posting in `apps/agentic-outer-dag/src/linear/mod.rs` by hashing handoff bodies to avoid duplicate comments across resumes.
- Extended `crates/tools/pr-comments` with open PR branch lookup, ready-for-review mutation support, CodeRabbit check suite / review / issue comment listing, GraphQL response validation, review commit-id tracking, and token-source diagnostics.
- Updated `crates/services/opencode-rs` to support explicit launcher args, managed-env injection opt-out for the top-level outer DAG server, and safer command dispatch retry behavior.
- Updated `crates/meta/xtask` and generated CLAUDE docs/templates so crate command snippets use repository `just` wrappers instead of raw cargo commands.
- Added regression coverage for OpenCode completion detection, command transport warnings, retry policy, worktree config portability/post-create execution, and GitHub response parsing.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification completed:

- [x] `gh pr view 258 --json url,title,number,state,baseRefName,headRefName,commits` confirmed this is open PR `#258` targeting `main`.
- [x] Reviewed the full PR diff and commit history for the current branch, including the latest outer-DAG supervision hardening, PR/comment helper updates, and generated CLAUDE template sync.

## Description for the changelog

Added the ENG-992 `agentic-outer-dag` automation binary for durable worktree-to-PR-to-CodeRabbit orchestration, including thoughts-backed run state, worktree freshness gates, resumable OpenCode supervision, explicit PR lookup and ready-for-review handling, safer no-PR human handoff behavior, CodeRabbit completion polling, safer `opencode-rs` command retry semantics, and updated generated CLAUDE command wrappers.
<!-- END:describe_pr:autogen -->




