### PR TITLE
chore: upgrade Rust toolchain to 1.96.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly, 1.93.0
+          toolchain: nightly, 1.96.1
           components: rustfmt, clippy
           cache: true
 
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           cache: true
 
       - name: Install tools
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           cache: true
 
       - name: Install just
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           cache: true
 
       - name: Install tools

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           cache: true
 
       - name: Sync generated files

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           cache: true
           rustflags: ""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ just codex-run -- <args>  # Run the vendored codex binary
 
 ## Toolchain and Formatter Quirks
 
-- Stable toolchain pinned to `1.93.0` (`rust-toolchain.toml`).
+- Stable toolchain pinned to `1.96.1` (`rust-toolchain.toml`).
 - Formatting requires nightly: `just fmt` and `just fmt-check` run `cargo +nightly fmt`. Running `cargo fmt` without `+nightly` uses the wrong edition settings and fails.
 - `rustfmt.toml` uses `edition = "2024"` and `imports_granularity = "Item"`; do not change these.
 - `just test` runs `mcp-test` (MCP schema validation via `npx @modelcontextprotocol/inspector`) before nextest. Node.js and `npx` must be available.

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-const IDLE_GRACE: Duration = Duration::from_millis(1000);
+const IDLE_GRACE: Duration = Duration::from_secs(1);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const TRANSCRIPT_SETTLING_RETRY_BACKOFFS: [Duration; 4] = [
     Duration::from_millis(50),
@@ -1002,8 +1002,8 @@ mod tests {
 
     fn test_timeouts() -> OpenCodeSupervisorTimeouts {
         OpenCodeSupervisorTimeouts {
-            session_deadline: Duration::from_secs(8 * 60 * 60),
-            inactivity_timeout: Duration::from_secs(5 * 60),
+            session_deadline: Duration::from_hours(8),
+            inactivity_timeout: Duration::from_mins(5),
         }
     }
 
@@ -1034,7 +1034,7 @@ mod tests {
 
     #[test]
     fn idle_gate_finalizes_after_observed_busy() {
-        let future_deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let future_deadline = tokio::time::Instant::now() + Duration::from_mins(1);
         assert_eq!(
             idle_gate_decision(true, Some(future_deadline), tokio::time::Instant::now()),
             IdleGateDecision::Finalize
@@ -1194,11 +1194,8 @@ mod tests {
 
     #[test]
     fn describe_duration_uses_human_friendly_units() {
-        assert_eq!(
-            describe_duration(Duration::from_secs(8 * 60 * 60)),
-            "8 hours"
-        );
-        assert_eq!(describe_duration(Duration::from_secs(5 * 60)), "5 minutes");
+        assert_eq!(describe_duration(Duration::from_hours(8)), "8 hours");
+        assert_eq!(describe_duration(Duration::from_mins(5)), "5 minutes");
         assert_eq!(describe_duration(Duration::from_secs(45)), "45 seconds");
     }
 

--- a/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
@@ -110,7 +110,7 @@ async fn it_times_out_after_5_min_inactivity() {
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(3600)),
+                .set_delay(Duration::from_hours(1)),
         )
         .mount(&mock)
         .await;
@@ -190,7 +190,7 @@ async fn it_does_not_timeout_while_busy() {
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(3600)),
+                .set_delay(Duration::from_hours(1)),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/integration.rs
+++ b/apps/opencode-orchestrator-mcp/tests/integration.rs
@@ -186,7 +186,7 @@ async fn prompt_completes_and_extracts_response() {
     };
 
     let result = timeout(
-        Duration::from_secs(180),
+        Duration::from_mins(3),
         tool.call(input, &agentic_tools_core::ToolContext::default()),
     )
     .await
@@ -246,7 +246,7 @@ async fn session_resumption_works() {
     };
 
     let result1 = timeout(
-        Duration::from_secs(180),
+        Duration::from_mins(3),
         tool.call(input1, &agentic_tools_core::ToolContext::default()),
     )
     .await
@@ -264,7 +264,7 @@ async fn session_resumption_works() {
     };
 
     let result2 = timeout(
-        Duration::from_secs(180),
+        Duration::from_mins(3),
         tool.call(input2, &agentic_tools_core::ToolContext::default()),
     )
     .await
@@ -310,7 +310,7 @@ async fn permission_request_returns_status() {
     // Should return PermissionRequired within 120 seconds, not hang
     // (Model inference time is variable; 60s was too tight)
     let result = timeout(
-        Duration::from_secs(120),
+        Duration::from_mins(2),
         run_tool.call(
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
@@ -392,7 +392,7 @@ async fn permission_response_resumes_and_completes() {
 
     // Step 1: Trigger permission request
     let result1 = timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         run_tool.call(
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
@@ -439,7 +439,7 @@ async fn permission_response_resumes_and_completes() {
         );
 
         let respond_result = timeout(
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             respond_tool.call(
                 RespondPermissionInput {
                     session_id: current_session_id.clone(),
@@ -521,7 +521,7 @@ async fn permission_reject_returns_none_with_warning() {
 
     // Step 1: Trigger permission request
     let result = timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         run_tool.call(
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),
@@ -549,7 +549,7 @@ async fn permission_reject_returns_none_with_warning() {
 
     // Step 2: Reject the permission
     let reject_result = timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         respond_tool.call(
             RespondPermissionInput {
                 session_id: session_id.clone(),
@@ -635,7 +635,7 @@ async fn live_question_tool_infrastructure() {
     // Run a simple prompt to verify the server is functional
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
     let result = timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         tool.call(
             OrchestratorRunInput {
                 session_id: Some(session_id.clone()),

--- a/crates/agentic-tools/utils/src/pagination.rs
+++ b/crates/agentic-tools/utils/src/pagination.rs
@@ -56,7 +56,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 /// Default TTL for pagination state: 5 minutes.
-pub const DEFAULT_TTL: Duration = Duration::from_secs(5 * 60);
+pub const DEFAULT_TTL: Duration = Duration::from_mins(5);
 
 /// Two-level locking pagination cache generic over result T and optional meta M.
 ///
@@ -386,9 +386,7 @@ mod tests {
         // Manually expire it by setting created_at to the past
         {
             let mut st = lock.state.lock().unwrap();
-            st.created_at = Instant::now()
-                .checked_sub(Duration::from_secs(6 * 60))
-                .unwrap();
+            st.created_at = Instant::now().checked_sub(Duration::from_mins(6)).unwrap();
         }
 
         // Sweep should remove expired entry

--- a/crates/linear/tools/tests/live.rs
+++ b/crates/linear/tools/tests/live.rs
@@ -18,12 +18,10 @@ fn live_env_ready() -> bool {
     std::env::var("LINEAR_LIVE_TESTS").ok().as_deref() == Some("1")
         && std::env::var("LINEAR_API_KEY")
             .ok()
-            .filter(|v| !v.is_empty())
-            .is_some()
+            .is_some_and(|v| !v.is_empty())
         && std::env::var("LINEAR_TEST_TEAM_ID")
             .ok()
-            .filter(|v| !v.is_empty())
-            .is_some()
+            .is_some_and(|v| !v.is_empty())
 }
 
 #[tokio::test]
@@ -70,7 +68,7 @@ async fn live_create_search_read_comment_archive() {
     // TODO(3): Add cleanup guard for test issue on failure (see PR #105 review)
 
     // 2) Wait for search indexing
-    sleep(Duration::from_millis(2000)).await;
+    sleep(Duration::from_secs(2)).await;
 
     // 3) Search by term
     let search = tools

--- a/crates/services/anthropic-async/src/client.rs
+++ b/crates/services/anthropic-async/src/client.rs
@@ -51,7 +51,7 @@ impl<C: Config> Client<C> {
         Self {
             http: reqwest::Client::builder()
                 .connect_timeout(std::time::Duration::from_secs(5))
-                .timeout(std::time::Duration::from_secs(600))
+                .timeout(std::time::Duration::from_mins(10))
                 .build()
                 .expect("reqwest client"),
             config,

--- a/crates/services/claudecode-rs/src/bin/fake_claude.rs
+++ b/crates/services/claudecode-rs/src/bin/fake_claude.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     break;
                 }
             }
-            () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {}
+            () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {}
         }
     }
 

--- a/crates/services/claudecode-rs/src/mcp/validate.rs
+++ b/crates/services/claudecode-rs/src/mcp/validate.rs
@@ -643,7 +643,10 @@ async fn validate_stdio_server(
             let handshake_ms = start.elapsed().as_millis() as u64;
 
             // Get server info
-            let Some(server_info) = handshake_result.peer_info().cloned() else {
+            let Some(server_info) = handshake_result
+                .peer_info()
+                .map(|peer_info| peer_info.as_ref().clone())
+            else {
                 let tail = snapshot_tail(stderr_buf.as_ref()).await;
                 return Err(McpServerValidationError::HandshakeProtocol {
                     message: "Server info not available after handshake".to_string(),

--- a/crates/services/exa-async/src/client.rs
+++ b/crates/services/exa-async/src/client.rs
@@ -51,7 +51,7 @@ impl<C: Config> Client<C> {
         Self {
             http: reqwest::Client::builder()
                 .connect_timeout(std::time::Duration::from_secs(5))
-                .timeout(std::time::Duration::from_secs(60))
+                .timeout(std::time::Duration::from_mins(1))
                 .build()
                 .expect("reqwest client"),
             config,

--- a/crates/services/opencode-rs/examples/full_workflow.rs
+++ b/crates/services/opencode-rs/examples/full_workflow.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 6: Stream response events
     println!("\n6. Streaming response...\n");
     let mut response_text = String::new();
-    let timeout = Duration::from_secs(60);
+    let timeout = Duration::from_mins(1);
     let start = std::time::Instant::now();
 
     loop {

--- a/crates/services/opencode-rs/src/client.rs
+++ b/crates/services/opencode-rs/src/client.rs
@@ -38,7 +38,7 @@ impl Default for ClientBuilder {
             base_url: "http://127.0.0.1:4096".to_string(),
             directory: None,
             workspace: None,
-            timeout: Duration::from_secs(1800), // 30 min for long-running tool calls
+            timeout: Duration::from_mins(30), // 30 min for long-running tool calls
         }
     }
 }
@@ -408,7 +408,7 @@ mod tests {
     fn test_client_builder_defaults() {
         let builder = ClientBuilder::new();
         assert_eq!(builder.base_url, "http://127.0.0.1:4096");
-        assert_eq!(builder.timeout, Duration::from_secs(1800));
+        assert_eq!(builder.timeout, Duration::from_mins(30));
         assert!(builder.directory.is_none());
         assert!(builder.workspace.is_none());
     }
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(builder.base_url, "http://localhost:8080");
         assert_eq!(builder.directory, Some("/my/project".to_string()));
         assert_eq!(builder.workspace, Some("workspace-1".to_string()));
-        assert_eq!(builder.timeout, Duration::from_secs(60));
+        assert_eq!(builder.timeout, Duration::from_mins(1));
     }
 
     #[cfg(feature = "http")]

--- a/crates/services/opencode-rs/src/http/mod.rs
+++ b/crates/services/opencode-rs/src/http/mod.rs
@@ -94,7 +94,7 @@ impl HttpClient {
         directory: Option<PathBuf>,
         http: Option<ReqClient>,
     ) -> Result<Self> {
-        let timeout = Duration::from_secs(1800);
+        let timeout = Duration::from_mins(30);
         let inner = match http {
             Some(client) => client,
             None => ReqClient::builder()

--- a/crates/services/opencode-rs/tests/integration/http_endpoints.rs
+++ b/crates/services/opencode-rs/tests/integration/http_endpoints.rs
@@ -583,7 +583,7 @@ async fn test_session_init_required_body() {
         }
     };
 
-    let ok = match tokio::time::timeout(Duration::from_secs(300), driver).await {
+    let ok = match tokio::time::timeout(Duration::from_mins(5), driver).await {
         Ok(Ok(ok)) => ok,
         Ok(Err(error)) => {
             init_task.as_mut().abort();

--- a/crates/services/opencode-rs/tests/integration/server_sse.rs
+++ b/crates/services/opencode-rs/tests/integration/server_sse.rs
@@ -169,11 +169,9 @@ async fn test_sse_message_events() {
                     }
                     saw_message_event = true;
                 }
-                Event::MessagePartUpdated { properties } => {
+                Event::MessagePartUpdated { properties } if properties.part.is_some() => {
                     // Part events may not have session_id at top level (it's in the Part)
-                    if properties.part.is_some() {
-                        saw_message_event = true;
-                    }
+                    saw_message_event = true;
                 }
                 _ => {}
             }
@@ -214,7 +212,7 @@ async fn test_sse_heartbeat() {
     let mut subscription = client.subscribe().expect("Failed to subscribe to SSE");
 
     // Wait for a heartbeat (sent periodically)
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+    let deadline = tokio::time::Instant::now() + Duration::from_mins(2);
     let mut saw_heartbeat = false;
 
     while tokio::time::Instant::now() < deadline && !saw_heartbeat {

--- a/crates/tools/coding-agent-tools/src/glob.rs
+++ b/crates/tools/coding-agent-tools/src/glob.rs
@@ -108,7 +108,7 @@ pub fn run(cfg: GlobConfig) -> Result<GlobOutput, ToolError> {
     match cfg.sort {
         SortOrder::Name => {
             // Case-insensitive alphabetical
-            entries.sort_by(|a, b| a.rel_path.to_lowercase().cmp(&b.rel_path.to_lowercase()));
+            entries.sort_by_key(|entry| entry.rel_path.to_lowercase());
         }
         SortOrder::Mtime => {
             // Newest first (reverse chronological)

--- a/crates/tools/coding-agent-tools/src/just/pager.rs
+++ b/crates/tools/coding-agent-tools/src/just/pager.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 /// Time-to-live for pagination state
-const TTL: Duration = Duration::from_secs(5 * 60);
+const TTL: Duration = Duration::from_mins(5);
 
 /// Items per page for search results
 pub const PAGE_SIZE: usize = 10;
@@ -219,9 +219,7 @@ mod tests {
         {
             let mut st = lock.state.lock().unwrap();
             // Manually expire
-            st.created_at = Instant::now()
-                .checked_sub(Duration::from_secs(6 * 60))
-                .unwrap();
+            st.created_at = Instant::now().checked_sub(Duration::from_mins(6)).unwrap();
         }
 
         cache.sweep_expired();

--- a/crates/tools/coding-agent-tools/src/walker.rs
+++ b/crates/tools/coding-agent-tools/src/walker.rs
@@ -287,7 +287,7 @@ fn sort_entries(entries: &mut [LsEntry], show: Show) {
         }
         _ => {
             // Plain alphabetical for files-only or dirs-only
-            entries.sort_by(|a, b| a.path.to_lowercase().cmp(&b.path.to_lowercase()));
+            entries.sort_by_key(|entry| entry.path.to_lowercase());
         }
     }
 }

--- a/crates/tools/coding-agent-tools/tests/glob_tests.rs
+++ b/crates/tools/coding-agent-tools/tests/glob_tests.rs
@@ -163,12 +163,12 @@ fn test_glob_sort_by_mtime() {
 
     // Create oldest file first
     fs::write(tmp.path().join("old.txt"), "old").unwrap();
-    let old_time = FileTime::from_system_time(now - Duration::from_secs(3600));
+    let old_time = FileTime::from_system_time(now - Duration::from_hours(1));
     set_file_mtime(tmp.path().join("old.txt"), old_time).unwrap();
 
     // Create middle file
     fs::write(tmp.path().join("mid.txt"), "mid").unwrap();
-    let mid_time = FileTime::from_system_time(now - Duration::from_secs(1800));
+    let mid_time = FileTime::from_system_time(now - Duration::from_mins(30));
     set_file_mtime(tmp.path().join("mid.txt"), mid_time).unwrap();
 
     // Create newest file

--- a/crates/tools/gpt5-reasoner/src/template/mod.rs
+++ b/crates/tools/gpt5-reasoner/src/template/mod.rs
@@ -45,7 +45,7 @@ pub async fn inject_files(xml_template: &str, groups: &FileGrouping) -> Result<S
             .collect()
     };
 
-    let file_map_vec: Vec<(String, String)> = stream::iter(unique_paths.into_iter())
+    let file_map_vec: Vec<(String, String)> = stream::iter(unique_paths)
         .map(|p| async move {
             let content = read_file_utf8(&p).await?;
             Ok::<_, ReasonerError>((p, content))

--- a/crates/tools/review-tools/src/cache.rs
+++ b/crates/tools/review-tools/src/cache.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use crate::types::ReviewSnapshot;
 
 /// Snapshot TTL: 60 minutes (exceeds 30-min session timeout).
-pub const SNAPSHOT_TTL: Duration = Duration::from_secs(60 * 60);
+pub const SNAPSHOT_TTL: Duration = Duration::from_hours(1);
 
 /// Thread-safe cache for review snapshots.
 #[derive(Default)]
@@ -128,6 +128,6 @@ mod tests {
 
     #[test]
     fn ttl_is_60_minutes() {
-        assert_eq!(SNAPSHOT_TTL, Duration::from_secs(3600));
+        assert_eq!(SNAPSHOT_TTL, Duration::from_hours(1));
     }
 }

--- a/crates/tools/review-tools/src/reviewer.rs
+++ b/crates/tools/review-tools/src/reviewer.rs
@@ -59,7 +59,7 @@ pub const MAX_CONCURRENT_SESSIONS: usize = 3;
 pub const RETRY_DELAYS: [Duration; 3] = [
     Duration::from_millis(0),
     Duration::from_millis(500),
-    Duration::from_millis(1000),
+    Duration::from_secs(1),
 ];
 
 /// Trait for reviewer runners (enables mocking in tests).
@@ -398,7 +398,7 @@ mod tests {
             [
                 Duration::from_millis(0),
                 Duration::from_millis(500),
-                Duration::from_millis(1000)
+                Duration::from_secs(1)
             ]
         );
     }

--- a/crates/tools/workspace-tools/src/paths.rs
+++ b/crates/tools/workspace-tools/src/paths.rs
@@ -133,8 +133,7 @@ mod tests {
             let mut path = std::env::temp_dir();
             let nanos = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_nanos())
-                .unwrap_or(0);
+                .map_or(0, |duration| duration.as_nanos());
             path.push(format!("{prefix}{}-{nanos}", std::process::id()));
             std::fs::create_dir_all(&path).unwrap();
             Self { path }

--- a/crates/tools/workspace-tools/src/tools.rs
+++ b/crates/tools/workspace-tools/src/tools.rs
@@ -486,9 +486,7 @@ fn render_directory(
             .file_type()
             .map_err(|error| ToolError::Internal(error.to_string()))?;
         let is_dir = if entry_type.is_symlink() {
-            fs::metadata(entry.path())
-                .map(|meta| meta.is_dir())
-                .unwrap_or(false)
+            fs::metadata(entry.path()).is_ok_and(|meta| meta.is_dir())
         } else {
             entry_type.is_dir()
         };
@@ -748,8 +746,7 @@ mod tests {
             let mut path = std::env::temp_dir();
             let nanos = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_nanos())
-                .unwrap_or(0);
+                .map_or(0, |duration| duration.as_nanos());
             path.push(format!("{prefix}{}-{nanos}", std::process::id()));
             std::fs::create_dir_all(&path).unwrap();
             Self { path }

--- a/mise.lock
+++ b/mise.lock
@@ -49,7 +49,7 @@ checksum = "sha256:7c8b10a93723838bc3533f6e1886d868fdbb109b81606ebe6d1a533d11d8e
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_windows_amd64.zip"
 
 [[tools.agentic-bin]]
-version = "0.1.11"
+version = "0.1.12"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-bin.options]
@@ -57,27 +57,27 @@ asset_pattern = "agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
 version_prefix = "agentic-bin-v"
 
 [tools.agentic-bin."platforms.linux-x64"]
-checksum = "sha256:7af3fd6aef637d7725f5ce640d69e205c5d31283e2e9f3822befb2f48254490f"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820443"
+checksum = "sha256:abffdfde72ba220e7b87dbcd75a677bf4dacc04409eb0d0a32281ae72419e185"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643084"
 
 [tools.agentic-bin."platforms.linux-x64-baseline"]
-checksum = "sha256:7af3fd6aef637d7725f5ce640d69e205c5d31283e2e9f3822befb2f48254490f"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820443"
+checksum = "sha256:abffdfde72ba220e7b87dbcd75a677bf4dacc04409eb0d0a32281ae72419e185"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643084"
 
 [tools.agentic-bin."platforms.linux-x64-musl"]
-checksum = "sha256:7af3fd6aef637d7725f5ce640d69e205c5d31283e2e9f3822befb2f48254490f"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820443"
+checksum = "sha256:abffdfde72ba220e7b87dbcd75a677bf4dacc04409eb0d0a32281ae72419e185"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643084"
 
 [tools.agentic-bin."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:7af3fd6aef637d7725f5ce640d69e205c5d31283e2e9f3822befb2f48254490f"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820443"
+checksum = "sha256:abffdfde72ba220e7b87dbcd75a677bf4dacc04409eb0d0a32281ae72419e185"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643084"
 
 [[tools.agentic-bin]]
-version = "0.1.11"
+version = "0.1.12"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-bin.options]
@@ -85,30 +85,17 @@ asset_pattern = "agentic-bin-aarch64-unknown-linux-gnu.tar.xz"
 version_prefix = "agentic-bin-v"
 
 [tools.agentic-bin."platforms.linux-arm64"]
-checksum = "sha256:490017ec52a9e6ede6ff8e1fe5be46c4984837343bc3201b940b065baf456fbb"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820437"
+checksum = "sha256:54ce4b99070fda80296200984a7aa77fabd1fd2e0841b13d91c7e84be71b8e00"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643075"
 
 [tools.agentic-bin."platforms.linux-arm64-musl"]
-checksum = "sha256:490017ec52a9e6ede6ff8e1fe5be46c4984837343bc3201b940b065baf456fbb"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820437"
+checksum = "sha256:54ce4b99070fda80296200984a7aa77fabd1fd2e0841b13d91c7e84be71b8e00"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643075"
 
 [[tools.agentic-bin]]
-version = "0.1.11"
-backend = "github:allisoneer/agentic_auxilary"
-
-[tools.agentic-bin.options]
-asset_pattern = "agentic-bin-aarch64-apple-darwin.tar.xz"
-version_prefix = "agentic-bin-v"
-
-[tools.agentic-bin."platforms.macos-arm64"]
-checksum = "sha256:fff26c0f026961210bc16de08eedbb514f3e3df05e80af6a09807d6bd6ef9f6e"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-aarch64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820435"
-
-[[tools.agentic-bin]]
-version = "0.1.11"
+version = "0.1.12"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-bin.options]
@@ -116,125 +103,83 @@ asset_pattern = "agentic-bin-x86_64-apple-darwin.tar.xz"
 version_prefix = "agentic-bin-v"
 
 [tools.agentic-bin."platforms.macos-x64"]
-checksum = "sha256:5ee7ab1931f3c57c52ce8b6c29a0ffde083dfa443b5a1b8d23e200a8b452afa3"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820441"
+checksum = "sha256:255388f2d57782769ade1d18bb0f6d012bc93277f6f21470e901e7180829daa6"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643081"
 
 [tools.agentic-bin."platforms.macos-x64-baseline"]
-checksum = "sha256:5ee7ab1931f3c57c52ce8b6c29a0ffde083dfa443b5a1b8d23e200a8b452afa3"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/agentic-bin-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820441"
+checksum = "sha256:255388f2d57782769ade1d18bb0f6d012bc93277f6f21470e901e7180829daa6"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643081"
 
 [[tools.agentic-bin]]
-version = "0.1.11"
+version = "0.1.12"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-bin.options]
+asset_pattern = "agentic-bin-aarch64-apple-darwin.tar.xz"
+version_prefix = "agentic-bin-v"
+
+[tools.agentic-bin."platforms.macos-arm64"]
+checksum = "sha256:f5bda199a67f569b4051b26613c0ee85bb827a7176a200cbf960270dbc6b7b51"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/agentic-bin-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643074"
+
+[[tools.agentic-bin]]
+version = "0.1.12"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-bin.options]
 version_prefix = "agentic-bin-v"
 
 [tools.agentic-bin."platforms.windows-x64"]
-checksum = "sha256:19c269befc1f69c8405a94f782fb257b76c082b8a77330751be70d1aa6434a4e"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820451"
+checksum = "sha256:36ea9b918d5cad3250b8450644e5fc56f219ddb8a3549541f7e37d9270d20e95"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643091"
 
 [tools.agentic-bin."platforms.windows-x64-baseline"]
-checksum = "sha256:19c269befc1f69c8405a94f782fb257b76c082b8a77330751be70d1aa6434a4e"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.11/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463820451"
+checksum = "sha256:36ea9b918d5cad3250b8450644e5fc56f219ddb8a3549541f7e37d9270d20e95"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-bin-v0.1.12/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464643091"
 
 [[tools.agentic-mcp]]
-version = "0.2.36"
+version = "0.2.37"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-mcp.options]
 asset_pattern = "agentic-mcp-aarch64-unknown-linux-gnu.tar.xz"
 version_prefix = "agentic-mcp-v"
 
-[tools.agentic-mcp."platforms.linux-arm64"]
-checksum = "sha256:c5e8ecf708306cbfbaecb67399072180d82b97887f1989aa3b2b9c0e880a8932"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832816"
-
-[tools.agentic-mcp."platforms.linux-arm64-musl"]
-checksum = "sha256:c5e8ecf708306cbfbaecb67399072180d82b97887f1989aa3b2b9c0e880a8932"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832816"
-
 [[tools.agentic-mcp]]
-version = "0.2.36"
+version = "0.2.37"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-mcp.options]
 asset_pattern = "agentic-mcp-x86_64-unknown-linux-gnu.tar.xz"
 version_prefix = "agentic-mcp-v"
 
-[tools.agentic-mcp."platforms.linux-x64"]
-checksum = "sha256:7e071c7d3ad603be0f961248c3eeac1e85b6a159ef656eeb311a96ec4a4af574"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832837"
-
-[tools.agentic-mcp."platforms.linux-x64-baseline"]
-checksum = "sha256:7e071c7d3ad603be0f961248c3eeac1e85b6a159ef656eeb311a96ec4a4af574"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832837"
-
-[tools.agentic-mcp."platforms.linux-x64-musl"]
-checksum = "sha256:7e071c7d3ad603be0f961248c3eeac1e85b6a159ef656eeb311a96ec4a4af574"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832837"
-
-[tools.agentic-mcp."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:7e071c7d3ad603be0f961248c3eeac1e85b6a159ef656eeb311a96ec4a4af574"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832837"
-
 [[tools.agentic-mcp]]
-version = "0.2.36"
-backend = "github:allisoneer/agentic_auxilary"
-
-[tools.agentic-mcp.options]
-asset_pattern = "agentic-mcp-x86_64-apple-darwin.tar.xz"
-version_prefix = "agentic-mcp-v"
-
-[tools.agentic-mcp."platforms.macos-x64"]
-checksum = "sha256:016b9597e65393a3c966018e282ea2e25041a7ae1c52902e1ad4a27439a997d1"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832834"
-
-[tools.agentic-mcp."platforms.macos-x64-baseline"]
-checksum = "sha256:016b9597e65393a3c966018e282ea2e25041a7ae1c52902e1ad4a27439a997d1"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832834"
-
-[[tools.agentic-mcp]]
-version = "0.2.36"
+version = "0.2.37"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-mcp.options]
 asset_pattern = "agentic-mcp-aarch64-apple-darwin.tar.xz"
 version_prefix = "agentic-mcp-v"
 
-[tools.agentic-mcp."platforms.macos-arm64"]
-checksum = "sha256:015f52f52ec67e23f9f625ab52255af41c1b798179bfdb65ffd5cc74a8820dc9"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/agentic-mcp-aarch64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832817"
+[[tools.agentic-mcp]]
+version = "0.2.37"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-mcp.options]
+asset_pattern = "agentic-mcp-x86_64-apple-darwin.tar.xz"
+version_prefix = "agentic-mcp-v"
 
 [[tools.agentic-mcp]]
-version = "0.2.36"
+version = "0.2.37"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.agentic-mcp.options]
 version_prefix = "agentic-mcp-v"
-
-[tools.agentic-mcp."platforms.windows-x64"]
-checksum = "sha256:1a343e01d0c8d364b8bcf86944435c4e7d5c0c74c39fa8e6a5d995aaa9c231c9"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832857"
-
-[tools.agentic-mcp."platforms.windows-x64-baseline"]
-checksum = "sha256:1a343e01d0c8d364b8bcf86944435c4e7d5c0c74c39fa8e6a5d995aaa9c231c9"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.36/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463832857"
 
 [[tools."aqua:taiki-e/cargo-llvm-cov"]]
 version = "0.6.14"
@@ -810,98 +755,43 @@ checksum = "sha256:657338772efd17a31d67285bb5ed691da87741e44311c0366273c6cb7d913
 url = "https://github.com/casey/just/releases/download/1.49.0/just-1.49.0-x86_64-pc-windows-msvc.zip"
 
 [[tools.opencode-orchestrator-mcp]]
-version = "0.7.5"
+version = "0.7.6"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.opencode-orchestrator-mcp.options]
 asset_pattern = "opencode-orchestrator-mcp-aarch64-unknown-linux-gnu.tar.xz"
 version_prefix = "opencode-orchestrator-mcp-v"
 
-[tools.opencode-orchestrator-mcp."platforms.linux-arm64"]
-checksum = "sha256:fa666aa6d7d875db570738396697a674845bced8da173b21c392d8f42ed96275"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834937"
-
-[tools.opencode-orchestrator-mcp."platforms.linux-arm64-musl"]
-checksum = "sha256:fa666aa6d7d875db570738396697a674845bced8da173b21c392d8f42ed96275"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834937"
-
 [[tools.opencode-orchestrator-mcp]]
-version = "0.7.5"
+version = "0.7.6"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.opencode-orchestrator-mcp.options]
 asset_pattern = "opencode-orchestrator-mcp-x86_64-unknown-linux-gnu.tar.xz"
 version_prefix = "opencode-orchestrator-mcp-v"
 
-[tools.opencode-orchestrator-mcp."platforms.linux-x64"]
-checksum = "sha256:9d53a506acb1c1c80d0e0e2f538ee1d1fa5e15f671b49074669b2606a7136e14"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834953"
-
-[tools.opencode-orchestrator-mcp."platforms.linux-x64-baseline"]
-checksum = "sha256:9d53a506acb1c1c80d0e0e2f538ee1d1fa5e15f671b49074669b2606a7136e14"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834953"
-
-[tools.opencode-orchestrator-mcp."platforms.linux-x64-musl"]
-checksum = "sha256:9d53a506acb1c1c80d0e0e2f538ee1d1fa5e15f671b49074669b2606a7136e14"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834953"
-
-[tools.opencode-orchestrator-mcp."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:9d53a506acb1c1c80d0e0e2f538ee1d1fa5e15f671b49074669b2606a7136e14"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834953"
-
 [[tools.opencode-orchestrator-mcp]]
-version = "0.7.5"
+version = "0.7.6"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.opencode-orchestrator-mcp.options]
 asset_pattern = "opencode-orchestrator-mcp-aarch64-apple-darwin.tar.xz"
 version_prefix = "opencode-orchestrator-mcp-v"
 
-[tools.opencode-orchestrator-mcp."platforms.macos-arm64"]
-checksum = "sha256:715073ad52e6ee5b0dcebec07b69f028582045b6377f77fc822bc8249cb50572"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-aarch64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834941"
+[[tools.opencode-orchestrator-mcp]]
+version = "0.7.6"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.opencode-orchestrator-mcp.options]
+version_prefix = "opencode-orchestrator-mcp-v"
 
 [[tools.opencode-orchestrator-mcp]]
-version = "0.7.5"
+version = "0.7.6"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.opencode-orchestrator-mcp.options]
 asset_pattern = "opencode-orchestrator-mcp-x86_64-apple-darwin.tar.xz"
 version_prefix = "opencode-orchestrator-mcp-v"
-
-[tools.opencode-orchestrator-mcp."platforms.macos-x64"]
-checksum = "sha256:747612d2efbec375fc8c3775ab28fcf3a3820d3e3bb58d74dca42ecc11fb9298"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834946"
-
-[tools.opencode-orchestrator-mcp."platforms.macos-x64-baseline"]
-checksum = "sha256:747612d2efbec375fc8c3775ab28fcf3a3820d3e3bb58d74dca42ecc11fb9298"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/opencode-orchestrator-mcp-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834946"
-
-[[tools.opencode-orchestrator-mcp]]
-version = "0.7.5"
-backend = "github:allisoneer/agentic_auxilary"
-
-[tools.opencode-orchestrator-mcp.options]
-version_prefix = "opencode-orchestrator-mcp-v"
-
-[tools.opencode-orchestrator-mcp."platforms.windows-x64"]
-checksum = "sha256:baa40356f395a9b961504a2e5ad55f0a458d9205852d7941eb9141ea76e69140"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834961"
-
-[tools.opencode-orchestrator-mcp."platforms.windows-x64-baseline"]
-checksum = "sha256:baa40356f395a9b961504a2e5ad55f0a458d9205852d7941eb9141ea76e69140"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/opencode-orchestrator-mcp-v0.7.5/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463834961"
 
 [[tools.opentofu]]
 version = "1.11.5"
@@ -1085,7 +975,7 @@ url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x86_64.zip"
 
 [[tools.thoughts-bin]]
-version = "0.1.21"
+version = "0.1.22"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.thoughts-bin.options]
@@ -1093,27 +983,27 @@ asset_pattern = "thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
 version_prefix = "thoughts-bin-v"
 
 [tools.thoughts-bin."platforms.linux-x64"]
-checksum = "sha256:a2dbee9ba1bd0f33be5578241b4c569ab86439b3d142356271a72488bd731f74"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827303"
+checksum = "sha256:db26870e2e544201988f96996f2041bf51653ce47677914a18ce13bd6c431bb9"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649104"
 
 [tools.thoughts-bin."platforms.linux-x64-baseline"]
-checksum = "sha256:a2dbee9ba1bd0f33be5578241b4c569ab86439b3d142356271a72488bd731f74"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827303"
+checksum = "sha256:db26870e2e544201988f96996f2041bf51653ce47677914a18ce13bd6c431bb9"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649104"
 
 [tools.thoughts-bin."platforms.linux-x64-musl"]
-checksum = "sha256:a2dbee9ba1bd0f33be5578241b4c569ab86439b3d142356271a72488bd731f74"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827303"
+checksum = "sha256:db26870e2e544201988f96996f2041bf51653ce47677914a18ce13bd6c431bb9"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649104"
 
 [tools.thoughts-bin."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:a2dbee9ba1bd0f33be5578241b4c569ab86439b3d142356271a72488bd731f74"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827303"
+checksum = "sha256:db26870e2e544201988f96996f2041bf51653ce47677914a18ce13bd6c431bb9"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649104"
 
 [[tools.thoughts-bin]]
-version = "0.1.21"
+version = "0.1.22"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.thoughts-bin.options]
@@ -1121,30 +1011,17 @@ asset_pattern = "thoughts-bin-aarch64-unknown-linux-gnu.tar.xz"
 version_prefix = "thoughts-bin-v"
 
 [tools.thoughts-bin."platforms.linux-arm64"]
-checksum = "sha256:05bf3780d05c51ec3993577d75f40e654d8f6e8dfe8f281b0b84653594a6be52"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827289"
+checksum = "sha256:307110c7332a82731149ee3a010e2700066592fafeb1a2aca64569c862c271b7"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649097"
 
 [tools.thoughts-bin."platforms.linux-arm64-musl"]
-checksum = "sha256:05bf3780d05c51ec3993577d75f40e654d8f6e8dfe8f281b0b84653594a6be52"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-aarch64-unknown-linux-gnu.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827289"
+checksum = "sha256:307110c7332a82731149ee3a010e2700066592fafeb1a2aca64569c862c271b7"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649097"
 
 [[tools.thoughts-bin]]
-version = "0.1.21"
-backend = "github:allisoneer/agentic_auxilary"
-
-[tools.thoughts-bin.options]
-asset_pattern = "thoughts-bin-aarch64-apple-darwin.tar.xz"
-version_prefix = "thoughts-bin-v"
-
-[tools.thoughts-bin."platforms.macos-arm64"]
-checksum = "sha256:455d41b70af5496b85e23f17176e30cc3806636ecd0acd7c35e07f9803c0e746"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-aarch64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827276"
-
-[[tools.thoughts-bin]]
-version = "0.1.21"
+version = "0.1.22"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.thoughts-bin.options]
@@ -1152,31 +1029,44 @@ asset_pattern = "thoughts-bin-x86_64-apple-darwin.tar.xz"
 version_prefix = "thoughts-bin-v"
 
 [tools.thoughts-bin."platforms.macos-x64"]
-checksum = "sha256:1dc9a6b186d3a150bcf6cb788783808ef701840c3e1e4455eb86e8a2acc45c98"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827301"
+checksum = "sha256:fe25df8610705721234a62bd9ce10def756c61efc72d6198f6e0891278abc2e2"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649101"
 
 [tools.thoughts-bin."platforms.macos-x64-baseline"]
-checksum = "sha256:1dc9a6b186d3a150bcf6cb788783808ef701840c3e1e4455eb86e8a2acc45c98"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/thoughts-bin-x86_64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827301"
+checksum = "sha256:fe25df8610705721234a62bd9ce10def756c61efc72d6198f6e0891278abc2e2"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649101"
 
 [[tools.thoughts-bin]]
-version = "0.1.21"
+version = "0.1.22"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.thoughts-bin.options]
+asset_pattern = "thoughts-bin-aarch64-apple-darwin.tar.xz"
+version_prefix = "thoughts-bin-v"
+
+[tools.thoughts-bin."platforms.macos-arm64"]
+checksum = "sha256:97ecaf6125ca5e7fcfcec14d073f10b52edfb0b1ef649652a801ed20a690942c"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/thoughts-bin-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649087"
+
+[[tools.thoughts-bin]]
+version = "0.1.22"
 backend = "github:allisoneer/agentic_auxilary"
 
 [tools.thoughts-bin.options]
 version_prefix = "thoughts-bin-v"
 
 [tools.thoughts-bin."platforms.windows-x64"]
-checksum = "sha256:87f83b7f6cda18eebb864d1cfdfcc944634fac6a9c7e07a809b74121e6ed3e71"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827275"
+checksum = "sha256:de1591f7e47d38b1f71ce2af063be010e241484cf66c6956a71fb2e5c605c811"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649086"
 
 [tools.thoughts-bin."platforms.windows-x64-baseline"]
-checksum = "sha256:87f83b7f6cda18eebb864d1cfdfcc944634fac6a9c7e07a809b74121e6ed3e71"
-url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.21/source.tar.gz"
-url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463827275"
+checksum = "sha256:de1591f7e47d38b1f71ce2af063be010e241484cf66c6956a71fb2e5c605c811"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/thoughts-bin-v0.1.22/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/464649086"
 
 [[tools.trivy]]
 version = "0.69.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.96.1"
 components = ["clippy", "rustfmt", "rust-src"]


### PR DESCRIPTION
## My Notes (preserved)

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

The repository was still pinned to Rust `1.93.0`, while current development and CI need to build, lint, format, and test cleanly on Rust `1.96.1`. Moving the pinned compiler forward surfaced new Clippy/rustfmt feedback and a small API-shape change around MCP handshake peer info handling.

This PR updates the project to the new pinned stable toolchain and applies the resulting compatibility cleanup so CI can pass consistently on the upgraded compiler.

## What user-facing changes did I ship?

- Updated the pinned Rust stable toolchain from `1.93.0` to `1.96.1` in `rust-toolchain.toml`.
- Updated GitHub Actions workflows to install/use Rust `1.96.1` for CI, README sync, and release-plz jobs.
- Updated repository guidance in `CLAUDE.md` so local development instructions match the new pinned toolchain.
- Refreshed `mise.lock` for the current released versions/checksums of the distributed repository tools.

There are no intentional runtime behavior changes for end users. The Rust code changes are compatibility, lint, and formatting fixes required by the toolchain upgrade.

## How I implemented it

- Bumped the stable Rust channel to `1.96.1` in the checked-in toolchain file and matching CI workflow setup steps.
- Applied Clippy cleanups introduced by the newer toolchain, including:
  - Replacing manual duration arithmetic such as `Duration::from_secs(60 * n)` with clearer `Duration::from_mins(...)` / `Duration::from_hours(...)` constructors.
  - Replacing `sort_by(...cmp...)` with `sort_by_key(...)` where appropriate.
  - Replacing `map(...).unwrap_or(...)` and metadata checks with `map_or(...)` / `is_ok_and(...)`.
  - Removing an unnecessary `.into_iter()` when constructing a stream from an owned collection.
  - Collapsing a nested SSE test match/if into a guarded match arm.
- Adjusted Claude Code MCP validation to clone peer info from the `Arc`-wrapped peer info returned by the current handshake API.
- Updated tests and fixtures to preserve existing behavior while satisfying the new lints and formatter output.
- Regenerated/updated `mise.lock` entries for the released `agentic-bin`, `agentic-mcp`, `opencode-orchestrator-mcp`, and `thoughts-bin` artifacts.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] I ran `just check` and it passed
- [x] I ran `just test` and it passed
- [x] I ran `just xtask-verify-check` and it passed

## Description for the changelog

- Upgrade the pinned Rust toolchain to `1.96.1` and apply the resulting Clippy/rustfmt compatibility fixes across the workspace.
<!-- END:describe_pr:autogen -->

