### PR TITLE
ENG-1048: Reduce unnecessary amend/fixup prompts

### DIFF
--- a/.opencode/command/commit.md
+++ b/.opencode/command/commit.md
@@ -15,6 +15,9 @@ You are tasked with creating git commits for the changes made during this sessio
    - Run `git status` to see current changes
    - Run `git diff` to understand the modifications
    - Consider whether changes should be one commit or multiple logical commits
+   - For ordinary follow-up work, present new commit(s) rather than history-editing actions
+   - If the user explicitly requested amend/fixup/rebase/squash, or if you are correcting your own immediately previous unpushed commit mistake, state the rewrite implications explicitly
+   - If pushed-history rewrite or force-push implications exist or might exist, ask for specific approval instead of a generic confirmation
 
 2. **Determine commit type:**
    Analyze the changes and categorize them:
@@ -47,7 +50,8 @@ You are tasked with creating git commits for the changes made during this sessio
 4. **Present your plan to the user:**
    - List the files you plan to add for each commit
    - Show the conventional commit message(s) you'll use
-   - Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"
+   - Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?" for ordinary new commits
+   - Ask: "This plan would rewrite history [and may require a force push]. Do you want me to proceed with that history edit?" for history-rewrite actions
 
 5. **Execute upon confirmation:**
    - Use `git add` with specific files (never use `-A` or `.`)
@@ -69,6 +73,15 @@ You are tasked with creating git commits for the changes made during this sessio
 - Do not add "Co-Authored-By" lines
 - Write commit messages as if the user wrote them
 - **ALWAYS use conventional commit format for automated versioning**
+
+### History-editing policy:
+
+- Default to **new commit(s)** for ordinary follow-up work, even when the changes are small or overlap with a recent commit.
+- Do **not** routinely suggest `--amend`, `--fixup`, rebase, or other history-editing actions as a normal cleanup choice.
+- Preserve explicit user-requested history editing. If the user explicitly asks to amend, fix up, rebase, or squash, you may plan that path.
+- You may proactively offer amend/fixup only to correct your own immediately previous commit mistake, and only when it is safe to do so without rewriting pushed history.
+- If push status is unclear, assume a rewrite may affect pushed history and prefer a new commit instead.
+- If any plan would rewrite pushed commits, require force-push, or might do either because upstream status is ambiguous, call that out explicitly and ask for specific user approval before proceeding.
 
 ## Breaking Changes:
 If a change breaks backward compatibility, add `BREAKING CHANGE:` in the footer:

--- a/.opencode/orchestrator_sysprompt_gpt54.md
+++ b/.opencode/orchestrator_sysprompt_gpt54.md
@@ -186,10 +186,14 @@ Phase 4 - Implementation:
 Phase 5 - Commit:
 1. Run "commit" in the SAME session where implementation happened
 2. The commit command analyzes changes and presents a commit plan with proposed git commands
-3. Critical: OpenCode may reset command-granted tools between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly may go to a Normal agent which lacks bash access—the commands will fail.
-4. Correct pattern: After commit presents the plan, run the "bash" command with "Do it!" or the explicit git commands to re-invoke with Bash agent access
-5. Example flow: commit presents plan with "git add... git commit..." → run "bash" command with those commands to execute (this re-invokes the Bash agent)
-6. Thoughts documents are stored separately and are not committed
+3. Ordinary follow-up work defaults to **new commit(s)**; do not routinely suggest amend/fixup or other history edits as a normal cleanup choice
+4. Preserve explicit user-requested amend/fixup/rebase/squash flows
+5. Only allow proactive amend/fixup for correcting the orchestrator's own immediately previous commit mistake when that rewrite is safely unpushed; if push status is unclear, prefer a new commit
+6. If a history edit might rewrite pushed commits or imply a force push, call that out explicitly and require specific user approval before proceeding
+7. Critical: OpenCode may reset command-granted tools between turns. When commit (Bash agent) presents its plan and asks "Shall I proceed?", responding directly may go to a Normal agent which lacks bash access—the commands will fail.
+8. Correct pattern: After commit presents the plan, run the "bash" command with "Do it!" or the explicit git commands to re-invoke with Bash agent access
+9. Example flow: commit presents plan with "git add... git commit..." → run "bash" command with those commands to execute (this re-invokes the Bash agent)
+10. Thoughts documents are stored separately and are not committed
 
 General bash/session rule: command-granted bash/shell access is not durable across plain resumes. For any shell follow-up, exact CLI transcript, or session that reports it lacks shell, run orchestrator_run with command="bash" again instead of sending a plain message resume.
 </workflow_pipeline>


### PR DESCRIPTION
## Summary

- default ordinary follow-up work in the `/commit` prompt to new commit(s)
- preserve explicit amend/fixup/rebase/squash requests while requiring rewrite implications to be called out
- align the GPT-5.4 orchestrator workflow guidance with the new commit-history policy

## Verification

- `just fmt-check`
- `git diff --cached --check`
- static anchor checks for the new commit-history policy text

Linear: ENG-1048
