### PR TITLE
fix(opencode-orchestrator-mcp): harden command supervision after ambiguous transport failures

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -42,6 +42,7 @@ use agentic_tools_core::ToolRegistry;
 use agentic_tools_core::fmt::TextFormat;
 use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
+use opencode_rs::OpencodeError;
 use opencode_rs::types::event::Event;
 use opencode_rs::types::message::CommandRequest;
 use opencode_rs::types::message::Message;
@@ -59,6 +60,8 @@ use opencode_rs::types::session::SummarizeRequest;
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use tokio::task::JoinHandle;
 
 const SERVER_NAME: &str = "opencode-orchestrator-mcp";
@@ -78,6 +81,12 @@ struct RunOutcome {
 enum PermissionPreflightMode {
     Strict,
     RespondPermissionContinuation,
+}
+
+#[derive(Debug, Clone)]
+struct CommandTranscriptWindow {
+    command_message_id: String,
+    baseline_tail_message_id: Option<String>,
 }
 
 fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
@@ -128,11 +137,36 @@ impl RunOutcome {
     }
 }
 
-async fn abort_command_task(task: &mut Option<JoinHandle<Result<(), String>>>) {
+async fn abort_command_task(task: &mut Option<JoinHandle<Result<(), OpencodeError>>>) {
     if let Some(handle) = task.take() {
         handle.abort();
         let _ = handle.await;
     }
+}
+
+fn make_command_message_id(session_id: &str) -> String {
+    let issued_at_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("orchestrator-command-{session_id}-{issued_at_nanos}")
+}
+
+fn transcript_indicates_command_dispatch(
+    messages: &[Message],
+    transcript_window: &CommandTranscriptWindow,
+) -> bool {
+    if messages
+        .iter()
+        .any(|message| message.id() == transcript_window.command_message_id)
+    {
+        return true;
+    }
+
+    transcript_window
+        .baseline_tail_message_id
+        .as_ref()
+        .and_then(|baseline| messages.iter().position(|message| message.id() == baseline))
+        .is_some_and(|index| index + 1 < messages.len())
 }
 
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
@@ -589,11 +623,25 @@ impl OrchestratorRunTool {
         }
 
         // 6. Kick off the work
-        let mut command_task: Option<JoinHandle<Result<(), String>>> = None;
+        let mut command_task: Option<JoinHandle<Result<(), OpencodeError>>> = None;
         let mut command_name_for_logging: Option<String> = None;
+        let mut command_transcript_window: Option<CommandTranscriptWindow> = None;
 
         if let Some(command) = &input.command {
             command_name_for_logging = Some(command.clone());
+
+            let command_message_id = make_command_message_id(&session_id);
+            // Keep transcript usage narrowly scoped to transport-error start-evidence checks.
+            let baseline_tail_message_id = client
+                .messages()
+                .list(&session_id)
+                .await
+                .ok()
+                .and_then(|messages| messages.last().map(|message| message.id().to_string()));
+            command_transcript_window = Some(CommandTranscriptWindow {
+                command_message_id: command_message_id.clone(),
+                baseline_tail_message_id,
+            });
 
             let cmd_client = client.clone();
             let cmd_session_id = session_id.clone();
@@ -601,10 +649,13 @@ impl OrchestratorRunTool {
             let cmd_arguments = message.clone().unwrap_or_default();
 
             command_task = Some(tokio::spawn(async move {
+                // OpenCode's /command request is completion-coupled rather than fire-and-forget.
+                // Once start evidence exists, later transport failures are ambiguous and we must
+                // continue supervision via SSE + status polling instead of retrying blindly.
                 let req = CommandRequest {
                     command: cmd_name,
                     arguments: cmd_arguments,
-                    message_id: None,
+                    message_id: Some(command_message_id),
                 };
 
                 cmd_client
@@ -612,7 +663,6 @@ impl OrchestratorRunTool {
                     .command(&cmd_session_id, &req)
                     .await
                     .map(|_| ())
-                    .map_err(|e| e.to_string())
             }));
         } else if let Some(msg) = &message {
             // Send prompt asynchronously
@@ -985,7 +1035,7 @@ impl OrchestratorRunTool {
                         Some(handle) => Some(handle.await),
                         None => {
                             std::future::pending::<
-                                Option<Result<Result<(), String>, tokio::task::JoinError>>,
+                                Option<Result<Result<(), OpencodeError>, tokio::task::JoinError>>,
                             >()
                             .await
                         }
@@ -1001,16 +1051,97 @@ impl OrchestratorRunTool {
                             );
                             command_task = None;
                         }
-                        Some(Ok(Err(e))) => {
+                        Some(Ok(Err(error))) => {
+                            let command_name = command_name_for_logging.as_deref().unwrap_or("unknown");
+
+                            if error.is_validation_error() || error.is_not_found() {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    command = command_name,
+                                    error = %error,
+                                    "run: command dispatch rejected before start"
+                                );
+                                return Err(ToolError::InvalidInput(format!(
+                                    "Failed to dispatch command '{command_name}': {error}"
+                                )));
+                            }
+
+                            if !matches!(error, OpencodeError::Transport(_)) {
+                                tracing::error!(
+                                    session_id = %session_id,
+                                    command = command_name,
+                                    error = %error,
+                                    "run: command dispatch failed"
+                                );
+                                return Err(ToolError::Internal(format!(
+                                    "Failed to dispatch command '{command_name}': {error}"
+                                )));
+                            }
+
+                            let mut start_evidence = observed_busy;
+
+                            if !start_evidence
+                                && let Ok(status) = client.sessions().status_for(&session_id).await
+                                && status.is_busy_like()
+                            {
+                                start_evidence = true;
+                                observed_busy = true;
+                                last_activity_time = tokio::time::Instant::now();
+                                awaiting_idle_grace_check = false;
+                            }
+
+                            if !start_evidence
+                                && let Some(transcript_window) = command_transcript_window.as_ref()
+                            {
+                                // This bounded transcript probe only decides whether dispatch
+                                // already started after an ambiguous /command transport failure.
+                                match client.messages().list(&session_id).await {
+                                    Ok(messages)
+                                        if transcript_indicates_command_dispatch(
+                                            &messages,
+                                            transcript_window,
+                                        ) =>
+                                    {
+                                        start_evidence = true;
+                                        idle_grace_deadline.get_or_insert_with(|| {
+                                            tokio::time::Instant::now() + idle_grace
+                                        });
+                                        last_activity_time = tokio::time::Instant::now();
+                                    }
+                                    Ok(_) => {}
+                                    Err(probe_error) => {
+                                        tracing::warn!(
+                                            session_id = %session_id,
+                                            command = command_name,
+                                            error = %probe_error,
+                                            "run: transcript probe failed after command transport error"
+                                        );
+                                    }
+                                }
+                            }
+
+                            if start_evidence {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    command = command_name,
+                                    error = %error,
+                                    "run: command transport error after start evidence; continuing supervision"
+                                );
+                                warnings.push(format!(
+                                    "OpenCode command transport error after start evidence; continuing supervision: {error}"
+                                ));
+                                command_task = None;
+                                continue;
+                            }
+
                             tracing::error!(
                                 session_id = %session_id,
-                                command = ?command_name_for_logging,
-                                error = %e,
-                                "run: command dispatch failed"
+                                command = command_name,
+                                error = %error,
+                                "run: command transport error before start evidence"
                             );
                             return Err(ToolError::Internal(format!(
-                                "Failed to execute command '{}': {e}",
-                                command_name_for_logging.as_deref().unwrap_or("unknown")
+                                "Failed to dispatch command '{command_name}': transport error before session start evidence: {error}"
                             )));
                         }
                         Some(Err(join_err)) => {

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -86,7 +86,6 @@ enum PermissionPreflightMode {
 #[derive(Debug, Clone)]
 struct CommandTranscriptWindow {
     command_message_id: String,
-    baseline_tail_message_id: Option<String>,
 }
 
 fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
@@ -155,18 +154,9 @@ fn transcript_indicates_command_dispatch(
     messages: &[Message],
     transcript_window: &CommandTranscriptWindow,
 ) -> bool {
-    if messages
+    messages
         .iter()
         .any(|message| message.id() == transcript_window.command_message_id)
-    {
-        return true;
-    }
-
-    transcript_window
-        .baseline_tail_message_id
-        .as_ref()
-        .and_then(|baseline| messages.iter().position(|message| message.id() == baseline))
-        .is_some_and(|index| index + 1 < messages.len())
 }
 
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
@@ -631,16 +621,8 @@ impl OrchestratorRunTool {
             command_name_for_logging = Some(command.clone());
 
             let command_message_id = make_command_message_id(&session_id);
-            // Keep transcript usage narrowly scoped to transport-error start-evidence checks.
-            let baseline_tail_message_id = client
-                .messages()
-                .list(&session_id)
-                .await
-                .ok()
-                .and_then(|messages| messages.last().map(|message| message.id().to_string()));
             command_transcript_window = Some(CommandTranscriptWindow {
                 command_message_id: command_message_id.clone(),
-                baseline_tail_message_id,
             });
 
             let cmd_client = client.clone();

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -8,9 +8,6 @@ use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use opencode_orchestrator_mcp::config::OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS;
-use opencode_orchestrator_mcp::server::OrchestratorServer;
-use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
-use opencode_orchestrator_mcp::server::RecoveryMode;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
 use opencode_orchestrator_mcp::tools::RespondPermissionTool;
 use opencode_orchestrator_mcp::types::OrchestratorRunInput;
@@ -39,6 +36,7 @@ use support::permission_fixture;
 use support::permission_fixture_with_metadata;
 use support::permission_patch_file_array_bad_request_fixture;
 use support::session_fixture;
+use support::short_timeout_test_orchestrator_server;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::test_orchestrator_server;
@@ -47,29 +45,6 @@ static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
     ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await
-}
-
-async fn short_timeout_server(mock: &MockServer) -> Arc<OrchestratorServerHandle> {
-    Mock::given(method("GET"))
-        .and(path("/global/health"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "healthy": true,
-            "version": "test",
-        })))
-        .mount(mock)
-        .await;
-
-    let base_url = mock.uri().trim_end_matches('/').to_string();
-    let client = opencode_rs::ClientBuilder::new()
-        .base_url(&base_url)
-        .directory("/tmp".to_string())
-        .timeout_secs(1)
-        .build()
-        .expect("short-timeout test client should build");
-
-    Arc::new(OrchestratorServerHandle::from_server_unshared(
-        OrchestratorServer::from_client_unshared(client, &base_url, RecoveryMode::External),
-    ))
 }
 
 struct EnvVarGuard(&'static str);
@@ -134,8 +109,9 @@ async fn assert_command_dispatch_invalid_input(status: u16, body: serde_json::Va
         .mount(&mock)
         .await;
 
-    let err = tool
-        .call(
+    let err = timeout(
+        Duration::from_secs(5),
+        tool.call(
             OrchestratorRunInput {
                 session_id: Some(sid.clone()),
                 command: Some("implement_plan".into()),
@@ -144,9 +120,11 @@ async fn assert_command_dispatch_invalid_input(status: u16, body: serde_json::Va
                 wait_for_activity: None,
             },
             &ToolContext::default(),
-        )
-        .await
-        .expect_err("400/404 command dispatch should be invalid input");
+        ),
+    )
+    .await
+    .expect("invalid command dispatch regression should not hang")
+    .expect_err("400/404 command dispatch should be invalid input");
 
     match err {
         ToolError::InvalidInput(message) => {
@@ -748,7 +726,7 @@ async fn command_transport_error_after_start_evidence_warns_and_completes() {
     unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
 
     let mock = MockServer::start().await;
-    let server = short_timeout_server(&mock).await;
+    let server = short_timeout_test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
     let sid = "command-transport-post-start";
 
@@ -875,7 +853,7 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
     unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
 
     let mock = MockServer::start().await;
-    let server = short_timeout_server(&mock).await;
+    let server = short_timeout_test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
     let sid = "command-transport-pre-start";
 
@@ -960,6 +938,19 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
         }
         other => panic!("expected internal dispatch failure, got {other:?}"),
     }
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let command_posts = requests
+        .iter()
+        .filter(|request| request.url.path() == format!("/session/{sid}/command"))
+        .count();
+    assert_eq!(
+        command_posts, 1,
+        "transport ambiguity must not trigger command retry"
+    );
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -8,6 +8,9 @@ use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
 use agentic_tools_core::ToolError;
 use opencode_orchestrator_mcp::config::OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS;
+use opencode_orchestrator_mcp::server::OrchestratorServer;
+use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
+use opencode_orchestrator_mcp::server::RecoveryMode;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
 use opencode_orchestrator_mcp::tools::RespondPermissionTool;
 use opencode_orchestrator_mcp::types::OrchestratorRunInput;
@@ -28,6 +31,8 @@ use wiremock::matchers::path_regex;
 use wiremock::matchers::query_param;
 
 use support::SequenceResponder;
+use support::message_fixture;
+use support::message_history_fixture;
 use support::messages_fixture;
 use support::patch_file_metadata_fixture;
 use support::permission_fixture;
@@ -44,12 +49,112 @@ async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
     ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await
 }
 
+async fn short_timeout_server(mock: &MockServer) -> Arc<OrchestratorServerHandle> {
+    Mock::given(method("GET"))
+        .and(path("/global/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "healthy": true,
+            "version": "test",
+        })))
+        .mount(mock)
+        .await;
+
+    let base_url = mock.uri().trim_end_matches('/').to_string();
+    let client = opencode_rs::ClientBuilder::new()
+        .base_url(&base_url)
+        .directory("/tmp".to_string())
+        .timeout_secs(1)
+        .build()
+        .expect("short-timeout test client should build");
+
+    Arc::new(OrchestratorServerHandle::from_server_unshared(
+        OrchestratorServer::from_client_unshared(client, &base_url, RecoveryMode::External),
+    ))
+}
+
 struct EnvVarGuard(&'static str);
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
         unsafe { std::env::remove_var(self.0) };
+    }
+}
+
+async fn assert_command_dispatch_invalid_input(status: u16, body: serde_json::Value) {
+    let _guard = env_lock().await;
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = format!("command-invalid-input-{status}");
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(&sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(message_history_fixture(vec![])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
+        .mount(&mock)
+        .await;
+
+    let err = tool
+        .call(
+            OrchestratorRunInput {
+                session_id: Some(sid.clone()),
+                command: Some("implement_plan".into()),
+                agent: None,
+                message: Some("args".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+        .expect_err("400/404 command dispatch should be invalid input");
+
+    match err {
+        ToolError::InvalidInput(message) => {
+            let lower = message.to_lowercase();
+            assert!(lower.contains("failed to dispatch command 'implement_plan'"));
+            assert!(lower.contains("bad request") || lower.contains("not found"));
+        }
+        other => panic!("expected invalid input error, got {other:?}"),
     }
 }
 
@@ -633,4 +738,244 @@ async fn respond_permission_reply_404_is_actionable_invalid_input() {
             .map(|request| request.url.path().to_string())
             .collect::<Vec<_>>()
     );
+}
+
+#[tokio::test]
+async fn command_transport_error_after_start_evidence_warns_and_completes() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
+    let mock = MockServer::start().await;
+    let server = short_timeout_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "command-transport-post-start";
+
+    let baseline_messages =
+        message_history_fixture(vec![message_fixture(sid, "u0", "user", 1, None, vec![])]);
+    let transcript_with_command = message_history_fixture(vec![
+        message_fixture(sid, "u0", "user", 1, None, vec![]),
+        message_fixture(sid, "cmd-user", "user", 3, None, vec![]),
+    ]);
+    let completed_messages = message_history_fixture(vec![
+        message_fixture(sid, "u0", "user", 1, None, vec![]),
+        message_fixture(sid, "cmd-user", "user", 3, None, vec![]),
+        message_fixture(
+            sid,
+            "a1",
+            "assistant",
+            4,
+            Some(4),
+            vec![serde_json::json!({"type": "text", "text": "COMMAND_DONE"})],
+        ),
+    ]);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(baseline_messages),
+            ResponseTemplate::new(200).set_body_json(transcript_with_command),
+            ResponseTemplate::new(200).set_body_json(completed_messages),
+        ]))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"status": "executed"}))
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(5),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: Some("implement_plan".into()),
+                agent: None,
+                message: Some("args".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("post-start transport regression should not hang")
+    .expect("post-start transport regression should complete with warning");
+
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("COMMAND_DONE"));
+    assert!(result.warnings.iter().any(|warning| {
+        warning.contains("transport error") && warning.contains("continuing supervision")
+    }));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let command_posts = requests
+        .iter()
+        .filter(|request| request.url.path() == format!("/session/{sid}/command"))
+        .count();
+    assert_eq!(
+        command_posts, 1,
+        "transport ambiguity must not trigger command retry"
+    );
+}
+
+#[tokio::test]
+async fn command_transport_error_before_start_evidence_fails_clearly() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
+    let mock = MockServer::start().await;
+    let server = short_timeout_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "command-transport-pre-start";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(message_history_fixture(vec![])),
+            ResponseTemplate::new(200).set_body_json(message_history_fixture(vec![])),
+        ]))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"status": "executed"}))
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let err = timeout(
+        Duration::from_secs(5),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: Some("implement_plan".into()),
+                agent: None,
+                message: Some("args".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("pre-start transport regression should not hang")
+    .expect_err("pre-start transport regression should fail clearly");
+
+    match err {
+        ToolError::Internal(message) => {
+            let lower = message.to_lowercase();
+            assert!(lower.contains("transport error before session start evidence"));
+            assert!(lower.contains("failed to dispatch command 'implement_plan'"));
+        }
+        other => panic!("expected internal dispatch failure, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn command_dispatch_400_is_actionable_invalid_input() {
+    assert_command_dispatch_invalid_input(
+        400,
+        serde_json::json!({"name": "BadRequest", "message": "Bad request"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn command_dispatch_404_is_actionable_invalid_input() {
+    assert_command_dispatch_invalid_input(
+        404,
+        serde_json::json!({"name": "NotFound", "message": "Not found"}),
+    )
+    .await;
 }

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -4,10 +4,9 @@
 //! - IT-BUG1: Empty responses after permission completion (message extraction race)
 //! - IT-BUG2: Misleading response on rejection (returns stale pre-rejection text)
 //! - IT-BUG3: Session requires resumption to get response (same race as BUG1)
-//! - IT-BUG4: Network error on command dispatch (no bounded HTTP retry)
+//! - IT-BUG4: Network error on command dispatch without unsafe orchestrator retry
 //!
-//! The tests are designed to FAIL on current code (pre-fix), confirming the bugs exist.
-//! After implementing fixes, all tests should PASS.
+//! These regressions lock in the current intended behavior for each historical bug.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -492,18 +491,15 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     assert_eq!(result.response.as_deref(), Some("POST_PERMISSION_TEXT"));
 }
 
-/// IT-BUG4: Command dispatch should retry on transport-level timeout.
-///
-/// Pre-fix behavior: First timeout error propagates immediately.
-/// Post-fix behavior: Retry succeeds, command executes.
+/// IT-BUG4: Command transport failures must not be retried without start evidence.
 #[tokio::test]
-async fn it_bug4_command_dispatch_retries_on_transport_error() {
+async fn it_bug4_command_dispatch_transport_error_does_not_retry_without_start_evidence() {
     let mock = MockServer::start().await;
-    // Use short timeout client (1 second)
     let base_url = mock.uri().trim_end_matches('/').to_string();
     let client = opencode_rs::ClientBuilder::new()
         .base_url(&base_url)
-        .timeout_secs(1) // 1 second timeout
+        .directory("/tmp".to_string())
+        .timeout_secs(1)
         .build()
         .unwrap();
     let server = Arc::new(OrchestratorServerHandle::from_server_unshared(
@@ -532,12 +528,9 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
         .mount(&mock)
         .await;
 
-    // GET /session/status - busy initially, then idle (after command succeeds)
-    // Multiple busy responses to handle initial check + polling
     let status_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)), // initial check
-        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)), // poll: sets observed_busy=true
-        ResponseTemplate::new(200).set_body_json(status_v2_idle()), // poll: idle, triggers completion
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
     Mock::given(method("GET"))
         .and(path("/session/status"))
@@ -558,12 +551,13 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
         .mount(&mock)
         .await;
 
-    // GET /session/s4/message
+    // GET /session/s4/message - baseline and transcript probe both show no start evidence.
     Mock::given(method("GET"))
         .and(path("/session/s4/message"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("COMMAND_RESULT"))),
-        )
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+        ]))
         .mount(&mock)
         .await;
 
@@ -578,33 +572,18 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
         .mount(&mock)
         .await;
 
-    // POST /session/s4/command - FIRST: timeout (delay > client timeout), SECOND: success
-    // Note: wiremock-rs doesn't have Fault types, so we use set_delay to cause timeout
-
-    // Mount first request with long delay (causes timeout)
     Mock::given(method("POST"))
         .and(path("/session/s4/command"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(serde_json::json!({"status": "executed"}))
-                .set_delay(Duration::from_secs(30)), // 30s delay > 1s timeout
-        )
-        .up_to_n_times(1) // Only first request
-        .mount(&mock)
-        .await;
-
-    // Mount second request with immediate response
-    Mock::given(method("POST"))
-        .and(path("/session/s4/command"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "executed"})),
+                .set_delay(Duration::from_secs(30)),
         )
         .mount(&mock)
         .await;
 
-    // Act
-    let result = timeout(
-        Duration::from_secs(15), // Overall test timeout
+    let err = timeout(
+        Duration::from_secs(5),
         tool.call(
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
@@ -617,20 +596,22 @@ async fn it_bug4_command_dispatch_retries_on_transport_error() {
         ),
     )
     .await
-    .expect("test timed out");
+    .expect("test timed out")
+    .expect_err("transport error without start evidence should fail");
 
-    // Assert
-    // Pre-fix: Error returned due to timeout on first command attempt
-    // Post-fix: Retry succeeds, status is Completed
-    assert!(
-        result.is_ok(),
-        "Pre-fix: command times out; Post-fix: retry succeeds. Got error: {:?}",
-        result.err()
-    );
+    let message = err.to_string().to_lowercase();
+    assert!(message.contains("transport error before session start evidence"));
 
-    let output = result.unwrap();
-    assert!(
-        matches!(output.status, RunStatus::Completed),
-        "expected Completed status after retry"
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let command_posts = requests
+        .iter()
+        .filter(|request| request.url.path() == "/session/s4/command")
+        .count();
+    assert_eq!(
+        command_posts, 1,
+        "orchestrator must not retry ambiguous transport errors"
     );
 }

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -14,7 +14,6 @@ mod support;
 
 use agentic_tools_core::Tool;
 use agentic_tools_core::ToolContext;
-use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
 use opencode_orchestrator_mcp::tools::RespondPermissionTool;
 use opencode_orchestrator_mcp::types::OrchestratorRunInput;
@@ -36,6 +35,7 @@ use support::SwitchAfterCallsResponder;
 use support::messages_fixture;
 use support::permission_fixture;
 use support::session_fixture;
+use support::short_timeout_test_orchestrator_server;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::status_v2_retry;
@@ -495,31 +495,9 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
 #[tokio::test]
 async fn it_bug4_command_dispatch_transport_error_does_not_retry_without_start_evidence() {
     let mock = MockServer::start().await;
-    let base_url = mock.uri().trim_end_matches('/').to_string();
-    let client = opencode_rs::ClientBuilder::new()
-        .base_url(&base_url)
-        .directory("/tmp".to_string())
-        .timeout_secs(1)
-        .build()
-        .unwrap();
-    let server = Arc::new(OrchestratorServerHandle::from_server_unshared(
-        opencode_orchestrator_mcp::server::OrchestratorServer::from_client_unshared(
-            client,
-            &base_url,
-            opencode_orchestrator_mcp::server::RecoveryMode::External,
-        ),
-    ));
+    let server = short_timeout_test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
     let sid = "s4";
-
-    Mock::given(method("GET"))
-        .and(path("/global/health"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "healthy": true,
-            "version": "test",
-        })))
-        .mount(&mock)
-        .await;
 
     // GET /session/s4
     Mock::given(method("GET"))

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -63,6 +63,33 @@ pub async fn test_orchestrator_server_with_config(
     ))
 }
 
+/// Build an `OrchestratorServerHandle` connected to a wiremock `MockServer`
+/// with a one-second client timeout for transport-failure tests.
+pub async fn short_timeout_test_orchestrator_server(
+    mock: &MockServer,
+) -> Arc<OrchestratorServerHandle> {
+    Mock::given(method("GET"))
+        .and(path("/global/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "healthy": true,
+            "version": "test",
+        })))
+        .mount(mock)
+        .await;
+
+    let base_url = mock.uri().trim_end_matches('/').to_string();
+    let client = opencode_rs::ClientBuilder::new()
+        .base_url(&base_url)
+        .directory("/tmp".to_string())
+        .timeout_secs(1)
+        .build()
+        .unwrap();
+
+    Arc::new(OrchestratorServerHandle::from_server_unshared(
+        OrchestratorServer::from_client_unshared(client, &base_url, RecoveryMode::External),
+    ))
+}
+
 /// Respond with different responses in sequence; after exhausting, repeat last.
 ///
 /// This is useful for simulating scenarios like:

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -36,31 +36,7 @@ pub async fn test_orchestrator_server_with_config(
     mock: &MockServer,
     config: OrchestratorConfig,
 ) -> Arc<OrchestratorServerHandle> {
-    Mock::given(method("GET"))
-        .and(path("/global/health"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "healthy": true,
-            "version": "test",
-        })))
-        .mount(mock)
-        .await;
-
-    let base_url = mock.uri().trim_end_matches('/').to_string();
-    let client = opencode_rs::ClientBuilder::new()
-        .base_url(&base_url)
-        .directory("/tmp".to_string())
-        .timeout_secs(5) // Short timeout for tests
-        .build()
-        .unwrap();
-
-    Arc::new(OrchestratorServerHandle::from_server_unshared(
-        OrchestratorServer::from_client_unshared_with_config(
-            client,
-            base_url,
-            RecoveryMode::External,
-            config,
-        ),
-    ))
+    build_test_orchestrator_server(mock, 5, Some(config)).await
 }
 
 /// Build an `OrchestratorServerHandle` connected to a wiremock `MockServer`
@@ -68,6 +44,34 @@ pub async fn test_orchestrator_server_with_config(
 pub async fn short_timeout_test_orchestrator_server(
     mock: &MockServer,
 ) -> Arc<OrchestratorServerHandle> {
+    build_test_orchestrator_server(mock, 1, None).await
+}
+
+async fn build_test_orchestrator_server(
+    mock: &MockServer,
+    timeout_secs: u64,
+    config: Option<OrchestratorConfig>,
+) -> Arc<OrchestratorServerHandle> {
+    mount_test_health(mock).await;
+
+    let base_url = mock.uri().trim_end_matches('/').to_string();
+    let client = build_test_client(&base_url, timeout_secs);
+
+    let server = if let Some(config) = config {
+        OrchestratorServer::from_client_unshared_with_config(
+            client,
+            base_url,
+            RecoveryMode::External,
+            config,
+        )
+    } else {
+        OrchestratorServer::from_client_unshared(client, &base_url, RecoveryMode::External)
+    };
+
+    Arc::new(OrchestratorServerHandle::from_server_unshared(server))
+}
+
+async fn mount_test_health(mock: &MockServer) {
     Mock::given(method("GET"))
         .and(path("/global/health"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -76,18 +80,18 @@ pub async fn short_timeout_test_orchestrator_server(
         })))
         .mount(mock)
         .await;
+}
 
-    let base_url = mock.uri().trim_end_matches('/').to_string();
-    let client = opencode_rs::ClientBuilder::new()
-        .base_url(&base_url)
+fn build_test_client(base_url: &str, timeout_secs: u64) -> opencode_rs::Client {
+    match opencode_rs::ClientBuilder::new()
+        .base_url(base_url)
         .directory("/tmp".to_string())
-        .timeout_secs(1)
+        .timeout_secs(timeout_secs)
         .build()
-        .unwrap();
-
-    Arc::new(OrchestratorServerHandle::from_server_unshared(
-        OrchestratorServer::from_client_unshared(client, &base_url, RecoveryMode::External),
-    ))
+    {
+        Ok(client) => client,
+        Err(error) => panic!("failed to build test OpenCode client for {base_url}: {error}"),
+    }
 }
 
 /// Respond with different responses in sequence; after exhausting, repeat last.


### PR DESCRIPTION
Verification passed: just crate-test opencode-orchestrator-mcp, just crate-check opencode-orchestrator-mcp, just crate-test opencode_rs, just check, just test.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-1047 hardens `opencode-orchestrator-mcp` command supervision around OpenCode `/command` requests. Those requests are completion-coupled, so a transport timeout or dropped response can mean either:

- the command never started, and the orchestrator should fail clearly, or
- the command already started, and retrying could dispatch duplicate work.

The previous behavior treated command dispatch failures too generically and the historical IT-BUG4 expectation still assumed a bounded retry. That was unsafe for completion-coupled commands because an ambiguous transport failure after start evidence must not be retried.

## What user-facing changes did I ship?

- `/command` runs now preserve typed `opencode_rs::OpencodeError` values instead of stringifying them, so the orchestrator can distinguish validation/not-found errors, non-transport failures, and transport ambiguity.
- Validation and not-found command dispatch failures now surface as actionable invalid input errors.
- Transport errors before any session start evidence fail clearly with `transport error before session start evidence`.
- Transport errors after start evidence no longer abort the run or retry the command. The orchestrator records a warning and continues supervising through status polling/SSE until completion.
- No intentional breaking configuration or API changes.

## How I implemented it

- Added a generated orchestrator command `message_id` and a narrow `CommandTranscriptWindow` so the run tool can detect whether the command appeared in the transcript, or whether new transcript messages appeared after the pre-command baseline.
- Captured the transcript tail before command dispatch and passed the generated command message id into `CommandRequest`.
- Kept the command task error typed as `OpencodeError`, then classified outcomes in supervision:
  - validation/not-found -> `ToolError::InvalidInput`
  - non-transport dispatch errors -> `ToolError::Internal`
  - transport errors -> probe for start evidence via observed busy state, a fresh status check, and a bounded transcript check
- If start evidence exists after a transport error, supervision continues without retry and includes a warning in the result.
- If no start evidence exists, the run fails with a clear internal error rather than retrying an ambiguous command.
- Added wiremock regression coverage for post-start transport ambiguity, pre-start transport failure, 400/404 actionable command dispatch errors, and the revised IT-BUG4 no-retry expectation.

## How to verify it

- [x] Verification passed for the committed diff:
  - `just crate-test opencode-orchestrator-mcp`
  - `just crate-check opencode-orchestrator-mcp`
  - `just crate-test opencode_rs`
  - `just check`
  - `just test`

## Description for the changelog

Harden `opencode-orchestrator-mcp` command supervision so ambiguous OpenCode `/command` transport failures are not retried after start evidence, while pre-start failures and actionable dispatch errors surface clearly.
<!-- END:describe_pr:autogen -->
