### PR TITLE
fix(opencode-orchestrator-mcp): tolerate stale legacy permission failures

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -365,18 +365,30 @@ impl OrchestratorRunTool {
             Ok(pending_permissions) => Ok(pending_permissions
                 .into_iter()
                 .find(|permission| permission.session_id == session_id)),
-            Err(error)
-                if matches!(mode, PermissionPreflightMode::RespondPermissionContinuation)
-                    && error.is_validation_error() =>
-            {
-                tracing::warn!(
-                    session_id = %session_id,
-                    error = %error,
-                    "failed to list permissions during respond_permission continuation; falling back to polling"
-                );
-                warnings.push(format!(
-                    "Permission refresh failed after reply ({error}); continuing with polling fallback."
-                ));
+            Err(error) if error.is_validation_error() => {
+                match mode {
+                    PermissionPreflightMode::RespondPermissionContinuation => {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %error,
+                            "failed to list permissions during respond_permission continuation; falling back to polling"
+                        );
+                        warnings.push(format!(
+                            "Permission refresh failed after reply ({error}); permission state could not be listed and may be stale or malformed. Continuing with polling fallback."
+                        ));
+                    }
+                    PermissionPreflightMode::Strict => {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %error,
+                            "failed to list permissions during run preflight; continuing without permission preflight"
+                        );
+                        warnings.push(
+                            "Permission state could not be listed during preflight (HTTP 400). Permission state may be stale or malformed; pending permissions may be stale or undiscoverable."
+                                .to_string(),
+                        );
+                    }
+                }
                 Ok(None)
             }
             Err(error) => Err(ToolError::Internal(format!(
@@ -556,7 +568,7 @@ impl OrchestratorRunTool {
         if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
             let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
             let output =
-                Self::finalize_completed(client, session_id, &token_tracker, vec![]).await?;
+                Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
             return Ok(RunOutcome::with_tracker(output, &token_tracker));
         }
 
@@ -1636,9 +1648,20 @@ Parameters:
                         }
                     } else {
                         // Find the pending permission for this session when discovery is required.
-                        let pending = client.permissions().list().await.map_err(|e| {
-                            ToolError::Internal(format!("Failed to list permissions: {e}"))
-                        })?;
+                        let pending = match client.permissions().list().await {
+                            Ok(pending) => pending,
+                            Err(error) if error.is_validation_error() => {
+                                return Err(ToolError::InvalidInput(format!(
+                                    "Unable to discover a pending permission for session '{}': permission state could not be listed (HTTP 400). Permission state may be stale or malformed. Retry with permission_request_id (from run) if available; otherwise reopen the session or start a new one.",
+                                    input.session_id
+                                )));
+                            }
+                            Err(error) => {
+                                return Err(ToolError::Internal(format!(
+                                    "Failed to list permissions: {error}"
+                                )));
+                            }
+                        };
 
                         let mut perms: Vec<_> = pending
                             .into_iter()
@@ -1697,7 +1720,9 @@ Parameters:
                 };
 
                 // Send the reply
-                client
+                let session_id_for_error = input.session_id.clone();
+
+                match client
                     .permissions()
                     .reply(
                         &permission_request_id,
@@ -1707,9 +1732,19 @@ Parameters:
                         },
                     )
                     .await
-                    .map_err(|e| {
-                        ToolError::Internal(format!("Failed to reply to permission: {e}"))
-                    })?;
+                {
+                    Ok(_) => {}
+                    Err(error) if error.is_not_found() => {
+                        return Err(ToolError::InvalidInput(format!(
+                            "Permission request '{permission_request_id}' was not found or is no longer pending (HTTP 404). It may be stale. Re-run orchestrator_run(session_id='{session_id_for_error}') to get the latest permission_request_id and retry."
+                        )));
+                    }
+                    Err(error) => {
+                        return Err(ToolError::Internal(format!(
+                            "Failed to reply to permission: {error}"
+                        )));
+                    }
+                }
 
                 // Now continue monitoring the session using run logic
                 let run_tool = OrchestratorRunTool::new(Arc::clone(&server_handle));

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -458,7 +458,7 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
 }
 
 #[tokio::test]
-async fn run_still_errors_on_initial_permission_list_bad_request() {
+async fn run_tolerates_initial_permission_list_bad_request_with_warning() {
     let _guard = env_lock().await;
     let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
     // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
@@ -491,7 +491,19 @@ async fn run_still_errors_on_initial_permission_list_bad_request() {
         .mount(&mock)
         .await;
 
-    let err = timeout(
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("OK"))))
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
         Duration::from_secs(2),
         tool.call(
             OrchestratorRunInput {
@@ -505,8 +517,120 @@ async fn run_still_errors_on_initial_permission_list_bad_request() {
         ),
     )
     .await
-    .expect("strict run regression should not hang")
-    .expect_err("run should remain strict on initial permission-list failures");
+    .expect("degraded-success regression should not hang")
+    .expect("run should continue with a warning on initial permission-list 400");
 
-    assert!(matches!(err, ToolError::Internal(_)));
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("OK"));
+    assert!(result.warnings.iter().any(|warning| {
+        let warning = warning.to_lowercase();
+        warning.contains("could not be listed")
+            && warning.contains("stale")
+            && warning.contains("malformed")
+    }));
+}
+
+#[tokio::test]
+async fn respond_permission_no_id_permission_list_400_is_actionable_invalid_input() {
+    let _guard = env_lock().await;
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "permission-discovery-400";
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .and(query_param("directory", "/tmp"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_json(permission_patch_file_array_bad_request_fixture()),
+        )
+        .mount(&mock)
+        .await;
+
+    let err = tool
+        .call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: None,
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("no-id discovery should surface actionable invalid input");
+
+    match err {
+        ToolError::InvalidInput(message) => {
+            let message = message.to_lowercase();
+            assert!(message.contains("could not be listed"));
+            assert!(message.contains("permission_request_id"));
+        }
+        other => panic!("expected invalid input error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn respond_permission_reply_404_is_actionable_invalid_input() {
+    let _guard = env_lock().await;
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "permission-reply-404";
+    let perm_id = "perm-stale-404";
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            permission_fixture(perm_id, sid, "file.write", &["/tmp/out.txt"])
+        ])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/permission/{perm_id}/reply")))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "name": "NotFound",
+            "message": "Permission request not found"
+        })))
+        .mount(&mock)
+        .await;
+
+    let err = tool
+        .call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: None,
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("stale reply should surface actionable invalid input");
+
+    match err {
+        ToolError::InvalidInput(message) => {
+            let message = message.to_lowercase();
+            assert!(message.contains(perm_id));
+            assert!(message.contains("not found") || message.contains("no longer pending"));
+        }
+        other => panic!("expected invalid input error, got {other:?}"),
+    }
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
+        "reply POST should be observed for stale permission id: {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
 }


### PR DESCRIPTION
Initial PR for ENG-972. Full description will be generated by describe_pr.\n\nVerification:\n- just check\n- just test

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-972: opencode can return HTTP 400 while listing legacy permission state when that state is stale or malformed. Before this change, that malformed permission listing could make `orchestrator_run` fail even when the session itself was idle and had a usable final response.

The same stale permission state also produced less actionable failures in `respond_permission`: permission discovery failures and replies to no-longer-pending permission IDs were surfaced as internal errors instead of telling the caller how to recover.

## What user-facing changes did I ship?

- `orchestrator_run` now preserves run availability when permission preflight listing returns malformed-state HTTP 400s:
  - it continues without permission preflight instead of failing the run;
  - it returns a warning explaining that permission state could not be listed and may be stale or malformed.
- `respond_permission` now returns actionable invalid-input errors when:
  - it cannot discover a pending permission because permission listing returns HTTP 400;
  - the selected permission request returns HTTP 404 because it is stale or no longer pending.
- Warnings collected during permission preflight are preserved when an already-idle run completes immediately.

No migration is required. This only changes error/warning behavior around stale or malformed permission state.

## How I implemented it

- Updated permission preflight handling in `opencode-orchestrator-mcp` so validation errors from permission listing are downgraded to warnings in both strict run preflight and post-`respond_permission` continuation modes.
- Preserved accumulated preflight warnings when finalizing an already-idle completed run.
- Changed `respond_permission` permission discovery to map malformed permission-listing HTTP 400s to `ToolError::InvalidInput` with recovery guidance to retry with a known `permission_request_id`, reopen the session, or start a new one.
- Changed permission reply HTTP 404s to `ToolError::InvalidInput` with guidance to re-run `orchestrator_run` for the latest permission request ID.
- Added wiremock regression coverage for:
  - run completion with a warning when initial permission listing returns HTTP 400;
  - actionable invalid input when permission discovery cannot list malformed permission state;
  - actionable invalid input when replying to a stale permission request ID returns HTTP 404.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
  - `just check` passed
  - `just test` passed
  - `just crate-check opencode-orchestrator-mcp` passed
  - `just crate-test opencode-orchestrator-mcp` passed

## Description for the changelog

`opencode-orchestrator-mcp`: tolerate stale or malformed legacy permission listing failures during run preflight, preserve warning visibility, and return actionable invalid-input errors for stale permission discovery/reply paths.
<!-- END:describe_pr:autogen -->
