### PR TITLE
feat(build): add root just clean support

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ help:
     @echo "  just fix              # auto-fix clippy warnings for entire workspace"
     @echo "  just test             # run tests for entire workspace"
     @echo "  just build            # build entire workspace"
+    @echo "  just clean            # clean workspace + vendored Codex artifacts"
     @echo "  just fmt              # format entire workspace"
     @echo "  just fmt-check        # check formatting for entire workspace"
     @echo ""
@@ -73,6 +74,20 @@ test-integration: mcp-test
 
 build:
     {{ exec }}cargo build --workspace
+
+clean: clean-workspace clean-codex
+
+clean-workspace:
+    {{ exec }}cargo clean --workspace
+
+clean-codex:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    MANIFEST="vendor/codex/codex-rs/Cargo.toml"
+    if [ -f "$MANIFEST" ]; then
+      {{ exec }}cargo clean --manifest-path "$MANIFEST"
+    fi
 
 codex-check:
     cd vendor/codex/codex-rs && cargo check -p codex-cli --all-targets


### PR DESCRIPTION
## Summary
- add a root `just clean` aggregator for the workspace and vendored Codex artifacts
- add guarded Codex cleanup via `cargo clean --manifest-path ...`
- expose the new command in the default help output

## Verification
- `just fmt-check-just`
- `just clean`
- `just xtask-sync-check`
- confirmed `just help` includes `just clean`


<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

`gwt gc` and this repository's own worktree cleanup flow expect a root `just clean` command to exist. This repository did not provide that command, so stale worktrees could not rely on the default cleanup contract to reclaim Rust build artifacts.

A workspace-only clean would also have been incomplete here because `vendor/` is excluded from the root Cargo workspace, which means vendored Codex artifacts would be left behind.

## What user-facing changes did I ship?

- Added a root `just clean` command in the repository justfile
- Made `just clean` clean both the main workspace and vendored Codex artifacts
- Guarded the Codex cleanup step so the command still succeeds if `vendor/codex/codex-rs/Cargo.toml` is absent
- Added `just clean` to the default help output so the cleanup command is discoverable

## How I implemented it

- Added a small delegated clean surface in `justfile`:
  - `clean: clean-workspace clean-codex`
  - `clean-workspace` runs `cargo clean --workspace`
  - `clean-codex` runs `cargo clean --manifest-path vendor/codex/codex-rs/Cargo.toml` only when that manifest exists
- Kept the new recipes outside the xtask-managed autogen block
- Used a manifest-path-based Codex clean from repo root rather than changing directories, which keeps the existing `exec` wrapper behavior intact in minimal output mode
- Updated the `help` recipe so `just clean` appears alongside the other workspace commands

## How to verify it

- [x] I ran the `check` and `test` recipes via the Just MCP tools and they passed
- [x] `just fmt-check-just` passed
- [x] `just clean` passed
- [x] `just xtask-sync-check` passed
- [x] `just help` includes `just clean`

## Description for the changelog

Add root `just clean` support that cleans the main workspace and vendored Codex artifacts.
<!-- END:describe_pr:autogen -->
