### PR TITLE
feat(agentic-outer-dag): add merge-based sync command

### DIFF
--- a/.opencode/command/sync_with_main_and_resolve_conflicts.md
+++ b/.opencode/command/sync_with_main_and_resolve_conflicts.md
@@ -28,14 +28,18 @@ $ARGUMENTS
 <process>
 
 <step_1>
+
 ## Step 1: Establish context + todo list
+
 - Determine current branch (`git branch --show-current`) and base ref (default `origin/main`, fallback `origin/master` if needed).
 - Record whether this was invoked manually or by OuterDAG (treat $ARGUMENTS as optional metadata only).
 - Create todos for: preflight, fetch+behind check, merge attempt, conflict resolution (if needed), verification, push, summary.
 </step_1>
 
 <step_2>
+
 ## Step 2: Preflight safe starting git state (STOP conditions)
+
 In Bash:
 - `git status --porcelain=v2`
 - `git rev-parse --abbrev-ref HEAD`
@@ -49,7 +53,9 @@ STOP if:
 </step_2>
 
 <step_3>
+
 ## Step 3: Fetch + merge origin/main (no rebase)
+
 In Bash:
 - `git fetch origin --prune`
 - If `origin/main` is already merged (ancestor of HEAD), you may still run verification and push if local commits exist.
@@ -60,14 +66,17 @@ If merge reports conflicts: proceed to Step 4.
 </step_3>
 
 <step_4>
+
 ## Step 4: Conflict handling (bounded mechanical/code-local only)
 
 ### Capture conflicts
+
 In Bash:
 - `git diff --name-only --diff-filter=U`
 - `git status --porcelain=v1`
 
 ### Eligibility gates (ALL must pass or STOP)
+
 STOP if ANY are true:
 - Any conflicted file matches a forbidden pattern:
   - lockfiles: `Cargo.lock`, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `poetry.lock`
@@ -79,6 +88,7 @@ STOP if ANY are true:
 - Any conflict requires product/semantic choice (unclear intent, competing behaviors, or missing context)
 
 ### Mechanical/code-local resolution procedure
+
 - For each eligible conflicted file:
   - Read the file around conflict markers.
   - Resolve by combining both sides when non-overlapping, updating imports/paths/types locally, and keeping changes consistent with nearby code.
@@ -92,7 +102,9 @@ If you hit an out-of-bounds case, STOP and ask the operator to resolve manually,
 </step_4>
 
 <step_5>
+
 ## Step 5: Verification
+
 Run the strongest appropriate checks. Minimum:
 - `just check`
 - `just test`
@@ -100,7 +112,9 @@ If verification fails: STOP with actionable next steps (do not push).
 </step_5>
 
 <step_6>
+
 ## Step 6: Push (normal only, never force)
+
 In Bash:
 - `git push`
 If push is rejected (non-fast-forward) or would require force:
@@ -109,7 +123,9 @@ If push is rejected (non-fast-forward) or would require force:
 </step_6>
 
 <step_7>
+
 ## Step 7: Summary
+
 Report:
 - branch + base ref
 - old/new HEAD

--- a/.opencode/command/sync_with_main_and_resolve_conflicts.md
+++ b/.opencode/command/sync_with_main_and_resolve_conflicts.md
@@ -1,0 +1,130 @@
+---
+description: Sync current branch with origin/main via merge and resolve bounded mechanical conflicts (no force-push)
+agent: OrchestratorOpenAI
+---
+
+<task>
+Sync the CURRENT local worktree branch with the latest origin/main using MERGE (not rebase), resolve only bounded mechanical/code-local conflicts, verify, and push normally when safe.
+
+- Local context only (no Linear ticket required).
+- Never force-push. Never use rebase in v1.
+- If a push is rejected (non-fast-forward) or would require force, STOP with explicit operator instructions.
+</task>
+
+<workflow_contract>
+1. Follow all steps in order.
+2. Use `todowrite` and keep exactly one todo `in_progress`.
+3. All git mutation happens via a Bash child session.
+4. Conflict auto-resolution is ONLY allowed when ALL eligibility gates pass (see below).
+5. Stop immediately (ask a question / hand off) when any explicit stop condition is hit.
+6. Verification must run before declaring success.
+7. Push is normal `git push` only; never force-push.
+</workflow_contract>
+
+<userMessage>
+$ARGUMENTS
+</userMessage>
+
+<process>
+
+<step_1>
+## Step 1: Establish context + todo list
+- Determine current branch (`git branch --show-current`) and base ref (default `origin/main`, fallback `origin/master` if needed).
+- Record whether this was invoked manually or by OuterDAG (treat $ARGUMENTS as optional metadata only).
+- Create todos for: preflight, fetch+behind check, merge attempt, conflict resolution (if needed), verification, push, summary.
+</step_1>
+
+<step_2>
+## Step 2: Preflight safe starting git state (STOP conditions)
+In Bash:
+- `git status --porcelain=v2`
+- `git rev-parse --abbrev-ref HEAD`
+- Detect in-progress operations:
+  - If rebase in progress: STOP (do not convert to merge automatically).
+  - If merge in progress with unmerged paths: continue to conflict workflow (Step 4) rather than starting a new merge.
+STOP if:
+- working tree is dirty (uncommitted/untracked changes) AND no merge is in progress
+- HEAD is detached
+- base ref cannot be resolved after fetch
+</step_2>
+
+<step_3>
+## Step 3: Fetch + merge origin/main (no rebase)
+In Bash:
+- `git fetch origin --prune`
+- If `origin/main` is already merged (ancestor of HEAD), you may still run verification and push if local commits exist.
+- Attempt merge:
+  - `git merge --no-edit origin/main`
+If merge succeeds with no conflicts: proceed to verification (Step 5).
+If merge reports conflicts: proceed to Step 4.
+</step_3>
+
+<step_4>
+## Step 4: Conflict handling (bounded mechanical/code-local only)
+
+### Capture conflicts
+In Bash:
+- `git diff --name-only --diff-filter=U`
+- `git status --porcelain=v1`
+
+### Eligibility gates (ALL must pass or STOP)
+STOP if ANY are true:
+- Any conflicted file matches a forbidden pattern:
+  - lockfiles: `Cargo.lock`, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `poetry.lock`
+  - generated/binary-ish: `*.png`, `*.jpg`, `*.pdf`, `*.svg`, `*.wasm`, `*.bin`
+- Conflict kinds include add/add or modify/delete (porcelain codes like `AA`, `DD`, `UD`, `DU`)
+- More than 5 conflicted files
+- More than 10 total conflict marker blocks across all files (`<<<<<<<` count)
+- Any single file has >3 conflict blocks
+- Any conflict requires product/semantic choice (unclear intent, competing behaviors, or missing context)
+
+### Mechanical/code-local resolution procedure
+- For each eligible conflicted file:
+  - Read the file around conflict markers.
+  - Resolve by combining both sides when non-overlapping, updating imports/paths/types locally, and keeping changes consistent with nearby code.
+  - Do not accept “theirs” or “ours” wholesale unless trivially identical.
+  - Write edits, then `git add <file>`.
+- After all conflicts resolved:
+  - Confirm no unmerged paths remain.
+  - Conclude merge with `git commit --no-edit`.
+
+If you hit an out-of-bounds case, STOP and ask the operator to resolve manually, then respond with “ready” to continue.
+</step_4>
+
+<step_5>
+## Step 5: Verification
+Run the strongest appropriate checks. Minimum:
+- `just check`
+- `just test`
+If verification fails: STOP with actionable next steps (do not push).
+</step_5>
+
+<step_6>
+## Step 6: Push (normal only, never force)
+In Bash:
+- `git push`
+If push is rejected (non-fast-forward) or would require force:
+- STOP and instruct operator to resolve remote divergence manually.
+- Explicitly state: do NOT use `--force` / `--force-with-lease` in this workflow.
+</step_6>
+
+<step_7>
+## Step 7: Summary
+Report:
+- branch + base ref
+- old/new HEAD
+- whether merge commit was created
+- conflicted files (if any) and what was changed
+- verification commands + results
+- push outcome
+</step_7>
+
+</process>
+
+<completion_gate>
+Done only when:
+- branch is clean
+- merge is complete (no unmerged paths)
+- verification passed
+- normal push succeeded (or was unnecessary because no new commits)
+</completion_gate>

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -82,6 +82,7 @@ Steps:
 5. Exercise behind-main auto-sync dispatch and permission/resume flow:
 
    - use a worktree branch that is behind `origin/main`
+   - run the exercise with `--no-linear-handoff` so push-rejection/manual-stop paths never post Linear handoff comments during Phase 1
    - expect detect-only freshness to dispatch `sync_with_main_and_resolve_conflicts`
    - expect permission pauses for `git fetch`, `git merge`, and `git push`
    - confirm the sync policy stays merge-only and never uses force-push

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -42,7 +42,7 @@ Add any human-authored notes below. Content outside autogen blocks is preserved 
 
 ## Phase 1 live-test ladder (conservative)
 
-Goals: exercise worktree selection/creation, state persistence, and existing-PR observation without:
+Goals: exercise worktree selection/creation, state persistence, detect-only freshness checks, auto-dispatched sync behavior, and existing-PR observation without:
 - creating a PR,
 - running `linear_ticket_2_pr`,
 - running `resolve_pr_comments`,
@@ -73,13 +73,21 @@ Steps:
    agentic-outer-dag start --ticket ENG-992 --branch <branch> --stop-after dispatching_ticket_to_pr --no-opencode-dispatch --force
    ```
 
-4. Safety-test dirty/conflict freshness stops without posting Linear comments:
+4. Safety-test dirty-tree freshness stop without posting Linear comments:
 
    ```bash
    agentic-outer-dag start --ticket ENG-992 --branch <branch> --no-linear-handoff --force
    ```
 
-5. Stop before `resolve_pr_comments`:
+5. Exercise behind-main auto-sync dispatch and permission/resume flow:
+
+   - use a worktree branch that is behind `origin/main`
+   - expect detect-only freshness to dispatch `sync_with_main_and_resolve_conflicts`
+   - expect permission pauses for `git fetch`, `git merge`, and `git push`
+   - confirm the sync policy stays merge-only and never uses force-push
+   - if normal `git push` is rejected, confirm the workflow stops with operator instructions instead of using `--force` or `--force-with-lease`
+
+6. Stop before `resolve_pr_comments`:
 
    ```bash
    agentic-outer-dag resume --stop-after waiting_for_coderabbit --no-linear-handoff --no-opencode-dispatch

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -24,6 +24,7 @@ const DETECTING_PR_BACKOFFS: [Duration; 4] = [
     Duration::from_secs(8),
 ];
 const DETECTING_PR_MAX_ATTEMPTS: usize = DETECTING_PR_BACKOFFS.len() + 1;
+const SYNC_WITH_MAIN_COMMAND: &str = "sync_with_main_and_resolve_conflicts";
 
 pub struct DagEngine {
     supervisor: Option<OpenCodeSupervisor>,
@@ -53,7 +54,7 @@ pub fn planned_actions_for_start() -> Vec<PlannedAction> {
         },
         PlannedAction {
             id: "freshness.before_ticket_to_pr",
-            summary: "Freshness gate before ticket_to_pr (fetch/rebase)",
+            summary: "Freshness gate before ticket_to_pr (fetch/check; auto-sync if behind)",
         },
         PlannedAction {
             id: "github.pr.detect_existing",
@@ -69,7 +70,7 @@ pub fn planned_actions_for_start() -> Vec<PlannedAction> {
         },
         PlannedAction {
             id: "freshness.before_coderabbit_wait",
-            summary: "Freshness gate before CodeRabbit wait (fetch/rebase)",
+            summary: "Freshness gate before CodeRabbit wait (fetch/check; auto-sync if behind)",
         },
         PlannedAction {
             id: "github.coderabbit.wait",
@@ -520,36 +521,103 @@ impl DagEngine {
     }
 
     async fn advance_freshness(
-        &self,
+        &mut self,
         state: &mut RunState,
         next_stage: StageKind,
         resume_stage: StageKind,
     ) -> Result<()> {
         let outcome = freshness::run(&state.worktree.base_ref, state.settings.dry_run)?;
         state.freshness.last_checked_at = Some(chrono::Utc::now().to_rfc3339());
-        state.opencode.resume_stage = Some(resume_stage);
+        state.opencode.resume_stage = Some(resume_stage.clone());
         match outcome {
             freshness::FreshnessOutcome::UpToDate => {
                 state.freshness.last_result = Some("up_to_date".to_string());
                 state.stage.kind = next_stage;
                 state.stage.details = None;
             }
-            freshness::FreshnessOutcome::Rebases { old_head, new_head } => {
-                state.freshness.last_result = Some(format!("rebased:{old_head}->{new_head}"));
-                state.stage.kind = next_stage;
-                state.stage.details = Some("rebased onto base ref".to_string());
-                if state.pr.head_sha.is_some() {
-                    state.pr.head_sha = Some(new_head.clone());
-                    state.pr.last_observed_head_sha = Some(new_head);
+            freshness::FreshnessOutcome::Behind { head_sha, base_sha } => {
+                state.freshness.last_result = Some(format!("behind:{head_sha}..{base_sha}"));
+
+                let message = format!(
+                    "OuterDAG freshness gate: branch '{}' is behind {} (HEAD={head_sha}, base={base_sha}). Run merge-based sync, resolve only bounded mechanical conflicts, verify, and push normally (no force).",
+                    state.worktree.branch, state.worktree.base_ref,
+                );
+
+                self.run_supervised_command(
+                    state,
+                    resume_stage.clone(),
+                    SYNC_WITH_MAIN_COMMAND,
+                    Some(message.as_str()),
+                )
+                .await?;
+
+                if stages::is_paused(&state.stage.kind)
+                    || matches!(state.stage.kind, StageKind::StoppedFailed)
+                {
+                    return Ok(());
                 }
-            }
-            freshness::FreshnessOutcome::Conflict => {
-                let message = "rebase conflict requires manual handoff".to_string();
-                state.freshness.last_result = Some("conflict".to_string());
-                state.stage.kind = StageKind::StoppedRebaseConflict;
-                state.stage.details = Some(message);
-                let message = persist_stop_state_before_handoff(state, ThoughtsStateStore::save)?;
-                linear::post_handoff_once(state, &message).await?;
+
+                let post = freshness::run(&state.worktree.base_ref, state.settings.dry_run)?;
+                state.freshness.last_checked_at = Some(chrono::Utc::now().to_rfc3339());
+
+                match post {
+                    freshness::FreshnessOutcome::UpToDate => {
+                        state.freshness.last_result = Some("up_to_date".to_string());
+
+                        if state.pr.number.is_some() {
+                            let branch = state.worktree.branch.clone();
+                            let lookup = self.github.detect_open_pr_from_branch(&branch).await?;
+                            record_pr_lookup(state, resume_stage.clone(), &lookup);
+                            let Some(pr) = lookup.pr else {
+                                state.stage.kind = StageKind::StoppedManualHandoff;
+                                state.stage.details = Some(format!(
+                                    "sync completed but PR could not be re-detected for branch '{branch}'; stopping for human handoff"
+                                ));
+                                let message = persist_stop_state_before_handoff(
+                                    state,
+                                    ThoughtsStateStore::save,
+                                )?;
+                                linear::post_handoff_once(state, &message).await?;
+                                return ThoughtsStateStore::save(state);
+                            };
+
+                            let github = &self.github;
+                            let pr = ensure_pr_ready_for_review(
+                                state,
+                                &pr,
+                                "post_sync_refresh",
+                                |pr| async move { github.mark_ready_for_review(&pr).await },
+                            )
+                            .await?;
+                            persist_detected_pr(state, &pr);
+                        }
+
+                        state.stage.kind = next_stage;
+                        state.stage.details = Some(format!(
+                            "synced with {} via {SYNC_WITH_MAIN_COMMAND}",
+                            state.worktree.base_ref
+                        ));
+                    }
+                    freshness::FreshnessOutcome::Behind { .. } => {
+                        state.stage.kind = StageKind::StoppedManualHandoff;
+                        state.stage.details = Some(format!(
+                            "{SYNC_WITH_MAIN_COMMAND} completed but branch is still behind {}; stopping to avoid infinite redispatch. Operator: run the sync command manually and re-run outer-dag from this worktree.",
+                            state.worktree.base_ref
+                        ));
+                        let message =
+                            persist_stop_state_before_handoff(state, ThoughtsStateStore::save)?;
+                        linear::post_handoff_once(state, &message).await?;
+                    }
+                    freshness::FreshnessOutcome::DirtyTree => {
+                        let message = "dirty worktree blocks freshness gate".to_string();
+                        state.freshness.last_result = Some("dirty_tree".to_string());
+                        state.stage.kind = StageKind::StoppedDirtyTree;
+                        state.stage.details = Some(message);
+                        let message =
+                            persist_stop_state_before_handoff(state, ThoughtsStateStore::save)?;
+                        linear::post_handoff_once(state, &message).await?;
+                    }
+                }
             }
             freshness::FreshnessOutcome::DirtyTree => {
                 let message = "dirty worktree blocks freshness gate".to_string();
@@ -577,7 +645,12 @@ impl DagEngine {
 
         self.supervisor(&state.settings)
             .await?
-            .ensure_commands_present(&[command_name, "linear_ticket_2_pr", "resolve_pr_comments"])
+            .ensure_commands_present(&[
+                command_name,
+                "linear_ticket_2_pr",
+                "resolve_pr_comments",
+                SYNC_WITH_MAIN_COMMAND,
+            ])
             .await?;
         state.opencode.resume_stage = Some(resume_stage.clone());
         state.opencode.dispatch_attempt += 1;

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -598,7 +598,9 @@ impl DagEngine {
                             state.worktree.base_ref
                         ));
                     }
-                    freshness::FreshnessOutcome::Behind { .. } => {
+                    freshness::FreshnessOutcome::Behind { head_sha, base_sha } => {
+                        state.freshness.last_result =
+                            Some(format!("behind:{head_sha}..{base_sha}"));
                         state.stage.kind = StageKind::StoppedManualHandoff;
                         state.stage.details = Some(format!(
                             "{SYNC_WITH_MAIN_COMMAND} completed but branch is still behind {}; stopping to avoid infinite redispatch. Operator: run the sync command manually and re-run outer-dag from this worktree.",

--- a/apps/agentic-outer-dag/src/worktree/freshness.rs
+++ b/apps/agentic-outer-dag/src/worktree/freshness.rs
@@ -7,8 +7,7 @@ use std::process::Command;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FreshnessOutcome {
     UpToDate,
-    Rebases { old_head: String, new_head: String },
-    Conflict,
+    Behind { head_sha: String, base_sha: String },
     DirtyTree,
 }
 
@@ -23,19 +22,14 @@ pub fn run(base_ref: &str, dry_run: bool) -> Result<FreshnessOutcome> {
 
     git(["fetch", "origin", "--prune"])?;
 
-    if !needs_rebase(base_ref)? {
+    if !is_behind_base_ref(base_ref)? {
         return Ok(FreshnessOutcome::UpToDate);
     }
 
-    let old_head = rev_parse("HEAD")?;
-    let status = git_status(["rebase", base_ref])?;
-    if !status.success() {
-        git(["rebase", "--abort"])?;
-        return Ok(FreshnessOutcome::Conflict);
-    }
-    let new_head = rev_parse("HEAD")?;
-
-    Ok(FreshnessOutcome::Rebases { old_head, new_head })
+    Ok(FreshnessOutcome::Behind {
+        head_sha: rev_parse("HEAD")?,
+        base_sha: rev_parse(base_ref)?,
+    })
 }
 
 fn is_dirty() -> Result<bool> {
@@ -44,7 +38,7 @@ fn is_dirty() -> Result<bool> {
     is_worktree_dirty(&repo).context("failed to inspect worktree dirtiness")
 }
 
-fn needs_rebase(base_ref: &str) -> Result<bool> {
+fn is_behind_base_ref(base_ref: &str) -> Result<bool> {
     let output = Command::new("git")
         .args(["merge-base", "--is-ancestor", base_ref, "HEAD"])
         .output()
@@ -116,17 +110,25 @@ mod tests {
     }
 
     #[test]
-    fn rebases_when_origin_main_moves_forward() {
+    fn returns_behind_when_origin_main_moves_forward_and_does_not_mutate_head() {
         let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.advance_main("main update\n").unwrap();
         let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
+        let head_before = rev_parse("HEAD").unwrap();
         let outcome = run("origin/main", false).unwrap();
+        let head_after = rev_parse("HEAD").unwrap();
+
         match outcome {
-            FreshnessOutcome::Rebases { old_head, new_head } => assert_ne!(old_head, new_head),
-            other => panic!("expected rebase outcome, got {other:?}"),
+            FreshnessOutcome::Behind { head_sha, base_sha } => {
+                assert_eq!(head_sha, head_before);
+                assert_ne!(base_sha, head_sha);
+            }
+            other => panic!("expected Behind outcome, got {other:?}"),
         }
+
+        assert_eq!(head_before, head_after, "freshness must not mutate HEAD");
     }
 
     #[test]
@@ -155,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_conflict_when_rebase_hits_merge_conflict() {
+    fn remains_behind_when_feature_and_main_both_change_without_mutating_head() {
         let _guard = process_state_lock().lock().unwrap();
         let fixture = GitFixture::new().unwrap();
         fixture.write_shared_file("feature change\n").unwrap();
@@ -163,13 +165,20 @@ mod tests {
         fixture.advance_main("main change\n").unwrap();
         let _cwd = CwdGuard::pushd(&fixture.feature_clone).unwrap();
 
+        let head_before = rev_parse("HEAD").unwrap();
         let outcome = run("origin/main", false).unwrap();
-
-        assert!(!fixture.rebase_in_progress().unwrap());
+        let head_after = rev_parse("HEAD").unwrap();
         let rerun_outcome = run("origin/main", false).unwrap();
 
-        assert_eq!(outcome, FreshnessOutcome::Conflict);
-        assert_eq!(rerun_outcome, FreshnessOutcome::Conflict);
+        assert_eq!(
+            outcome,
+            FreshnessOutcome::Behind {
+                head_sha: head_before.clone(),
+                base_sha: rev_parse("origin/main").unwrap(),
+            }
+        );
+        assert_eq!(rerun_outcome, outcome);
+        assert_eq!(head_before, head_after, "freshness must not mutate HEAD");
     }
 
     #[test]
@@ -250,12 +259,6 @@ mod tests {
             run_git(&self.feature_clone, ["commit", "-m", message])?;
             Ok(())
         }
-
-        fn rebase_in_progress(&self) -> Result<bool> {
-            let git_dir = git_output(&self.feature_clone, ["rev-parse", "--git-dir"])?;
-            let git_dir = self.feature_clone.join(git_dir);
-            Ok(git_dir.join("rebase-apply").exists() || git_dir.join("rebase-merge").exists())
-        }
     }
 
     fn configure_repo(path: &Path) -> Result<()> {
@@ -268,19 +271,6 @@ mod tests {
         let output = Command::new("git").current_dir(cwd).args(args).output()?;
         if output.status.success() {
             Ok(())
-        } else {
-            anyhow::bail!(
-                "git {} failed: {}",
-                args.join(" "),
-                String::from_utf8_lossy(&output.stderr).trim()
-            )
-        }
-    }
-
-    fn git_output<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
-        let output = Command::new("git").current_dir(cwd).args(args).output()?;
-        if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
         } else {
             anyhow::bail!(
                 "git {} failed: {}",


### PR DESCRIPTION
Placeholder: describe_pr will update this PR description.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

OuterDAG’s freshness gate handled branches behind `origin/main` by mutating the branch with a local rebase. That was the wrong recovery model for supervised automation because it could rewrite branch history, made conflict recovery harder to resume safely, and did not provide a bounded operator workflow for syncing stale branches.

ENG-1023 changes freshness handling to detect that a branch is behind main, then dispatch a dedicated merge-based sync command that can be supervised, paused for permissions, verified, and pushed normally without force-push behavior.

## What user-facing changes did I ship?

- Added `/sync_with_main_and_resolve_conflicts`, an OpenCode command that syncs the current branch with `origin/main` using `git merge --no-edit origin/main`.
- The sync command explicitly forbids rebase and force-push in v1.
- The sync command can resolve only bounded mechanical/code-local conflicts, with explicit stop conditions for risky files, complex conflict shapes, too many conflicts, semantic/product decisions, dirty worktrees, detached HEAD, and non-fast-forward push rejection.
- OuterDAG freshness gates now report behind-main state and dispatch the sync command instead of rebasing automatically.
- After a successful sync, OuterDAG re-runs freshness, refreshes existing PR metadata when applicable, and ensures the PR remains ready for review.
- Updated `agentic-outer-dag` live-test guidance to cover detect-only freshness checks, auto-dispatched sync behavior, permission/resume flow, normal push behavior, and force-push rejection.

## How I implemented it

- Added `.opencode/command/sync_with_main_and_resolve_conflicts.md` with a step-by-step merge-only workflow:
  - preflight git state checks,
  - `git fetch origin --prune`,
  - merge from `origin/main`,
  - bounded conflict eligibility gates,
  - `just check` / `just test` verification before success,
  - normal `git push` only.
- Replaced freshness rebase outcomes with a detect-only `FreshnessOutcome::Behind { head_sha, base_sha }` in `apps/agentic-outer-dag/src/worktree/freshness.rs`.
- Changed freshness detection to fetch and use `git merge-base --is-ancestor <base> HEAD` to determine whether the branch is behind without mutating `HEAD`.
- Updated freshness tests so behind-main and conflict-shaped divergence both verify that `HEAD` is unchanged and the check is repeatable.
- Updated `DagEngine::advance_freshness` so a behind branch dispatches `sync_with_main_and_resolve_conflicts`, handles permission/failure pauses, rechecks freshness after completion, avoids infinite redispatch if the branch is still behind, and refreshes detected PR state after sync.
- Included the new sync command in supervised command availability checks so OuterDAG fails early if the required OpenCode command is missing.
- Updated the generated app guidance in `apps/agentic-outer-dag/CLAUDE.md` to document the new Phase 1 sync validation path.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-check agentic-outer-dag-bin` passed
- [x] `just crate-test agentic-outer-dag-bin` passed
- [x] `just check` passed
- [x] `just test` passed

## Description for the changelog

Add merge-based OuterDAG branch sync for behind-main freshness gates, replacing automatic rebase mutation with a supervised no-force sync command and detect-only freshness checks.
<!-- END:describe_pr:autogen -->
