### PR TITLE
fix(linear): clarify full ticket read guidance

### DIFF
--- a/.opencode/command/linear.md
+++ b/.opencode/command/linear.md
@@ -4,4 +4,12 @@ agent: Linear
 ---
 You have access to Linear tools for issue management now!
 
+Guidance:
+- If the user asks to read, fetch, understand, or summarize a Linear ticket, treat a full ticket read as:
+  1. Call `linear_read_issue` for issue details and description.
+  2. Call `linear_get_issue_comments` repeatedly with the same issue until `has_more=false`.
+  3. Stop when `has_more=false`; another identical call after completion restarts from the beginning.
+  4. Use the description plus full comment corpus in the response.
+- For unrelated Linear operations, do only the work needed for the user request.
+
 **User request:** $ARGUMENTS

--- a/.opencode/command/linear_ticket_2_pr.md
+++ b/.opencode/command/linear_ticket_2_pr.md
@@ -89,10 +89,10 @@ $ARGUMENTS
 
 ## Step 4: Persist the Ticket Corpus as a Thoughts Artifact
 
-1. Because the orchestrator cannot write artifacts directly and the Linear child may not have thoughts tools, use an explicit handoff pattern:
-   - first collect the full ticket description and comments in the Linear child result
-   - then spawn a normal or research-capable child session whose bounded task is to write a thoughts artifact containing that full corpus
-   - if it is cleaner, fold this into creation of a research-style artifact, but the full ticket description and comments must still be preserved verbatim enough for downstream reuse
+1. Because the orchestrator cannot write artifacts directly, persist the corpus via a child session:
+   - Preferred: have the same Linear child session from Step 3 write the thoughts artifact directly and return the artifact path.
+   - Fallback: if thoughts tools are unavailable in that Linear child configuration, hand off the full corpus to a normal or research-capable child whose bounded task is to write the artifact.
+   - If it is cleaner, fold this into creation of a research-style artifact, but the full ticket description and comments must still be preserved verbatim enough for downstream reuse.
 2. The artifact should capture at minimum:
    - ticket key and URL
    - current Linear status

--- a/crates/linear/tools/src/tools.rs
+++ b/crates/linear/tools/src/tools.rs
@@ -146,8 +146,7 @@ impl Tool for ReadIssueTool {
     type Input = ReadIssueInput;
     type Output = IssueDetails;
     const NAME: &'static str = "linear_read_issue";
-    const DESCRIPTION: &'static str =
-        "Read a Linear issue by ID, identifier (e.g., ENG-245), or URL";
+    const DESCRIPTION: &'static str = "Read a Linear issue by ID, identifier (e.g., ENG-245), or URL. Returns issue details and description only; comments are separate. For a full ticket read, also call linear_get_issue_comments until has_more=false.";
 
     fn call(
         &self,
@@ -317,7 +316,7 @@ impl Tool for GetIssueCommentsTool {
     type Input = GetIssueCommentsInput;
     type Output = crate::models::CommentsResult;
     const NAME: &'static str = "linear_get_issue_comments";
-    const DESCRIPTION: &'static str = "Get comments on a Linear issue. Returns 10 comments per call with implicit pagination - call again with the same issue to get more comments.";
+    const DESCRIPTION: &'static str = "Get comments on a Linear issue (up to 10 per call) with implicit pagination. Repeat calls with the same issue until has_more=false; another call after completion restarts from the beginning.";
 
     fn call(
         &self,


### PR DESCRIPTION
Placeholder draft PR for ENG-890. A detailed description will be added in a later describe_pr update.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-890 exposed that the Linear ticket-reading flow was underspecified in two places:

- `linear_read_issue` could be interpreted as a complete ticket fetch even though it only returns issue details and description.
- `linear_get_issue_comments` relied on implicit pagination behavior that was easy to stop early, which risked partial ticket reads and incomplete downstream summaries.
- The `linear_ticket_2_pr` command still described the older artifact handoff model instead of the current preferred flow for Linear-capable child sessions.

Together, those gaps made it possible for Linear-enabled sessions to summarize or hand off ticket context without exhausting comments or using the intended artifact persistence path.

## What user-facing changes did I ship?

- Clarified the Linear command guidance so a "full ticket read" explicitly requires:
  1. reading issue details and description,
  2. repeatedly fetching comments until `has_more=false`, and
  3. using the full description plus full comment corpus in the response.
- Clarified the tool descriptions surfaced to agents so `linear_read_issue` now states that comments are separate, and `linear_get_issue_comments` now states exactly when pagination is complete and that an extra identical call restarts pagination.
- Updated the Linear ticket-to-PR workflow so the preferred artifact persistence path is for the same Linear child session to write the thoughts artifact directly, with a normal/research child only as a fallback when thoughts tools are unavailable.

## How I implemented it

- Updated `.opencode/command/linear.md` to codify the required full-ticket read sequence for Linear requests.
- Updated `.opencode/command/linear_ticket_2_pr.md` to align Step 4 with the current orchestrator/child-session artifact handoff expectations.
- Updated tool metadata in `crates/linear/tools/src/tools.rs` so agent-visible descriptions reinforce the same contract at the API boundary.
- Kept the change scope limited to guidance and tool-description text; there are no behavior, schema, or runtime API changes.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-check linear-tools`
- [x] `just crate-test linear-tools`
- [x] `just check`
- [x] `just test`

## Description for the changelog

Clarify the Linear full-ticket read contract so agents exhaust comment pagination and use the current ticket-corpus artifact handoff flow.
<!-- END:describe_pr:autogen -->
