### PR TITLE
fix(opencode-orchestrator-mcp): generate valid command message ids

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -50,6 +50,7 @@ use opencode_rs::types::message::Part;
 use opencode_rs::types::message::PromptPart;
 use opencode_rs::types::message::PromptRequest;
 use opencode_rs::types::message::ToolState;
+use opencode_rs::types::new_message_id;
 use opencode_rs::types::permission::PermissionReply as ApiPermissionReply;
 use opencode_rs::types::permission::PermissionReplyRequest;
 use opencode_rs::types::question::QuestionReply;
@@ -60,8 +61,6 @@ use opencode_rs::types::session::SummarizeRequest;
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use tokio::task::JoinHandle;
 
 const SERVER_NAME: &str = "opencode-orchestrator-mcp";
@@ -141,13 +140,6 @@ async fn abort_command_task(task: &mut Option<JoinHandle<Result<(), OpencodeErro
         handle.abort();
         let _ = handle.await;
     }
-}
-
-fn make_command_message_id(session_id: &str) -> String {
-    let issued_at_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    format!("orchestrator-command-{session_id}-{issued_at_nanos}")
 }
 
 fn transcript_indicates_command_dispatch(
@@ -620,7 +612,7 @@ impl OrchestratorRunTool {
         if let Some(command) = &input.command {
             command_name_for_logging = Some(command.clone());
 
-            let command_message_id = make_command_message_id(&session_id);
+            let command_message_id = new_message_id();
             command_transcript_window = Some(CommandTranscriptWindow {
                 command_message_id: command_message_id.clone(),
             });

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -970,3 +970,106 @@ async fn command_dispatch_404_is_actionable_invalid_input() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn command_dispatch_posts_server_valid_message_id() {
+    let _guard = env_lock().await;
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "command-valid-message-id";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    let status_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(status_seq)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("COMMAND_DONE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "ok"})))
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(5),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: Some("implement_plan".into()),
+                agent: None,
+                message: Some("args".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("command dispatch message-id regression should not hang")
+    .expect("command dispatch should succeed");
+
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("COMMAND_DONE"));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let command_request = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == format!("/session/{sid}/command")
+        })
+        .expect("wiremock should capture command POST");
+    let body: serde_json::Value =
+        serde_json::from_slice(&command_request.body).expect("command request body should be JSON");
+    let message_id = body
+        .get("messageID")
+        .and_then(serde_json::Value::as_str)
+        .expect("command request should include messageID");
+    assert!(
+        message_id.starts_with("msg"),
+        "expected server-valid messageID prefix, got {message_id}"
+    );
+}

--- a/crates/services/opencode-rs/src/types/message.rs
+++ b/crates/services/opencode-rs/src/types/message.rs
@@ -702,6 +702,7 @@ pub struct ShellRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::new_message_id;
 
     #[test]
     fn test_part_text_deserialize() {
@@ -736,6 +737,24 @@ mod tests {
         let json = r#"{"type":"future-part-type","data":"whatever"}"#;
         let part: Part = serde_json::from_str(json).unwrap();
         assert!(matches!(part, Part::Unknown));
+    }
+
+    #[test]
+    fn test_command_request_serializes_message_id_as_message_id() {
+        let message_id = new_message_id();
+        let value = serde_json::to_value(CommandRequest {
+            command: "implement_plan".into(),
+            arguments: "args".into(),
+            message_id: Some(message_id.clone()),
+        })
+        .unwrap();
+
+        assert_eq!(
+            value.get("messageID").and_then(serde_json::Value::as_str),
+            Some(message_id.as_str())
+        );
+        assert!(message_id.starts_with("msg"));
+        assert!(value.get("message_id").is_none());
     }
 
     #[test]
@@ -877,7 +896,7 @@ mod tests {
         }"#;
         let source: FilePartSource = serde_json::from_str(json).unwrap();
         assert!(
-            matches!(source, FilePartSource::Resource { client_name, uri, .. } 
+            matches!(source, FilePartSource::Resource { client_name, uri, .. }
             if client_name == "my-mcp-server" && uri == "resource://data/file.txt")
         );
     }

--- a/crates/services/opencode-rs/tests/integration.rs
+++ b/crates/services/opencode-rs/tests/integration.rs
@@ -46,6 +46,7 @@ use opencode_rs::types::event::Event;
 use opencode_rs::types::message::CommandRequest;
 use opencode_rs::types::message::PromptPart;
 use opencode_rs::types::message::PromptRequest;
+use opencode_rs::types::new_message_id;
 use opencode_rs::types::session::CreateSessionRequest;
 use std::time::Duration;
 
@@ -533,7 +534,7 @@ async fn test_agents_list() {
 /// Test that command dispatch reaches command lookup instead of request validation.
 #[tokio::test]
 #[ignore = "requires: opencode serve"]
-async fn test_command_dispatch_passes_request_validation() {
+async fn test_command_dispatch_passes_request_validation_with_message_id() {
     if !should_run() {
         return;
     }
@@ -552,7 +553,7 @@ async fn test_command_dispatch_passes_request_validation() {
             &CommandRequest {
                 command: "___definitely_not_a_real_command___".into(),
                 arguments: "hello".into(),
-                message_id: None,
+                message_id: Some(new_message_id()),
             },
         )
         .await;


### PR DESCRIPTION
## Summary
- generate orchestrator command message IDs with the OpenCode-compatible `msg` prefix
- add wiremock regression coverage for `/command` request `messageID`
- add SDK serialization/live validation coverage for caller-provided command message IDs

## Tests
- just check
- just test

## Live validation requested
- OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" OPENCODE_INTEGRATION=1 cargo test -p opencode_rs --features server --test integration test_command_dispatch_passes_request_validation_with_message_id -- --ignored --exact --test-threads=1
- OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" OPENCODE_ORCHESTRATOR_INTEGRATION=1 cargo test -p opencode-orchestrator-mcp --test integration unknown_command_errors_fast -- --ignored --exact --test-threads=1

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

Command dispatches from `opencode-orchestrator-mcp` were attaching a custom `messageID` like `orchestrator-command-...`, but OpenCode expects server-valid message IDs with the `msg_` format. That meant command requests could fail request validation before the server even looked up the command, and it weakened the orchestrator's transport-recovery path because the transcript probe depends on a valid persisted message ID.

## What user-facing changes did I ship?

Commands launched through the orchestrator now send OpenCode-compatible `messageID` values, which prevents avoidable invalid-input failures and lets the orchestrator correlate dispatched commands with the session transcript after ambiguous transport errors. This is a reliability fix; there is no new user-facing API or configuration.

## How I implemented it

- Replaced the orchestrator-local command message ID generator with `opencode_rs::types::new_message_id()` so `/session/{id}/command` uses the same `msg_...` format as the SDK.
- Kept the generated ID in the existing command transcript window so the post-transport transcript probe can still match the exact dispatched command.
- Added SDK serialization coverage to assert `CommandRequest.message_id` is emitted as `messageID` and carries a `msg`-prefixed value.
- Added an ignored live `opencode-rs` integration test that verifies a caller-provided command `messageID` now gets past request validation and fails later at unknown-command lookup, which is the expected server behavior.
- Added a wiremock regression test in the orchestrator crate that inspects the outgoing `/command` POST body and verifies the generated `messageID` is present and server-valid.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools and they passed
- [ ] I did not run the ignored live SDK validation that requires an external OpenCode server (`opencode serve`). Suggested command: `OPENCODE_BINARY=bunx OPENCODE_BINARY_ARGS="--yes opencode-ai@1.17.4" OPENCODE_INTEGRATION=1 cargo test -p opencode_rs --features server --test integration test_command_dispatch_passes_request_validation_with_message_id -- --ignored --exact --test-threads=1`

## Description for the changelog

Fix orchestrator command dispatch to send OpenCode-compatible message IDs and add regression coverage for command request validation.
<!-- END:describe_pr:autogen -->
