### PR TITLE
fix(agentic-outer-dag): recover from github check-suite 422s

### DIFF
--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -13,6 +13,7 @@ use crate::state::StageKind;
 use crate::state::store::ThoughtsStateStore;
 use crate::worktree::freshness;
 use anyhow::Result;
+use pr_comments::github::GitHubRestError;
 use std::fmt::Write as _;
 use std::future::Future;
 use std::time::Duration;
@@ -225,9 +226,31 @@ where
     Ok(updated_pr)
 }
 
+#[derive(Debug)]
 enum DraftSkipRecovery {
     ContinueWaiting,
     TerminalStop { message: String },
+}
+
+#[derive(Debug)]
+enum CheckSuite422Recovery {
+    NotApplicable,
+    ContinueWaiting,
+    TerminalStop { message: String },
+}
+
+fn is_check_suites_no_commit_found_422(err: &GitHubRestError, head_sha: &str) -> bool {
+    if err.status != 422 {
+        return false;
+    }
+
+    let expected_path = format!("/commits/{head_sha}/check-suites");
+    if !err.url.contains(&expected_path) {
+        return false;
+    }
+
+    let body = err.body.to_ascii_lowercase();
+    body.contains("no commit found for sha") && body.contains(&head_sha.to_ascii_lowercase())
 }
 
 async fn recover_from_draft_review_skip<DetectPr, DetectPrFut, MarkReady, MarkReadyFut>(
@@ -276,6 +299,68 @@ where
             .to_string(),
     );
     Ok(DraftSkipRecovery::ContinueWaiting)
+}
+
+async fn recover_from_check_suite_no_commit_found_422<DetectPr, DetectPrFut>(
+    state: &mut RunState,
+    head_sha: &str,
+    poll_error: &anyhow::Error,
+    detect_pr: DetectPr,
+) -> Result<CheckSuite422Recovery>
+where
+    DetectPr: FnOnce() -> DetectPrFut,
+    DetectPrFut: Future<Output = Result<DetectedPrLookup>>,
+{
+    let Some(rest) = poll_error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<GitHubRestError>())
+        .filter(|rest| is_check_suites_no_commit_found_422(rest, head_sha))
+    else {
+        return Ok(CheckSuite422Recovery::NotApplicable);
+    };
+
+    let branch = state.worktree.branch.clone();
+    let lookup = match detect_pr().await {
+        Ok(lookup) => lookup,
+        Err(error) => {
+            return Ok(CheckSuite422Recovery::TerminalStop {
+                message: format!(
+                    "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, and PR re-detection failed for branch '{branch}': {error}\n\nURL: {}\nBody: {}",
+                    rest.url, rest.body
+                ),
+            });
+        }
+    };
+
+    record_pr_lookup(state, StageKind::WaitingForCoderabbit, &lookup);
+
+    let Some(pr) = lookup.pr else {
+        return Ok(CheckSuite422Recovery::TerminalStop {
+            message: format!(
+                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, but no open PR could be re-detected for branch '{branch}'.\n\nURL: {}\nBody: {}",
+                rest.url, rest.body
+            ),
+        });
+    };
+
+    if pr.head_sha == head_sha {
+        return Ok(CheckSuite422Recovery::TerminalStop {
+            message: format!(
+                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}. Re-detected remote PR head is unchanged ({head_sha}); stopping for manual handoff.\n\nURL: {}\nBody: {}",
+                rest.url, rest.body
+            ),
+        });
+    }
+
+    let old = head_sha.to_string();
+    let new = pr.head_sha.clone();
+    persist_detected_pr(state, &pr);
+    state.stage.kind = StageKind::WaitingForCoderabbit;
+    state.stage.details = Some(format!(
+        "Recovered from GitHub check-suites 422 (No commit found for SHA) for stale head {old}; remote PR head is now {new}. Updated stored head SHA and continuing to wait."
+    ));
+
+    Ok(CheckSuite422Recovery::ContinueWaiting)
 }
 
 fn persist_stop_state_before_handoff<Save>(state: &RunState, save: Save) -> Result<String>
@@ -412,16 +497,55 @@ impl DagEngine {
                         .pr
                         .number
                         .ok_or_else(|| anyhow::anyhow!("missing PR number in state"))?;
-                    let head_sha = state
-                        .pr
-                        .head_sha
-                        .clone()
-                        .ok_or_else(|| anyhow::anyhow!("missing PR head SHA in state"))?;
                     let mut started_at = chrono::Utc::now();
                     let timeout_seconds = i64::try_from(state.settings.coderabbit_timeout_seconds)
                         .map_err(|_| anyhow::anyhow!("coderabbit timeout exceeds i64 range"))?;
                     loop {
-                        match self.coderabbit.poll_once(pr_number, &head_sha).await? {
+                        let head_sha = state
+                            .pr
+                            .head_sha
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("missing PR head SHA in state"))?;
+                        let poll = match self.coderabbit.poll_once(pr_number, &head_sha).await {
+                            Ok(poll) => poll,
+                            Err(err) => {
+                                let branch = state.worktree.branch.clone();
+                                let github = &self.github;
+
+                                match recover_from_check_suite_no_commit_found_422(
+                                    &mut state,
+                                    &head_sha,
+                                    &err,
+                                    || github.detect_open_pr_from_branch(&branch),
+                                )
+                                .await?
+                                {
+                                    CheckSuite422Recovery::NotApplicable => return Err(err),
+                                    CheckSuite422Recovery::ContinueWaiting => {
+                                        started_at = chrono::Utc::now();
+                                        ThoughtsStateStore::save(&state)?;
+                                        tokio::time::sleep(poll_interval_sleep_duration(
+                                            state.settings.poll_interval_seconds,
+                                        ))
+                                        .await;
+                                        continue;
+                                    }
+                                    CheckSuite422Recovery::TerminalStop { message } => {
+                                        state.stage.kind = StageKind::StoppedManualHandoff;
+                                        state.stage.details = Some(message);
+                                        let message = persist_stop_state_before_handoff(
+                                            &state,
+                                            ThoughtsStateStore::save,
+                                        )?;
+                                        linear::post_handoff_once(&mut state, &message).await?;
+                                        ThoughtsStateStore::save(&state)?;
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        };
+
+                        match poll {
                             CodeRabbitPoll::Completed => {
                                 state.coderabbit.current_cycle += 1;
                                 state.stage.kind = StageKind::DispatchingResolvePrComments;
@@ -768,14 +892,17 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::CheckSuite422Recovery;
     use super::DagEngine;
     use super::DraftSkipRecovery;
     use super::detecting_pr_retry_attempt_number;
     use super::ensure_pr_ready_for_review;
+    use super::is_check_suites_no_commit_found_422;
     use super::persist_stop_state_before_handoff;
     use super::planned_actions_for_start;
     use super::poll_interval_sleep_duration;
     use super::record_pr_lookup;
+    use super::recover_from_check_suite_no_commit_found_422;
     use super::recover_from_draft_review_skip;
     use super::should_reset_coderabbit_timeout_baseline;
     use super::stage_kind_label;
@@ -787,6 +914,7 @@ mod tests {
     use crate::state::StageKind;
     use crate::test_support::process_state_lock;
     use crate::worktree::TargetWorktree;
+    use pr_comments::github::GitHubRestError;
     use pr_comments::models::PrRef;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -812,6 +940,17 @@ mod tests {
             false,
         )
         .expect("sample state builds")
+    }
+
+    fn check_suites_422_error(head_sha: &str) -> anyhow::Error {
+        GitHubRestError {
+            status: 422,
+            url: format!(
+                "https://api.github.com/repos/owner/repo/commits/{head_sha}/check-suites?page=1&per_page=100"
+            ),
+            body: format!("{{\"message\":\"No commit found for SHA: {head_sha}\"}}"),
+        }
+        .into()
     }
 
     #[test]
@@ -1234,6 +1373,165 @@ mod tests {
                 .expect("stale detail")
                 .contains("treating it as stale")
         );
+    }
+
+    #[test]
+    fn check_suite_422_classifier_requires_status_url_and_body_match() {
+        let matching = GitHubRestError {
+            status: 422,
+            url: "https://api.github.com/repos/owner/repo/commits/abc123/check-suites?page=1"
+                .to_string(),
+            body: "No commit found for SHA: abc123".to_string(),
+        };
+        assert!(is_check_suites_no_commit_found_422(&matching, "abc123"));
+
+        let wrong_status = GitHubRestError {
+            status: 404,
+            ..matching.clone()
+        };
+        assert!(!is_check_suites_no_commit_found_422(
+            &wrong_status,
+            "abc123"
+        ));
+
+        let wrong_url = GitHubRestError {
+            url: "https://api.github.com/repos/owner/repo/issues/1/comments".to_string(),
+            ..matching.clone()
+        };
+        assert!(!is_check_suites_no_commit_found_422(&wrong_url, "abc123"));
+
+        let wrong_body = GitHubRestError {
+            body: "validation failed".to_string(),
+            ..matching
+        };
+        assert!(!is_check_suites_no_commit_found_422(&wrong_body, "abc123"));
+    }
+
+    #[tokio::test]
+    async fn recover_from_check_suites_422_continues_when_remote_head_changed() {
+        let mut state = sample_state();
+        state.pr.head_sha = Some("abc123".to_string());
+
+        let recovery = recover_from_check_suite_no_commit_found_422(
+            &mut state,
+            "abc123",
+            &check_suites_422_error("abc123"),
+            || async {
+                Ok(DetectedPrLookup {
+                    requested_branch: "feature/eng-992".to_string(),
+                    current_branch: Some("feature/eng-992".to_string()),
+                    repo_owner: "allisoneer".to_string(),
+                    repo_name: "agentic_auxilary".to_string(),
+                    token_source: Some("GH_TOKEN".to_string()),
+                    empty_result_reason: None,
+                    pr: Some(PrRef {
+                        head_sha: "def456".to_string(),
+                        ..sample_pr(false)
+                    }),
+                })
+            },
+        )
+        .await
+        .expect("recovery should succeed");
+
+        assert!(matches!(recovery, CheckSuite422Recovery::ContinueWaiting));
+        assert_eq!(state.pr.head_sha.as_deref(), Some("def456"));
+        assert_eq!(state.pr.last_observed_head_sha.as_deref(), Some("def456"));
+        assert_eq!(state.stage.kind, StageKind::WaitingForCoderabbit);
+        assert!(
+            state
+                .stage
+                .details
+                .as_deref()
+                .expect("recovery detail")
+                .contains("Updated stored head SHA and continuing to wait")
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_from_check_suites_422_stops_when_remote_head_unchanged() {
+        let mut state = sample_state();
+
+        let recovery = recover_from_check_suite_no_commit_found_422(
+            &mut state,
+            "abc123",
+            &check_suites_422_error("abc123"),
+            || async {
+                Ok(DetectedPrLookup {
+                    requested_branch: "feature/eng-992".to_string(),
+                    current_branch: Some("feature/eng-992".to_string()),
+                    repo_owner: "allisoneer".to_string(),
+                    repo_name: "agentic_auxilary".to_string(),
+                    token_source: Some("GH_TOKEN".to_string()),
+                    empty_result_reason: None,
+                    pr: Some(sample_pr(false)),
+                })
+            },
+        )
+        .await
+        .expect("recovery should succeed");
+
+        match recovery {
+            CheckSuite422Recovery::TerminalStop { message } => {
+                assert!(message.contains("Re-detected remote PR head is unchanged (abc123)"));
+                assert!(message.contains("/commits/abc123/check-suites"));
+                assert!(message.contains("No commit found for SHA"));
+            }
+            other => panic!("expected terminal stop, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recover_from_check_suites_422_stops_when_pr_not_redetected() {
+        let mut state = sample_state();
+
+        let recovery = recover_from_check_suite_no_commit_found_422(
+            &mut state,
+            "abc123",
+            &check_suites_422_error("abc123"),
+            || async {
+                Ok(DetectedPrLookup {
+                    requested_branch: "feature/eng-992".to_string(),
+                    current_branch: Some("feature/eng-992".to_string()),
+                    repo_owner: "allisoneer".to_string(),
+                    repo_name: "agentic_auxilary".to_string(),
+                    token_source: Some("GH_TOKEN".to_string()),
+                    empty_result_reason: Some("no_open_pull_requests_matched_branch".to_string()),
+                    pr: None,
+                })
+            },
+        )
+        .await
+        .expect("recovery should succeed");
+
+        match recovery {
+            CheckSuite422Recovery::TerminalStop { message } => {
+                assert!(message.contains("no open PR could be re-detected"));
+                assert!(message.contains("No commit found for SHA"));
+            }
+            other => panic!("expected terminal stop, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recover_from_check_suites_422_ignores_non_matching_422() {
+        let mut state = sample_state();
+
+        let err: anyhow::Error = GitHubRestError {
+            status: 422,
+            url: "https://api.github.com/repos/owner/repo/issues/1/comments".to_string(),
+            body: "No commit found for SHA: abc123".to_string(),
+        }
+        .into();
+
+        let recovery =
+            recover_from_check_suite_no_commit_found_422(&mut state, "abc123", &err, || async {
+                panic!("non-matching 422 should not trigger PR re-detection")
+            })
+            .await
+            .expect("classification should succeed");
+
+        assert!(matches!(recovery, CheckSuite422Recovery::NotApplicable));
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -253,6 +253,10 @@ fn is_check_suites_no_commit_found_422(err: &GitHubRestError, head_sha: &str) ->
     body.contains("no commit found for sha") && body.contains(&head_sha.to_ascii_lowercase())
 }
 
+fn check_suite_422_footer(rest: &GitHubRestError) -> String {
+    format!("\n\nURL: {}\nBody: {}", rest.url, rest.body)
+}
+
 async fn recover_from_draft_review_skip<DetectPr, DetectPrFut, MarkReady, MarkReadyFut>(
     state: &mut RunState,
     reason: &str,
@@ -325,8 +329,8 @@ where
         Err(error) => {
             return Ok(CheckSuite422Recovery::TerminalStop {
                 message: format!(
-                    "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, and PR re-detection failed for branch '{branch}': {error}\n\nURL: {}\nBody: {}",
-                    rest.url, rest.body
+                    "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, and PR re-detection failed for branch '{branch}': {error}{}",
+                    check_suite_422_footer(rest)
                 ),
             });
         }
@@ -337,8 +341,8 @@ where
     let Some(pr) = lookup.pr else {
         return Ok(CheckSuite422Recovery::TerminalStop {
             message: format!(
-                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, but no open PR could be re-detected for branch '{branch}'.\n\nURL: {}\nBody: {}",
-                rest.url, rest.body
+                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}, but no open PR could be re-detected for branch '{branch}'.{}",
+                check_suite_422_footer(rest)
             ),
         });
     };
@@ -346,8 +350,8 @@ where
     if pr.head_sha == head_sha {
         return Ok(CheckSuite422Recovery::TerminalStop {
             message: format!(
-                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}. Re-detected remote PR head is unchanged ({head_sha}); stopping for manual handoff.\n\nURL: {}\nBody: {}",
-                rest.url, rest.body
+                "GitHub check-suites returned 422 (No commit found for SHA) for {head_sha}. Re-detected remote PR head is unchanged ({head_sha}); stopping for manual handoff.{}",
+                check_suite_422_footer(rest)
             ),
         });
     }

--- a/crates/tools/pr-comments/src/github.rs
+++ b/crates/tools/pr-comments/src/github.rs
@@ -24,6 +24,25 @@ use std::time::Duration;
 
 const REST_PER_PAGE: usize = 100;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitHubRestError {
+    pub status: u16,
+    pub url: String,
+    pub body: String,
+}
+
+impl std::fmt::Display for GitHubRestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GitHub REST request failed: HTTP {} for {}: {}",
+            self.status, self.url, self.body
+        )
+    }
+}
+
+impl std::error::Error for GitHubRestError {}
+
 pub struct GitHubClient {
     client: Octocrab,
     http: reqwest::Client,
@@ -229,12 +248,24 @@ impl GitHubClient {
             .get(&url)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("GitHub REST request failed: {e}"))?
-            .error_for_status()
             .map_err(|e| anyhow::anyhow!("GitHub REST request failed: {e}"))?;
-        response
-            .json()
+
+        let status = response.status();
+        let body = response
+            .bytes()
             .await
+            .map_err(|e| anyhow::anyhow!("GitHub REST request failed: {e}"))?;
+
+        if status.is_client_error() || status.is_server_error() {
+            return Err(GitHubRestError {
+                status: status.as_u16(),
+                url,
+                body: String::from_utf8_lossy(&body).to_string(),
+            }
+            .into());
+        }
+
+        serde_json::from_slice(&body)
             .map_err(|e| anyhow::anyhow!("GitHub REST JSON parse failed: {e}"))
     }
 
@@ -782,6 +813,7 @@ fn parse_issue_comments_response(value: serde_json::Value) -> Result<Vec<IssueCo
 #[cfg(test)]
 mod tests {
     use super::GitHubClient;
+    use super::GitHubRestError;
     use super::REST_PER_PAGE;
     use super::parse_open_pr_ref_lookup_response;
     use crate::models::OpenPrRefData;
@@ -974,10 +1006,44 @@ mod tests {
             .await
             .expect_err("http status failure should bubble up");
 
+        let rest = err
+            .downcast_ref::<GitHubRestError>()
+            .expect("typed REST error should be preserved");
+        assert_eq!(rest.status, 500);
+        assert!(rest.url.contains("/commits/missing/check-suites"));
+        assert_eq!(rest.body, "server error");
         assert!(
-            err.to_string().contains("GitHub REST request failed:"),
-            "unexpected error: {err}"
+            rest.to_string()
+                .contains("GitHub REST request failed: HTTP 500")
         );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rest_get_preserves_422_body_for_check_suites_no_commit_found() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/repos/owner/repo/commits/badsha/check-suites")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), REST_PER_PAGE.to_string()),
+            ]))
+            .with_status(422)
+            .with_body(r#"{"message":"No commit found for SHA: badsha"}"#)
+            .create_async()
+            .await;
+
+        let err = client(server.url())
+            .list_check_suites_for_ref("badsha")
+            .await
+            .expect_err("422 should fail");
+
+        let rest = err
+            .downcast_ref::<GitHubRestError>()
+            .expect("should surface GitHubRestError");
+        assert_eq!(rest.status, 422);
+        assert!(rest.url.contains("/commits/badsha/check-suites"));
+        assert!(rest.body.contains("No commit found for SHA"));
         mock.assert_async().await;
     }
 


### PR DESCRIPTION
Preserve structured REST failure details so the waiting engine can distinguish the targeted "No commit found for SHA" case and recover without crashing. This keeps stale-head recovery bounded while preserving existing behavior for unrelated poll failures.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-1053: the outer DAG waiting loop could crash while waiting for CodeRabbit when GitHub returned a REST `422` from the check-suites endpoint with `No commit found for SHA` for the stored PR head SHA.

That can happen when the local stored head SHA becomes stale relative to the remote PR head. Before this change, the GitHub REST helper collapsed non-success HTTP responses into generic errors, so the DAG could not distinguish this recoverable stale-head case from unrelated polling failures.

## What user-facing changes did I ship?

- The outer DAG now recovers from GitHub check-suite `422` responses that specifically mean `No commit found for SHA` on the stored PR head.
- When recovery finds that the remote PR head changed, the DAG updates the stored PR head SHA, records the refreshed PR lookup, resets the CodeRabbit wait baseline, saves state, and continues waiting instead of crashing.
- If recovery cannot safely continue, the DAG stops in manual handoff with the GitHub URL/body included so the operator has actionable context.
- Non-matching GitHub REST failures still bubble up as errors, preserving existing behavior for unrelated polling problems.

## How I implemented it

- Added a typed `GitHubRestError` in `pr_comments::github` that preserves HTTP status, request URL, and response body for GitHub REST failures.
- Updated the GitHub REST JSON helper to read response bytes once, return `GitHubRestError` for 4xx/5xx responses, and continue deserializing successful responses from the captured body.
- Added check-suite `422` classification in the outer DAG that requires all of:
  - HTTP status `422`
  - a check-suites URL for the current stored head SHA
  - a response body containing `No commit found for SHA` and the same SHA
- Added bounded recovery that re-detects the open PR for the branch:
  - continues waiting only when the re-detected remote PR head differs from the stale stored head
  - stops for manual handoff if PR re-detection fails, no open PR is found, or the remote head is unchanged
- Added regression tests for typed REST error preservation, 422 body preservation, classifier matching, successful stale-head recovery, terminal handoff cases, and ignoring unrelated 422 responses.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
  - `just crate-check pr_comments`
  - `just crate-test pr_comments`
  - `just crate-check agentic-outer-dag-bin`
  - `just crate-test agentic-outer-dag-bin`
  - `just check`
  - `just test`

## Description for the changelog

- Fixed outer DAG CodeRabbit waiting so GitHub check-suite `422 No commit found for SHA` responses for stale PR heads are recovered by refreshing PR head state instead of crashing.
<!-- END:describe_pr:autogen -->
