### PR TITLE
fix(subagents): explicitly disallow claude lsp tool

### DIFF
--- a/crates/services/claudecode-rs/src/mcp/validate.rs
+++ b/crates/services/claudecode-rs/src/mcp/validate.rs
@@ -277,6 +277,7 @@ pub const KNOWN_BUILTIN_TOOLS: &[&str] = &[
     "KillShell",
     "SlashCommand",
     "LS",
+    "LSP",
     "AskUserQuestion",
     "Skill",
 ];
@@ -755,6 +756,7 @@ mod tests {
         assert!(KNOWN_BUILTIN_TOOLS.contains(&"WebSearch"));
         assert!(KNOWN_BUILTIN_TOOLS.contains(&"TodoWrite"));
         assert!(KNOWN_BUILTIN_TOOLS.contains(&"Task"));
+        assert!(KNOWN_BUILTIN_TOOLS.contains(&"LSP"));
     }
 
     #[test]

--- a/crates/tools/coding-agent-tools/src/lib.rs
+++ b/crates/tools/coding-agent-tools/src/lib.rs
@@ -51,6 +51,32 @@ fn pick_non_empty_text(result: &claudecode::types::Result) -> Option<String> {
 }
 
 const ASK_AGENT_TIMEOUT_CLEANUP_TIMEOUT_SECS: u64 = 5;
+const CLAUDE_TOOL_LSP: &str = "LSP";
+
+fn build_subagent_session_config(
+    query: String,
+    model: claudecode::types::Model,
+    system_prompt: String,
+    builtin_tools: Vec<String>,
+    enabled_tools: Vec<String>,
+    mcp_config: claudecode::config::MCPConfig,
+) -> claudecode::Result<claudecode::config::SessionConfig> {
+    use claudecode::config::SessionConfig;
+    use claudecode::types::OutputFormat;
+    use claudecode::types::PermissionMode;
+
+    SessionConfig::builder(query)
+        .model(model)
+        .output_format(OutputFormat::Text)
+        .permission_mode(PermissionMode::DontAsk)
+        .system_prompt(system_prompt)
+        .tools(builtin_tools)
+        .allowed_tools(enabled_tools)
+        .disallow_tool(CLAUDE_TOOL_LSP)
+        .mcp_config(mcp_config)
+        .strict_mcp_config(true)
+        .build()
+}
 
 async fn wait_for_claude_result<F, C, CFn>(
     ctx: &agentic_tools_core::ToolContext,
@@ -377,11 +403,8 @@ impl CodingAgentTools {
         ctx: &agentic_tools_core::ToolContext,
     ) -> Result<AgentOutput, ToolError> {
         use claudecode::client::Client;
-        use claudecode::config::SessionConfig;
         use claudecode::mcp::validate::ValidateOptions;
         use claudecode::mcp::validate::ensure_valid_mcp_config;
-        use claudecode::types::OutputFormat;
-        use claudecode::types::PermissionMode;
 
         // Start logging context
         let log_ctx = logging::ToolLogCtx::start("ask_agent");
@@ -444,18 +467,14 @@ impl CodingAgentTools {
             return Err(ToolError::Internal(error_msg));
         }
 
-        // Build session config
-        let builder = SessionConfig::builder(query)
-            .model(model)
-            .output_format(OutputFormat::Text)
-            .permission_mode(PermissionMode::DontAsk)
-            .system_prompt(system_prompt)
-            .tools(builtin_tools) // controls built-in tools in schema
-            .allowed_tools(enabled_tools.clone()) // auto-approve enabled tools (built-in + MCP)
-            .mcp_config(mcp_config)
-            .strict_mcp_config(true); // prevent inheritance of global MCP tools
-
-        let config = match builder.build() {
+        let config = match build_subagent_session_config(
+            query,
+            model,
+            system_prompt,
+            builtin_tools,
+            enabled_tools.clone(),
+            mcp_config,
+        ) {
             Ok(c) => c,
             Err(e) => {
                 let error_msg = format!("Failed to build session config: {e}");
@@ -1221,6 +1240,70 @@ mod ask_agent_filter_tests {
         };
         // Helper uses trim().is_empty() for emptiness check, but returns original string
         assert_eq!(pick_non_empty_text(&r).as_deref(), Some("  result text  "));
+    }
+
+    #[test]
+    fn ask_agent_config_disallows_lsp_for_analyzer_codebase() {
+        let agent_type = crate::types::AgentType::Analyzer;
+        let location = crate::types::AgentLocation::Codebase;
+        let model = agent::model_for(agent_type, &SubagentsConfig::default());
+        let system_prompt = agent::compose_prompt(agent_type, location);
+        let enabled_tools = agent::enabled_tools_for(agent_type, location);
+        let (builtin_tools, _mcp_tools): (Vec<String>, Vec<String>) = enabled_tools
+            .iter()
+            .cloned()
+            .partition(|tool| !tool.starts_with("mcp__"));
+
+        let config = build_subagent_session_config(
+            "query".to_string(),
+            model,
+            system_prompt,
+            builtin_tools.clone(),
+            enabled_tools.clone(),
+            agent::build_mcp_config(location, &enabled_tools),
+        )
+        .unwrap_or_else(|e| panic!("session config build failed: {e}"));
+
+        assert_eq!(config.tools.as_ref(), Some(&builtin_tools));
+        assert!(
+            config
+                .disallowed_tools
+                .as_ref()
+                .is_some_and(|tools| tools.iter().any(|tool| tool == CLAUDE_TOOL_LSP))
+        );
+    }
+
+    #[test]
+    fn ask_agent_config_disallows_lsp_when_builtin_tools_are_empty() {
+        let agent_type = crate::types::AgentType::Locator;
+        let location = crate::types::AgentLocation::Codebase;
+        let model = agent::model_for(agent_type, &SubagentsConfig::default());
+        let system_prompt = agent::compose_prompt(agent_type, location);
+        let enabled_tools = agent::enabled_tools_for(agent_type, location);
+        let (builtin_tools, _mcp_tools): (Vec<String>, Vec<String>) = enabled_tools
+            .iter()
+            .cloned()
+            .partition(|tool| !tool.starts_with("mcp__"));
+
+        assert!(builtin_tools.is_empty());
+
+        let config = build_subagent_session_config(
+            "query".to_string(),
+            model,
+            system_prompt,
+            builtin_tools,
+            enabled_tools.clone(),
+            agent::build_mcp_config(location, &enabled_tools),
+        )
+        .unwrap_or_else(|e| panic!("session config build failed: {e}"));
+
+        assert!(config.tools.as_ref().is_some_and(Vec::is_empty));
+        assert!(
+            config
+                .disallowed_tools
+                .as_ref()
+                .is_some_and(|tools| tools.iter().any(|tool| tool == CLAUDE_TOOL_LSP))
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/review-tools/Cargo.toml
+++ b/crates/tools/review-tools/Cargo.toml
@@ -31,7 +31,11 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "test-util",
+] }
 
 [lints]
 workspace = true

--- a/crates/tools/review-tools/src/reviewer.rs
+++ b/crates/tools/review-tools/src/reviewer.rs
@@ -22,6 +22,7 @@ use crate::types::ReviewLens;
 
 /// Reviewer sub-agent builtin tools (Claude Code native).
 pub const REVIEWER_BUILTIN_TOOLS: [&str; 1] = ["Read"];
+const CLAUDE_TOOL_LSP: &str = "LSP";
 
 /// Reviewer capability profile for a lens-specific reviewer session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,6 +195,25 @@ impl ClaudeCliRunner {
             mcp_servers: servers,
         }
     }
+
+    fn build_session_config(
+        profile: ReviewerCapabilityProfile,
+        system_prompt: String,
+        user_prompt: String,
+    ) -> Result<SessionConfig, ToolError> {
+        SessionConfig::builder(user_prompt)
+            .model(Model::Opus)
+            .output_format(OutputFormat::Text)
+            .permission_mode(PermissionMode::DontAsk)
+            .system_prompt(system_prompt)
+            .tools(Self::builtin_tools())
+            .allowed_tools(Self::all_tools(profile))
+            .disallow_tool(CLAUDE_TOOL_LSP)
+            .mcp_config(Self::mcp_config(profile))
+            .strict_mcp_config(true)
+            .build()
+            .map_err(|e| ToolError::Internal(format!("Failed to build session config: {e}")))
+    }
 }
 
 impl Default for ClaudeCliRunner {
@@ -212,9 +232,6 @@ impl ReviewerRunner for ClaudeCliRunner {
     ) -> BoxFuture<'static, Result<String, ToolError>> {
         let semaphore = Arc::clone(&self.semaphore);
         let run_timeout_secs = self.config.run_timeout_secs;
-        let builtin_tools = Self::builtin_tools();
-        let all_tools = Self::all_tools(profile);
-        let mcp_config = Self::mcp_config(profile);
 
         Box::pin(async move {
             // Acquire semaphore permit
@@ -224,17 +241,7 @@ impl ReviewerRunner for ClaudeCliRunner {
                 .map_err(|_| ToolError::Internal("Semaphore closed".into()))?;
 
             // Build session config
-            let cfg = SessionConfig::builder(user_prompt)
-                .model(Model::Opus)
-                .output_format(OutputFormat::Text)
-                .permission_mode(PermissionMode::DontAsk)
-                .system_prompt(system_prompt)
-                .tools(builtin_tools)
-                .allowed_tools(all_tools)
-                .mcp_config(mcp_config)
-                .strict_mcp_config(true)
-                .build()
-                .map_err(|e| ToolError::Internal(format!("Failed to build session config: {e}")))?;
+            let cfg = Self::build_session_config(profile, system_prompt, user_prompt)?;
 
             let result = run_with_optional_timeout(run_timeout_secs, async {
                 let client = Client::new()
@@ -401,6 +408,26 @@ mod tests {
                 Duration::from_secs(1)
             ]
         );
+    }
+
+    #[test]
+    fn reviewer_session_config_disallows_lsp_for_all_profiles() {
+        for profile in [
+            ReviewerCapabilityProfile::Narrow,
+            ReviewerCapabilityProfile::Completeness,
+        ] {
+            let config =
+                ClaudeCliRunner::build_session_config(profile, "system".into(), "user".into())
+                    .unwrap_or_else(|e| panic!("session config build failed: {e}"));
+
+            assert!(
+                config
+                    .disallowed_tools
+                    .as_ref()
+                    .is_some_and(|tools| tools.iter().any(|tool| tool == CLAUDE_TOOL_LSP)),
+                "missing LSP disallow for {profile:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -145,6 +145,7 @@ This repo's Claude settings are intentionally narrow. The point is to allow only
       "Edit",
       "Glob",
       "Grep",
+      "LSP",
       "Agent",
       "Skill",
       "EnterWorktree",


### PR DESCRIPTION
Prevents repo-owned coding and review sub-agent sessions from inheriting Claude's built-in LSP tool. describe_pr will update this body with full details.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-876: Claude Code added an `LSP` built-in tool that can appear through ambient/global Claude settings. Our repo-owned sub-agent launches already use strict MCP config and explicit allowlists, but the coding-agent `ask_agent` and review sub-agent session builders did not explicitly deny this built-in. That left room for sub-agents to inherit or access language-server capabilities outside the intended tool surface.

This PR is ready for review and is not a draft.

## What user-facing changes did I ship?

- Coding sub-agents launched through `ask_agent` now explicitly disallow Claude's `LSP` tool.
- Review sub-agents now explicitly disallow Claude's `LSP` tool for both narrow and completeness profiles.
- Fresh install Claude permission guidance now includes `LSP` in the example deny list.
- Built-in tool validation metadata now recognizes `LSP`, so deny/allow validation can reason about the current Claude built-in tool set.

## How I implemented it

- Added a shared `CLAUDE_TOOL_LSP` constant where session configs are assembled.
- Extracted coding-agent sub-agent session config construction into `build_subagent_session_config`, preserving the existing model, prompt, output format, `DontAsk` permission mode, explicit built-in tool list, allowed tools, MCP config, and `strict_mcp_config(true)`, while adding `.disallow_tool("LSP")`.
- Extracted review-agent session config construction into `ClaudeCliRunner::build_session_config`, preserving existing reviewer profile tool selection and strict MCP config while adding `.disallow_tool("LSP")`.
- Added focused regression tests that assert `LSP` appears in `disallowed_tools` for:
  - coding-agent analyzer/codebase sessions with built-in tools present
  - coding-agent locator/codebase sessions where the built-in tool list is empty
  - review-agent narrow and completeness profiles
- Added `LSP` to `KNOWN_BUILTIN_TOOLS` and its coverage test.
- Enabled Tokio `test-util` for `review_tools` test support.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Verification passed:

- [x] `just crate-check claudecode`
- [x] `just crate-test claudecode`
- [x] `just crate-check coding_agent_tools`
- [x] `just crate-test coding_agent_tools`
- [x] `just crate-check review_tools`
- [x] `just crate-test review_tools`
- [x] `just check`
- [x] `just test`

## Description for the changelog

Explicitly disallow Claude's built-in `LSP` tool for coding and review sub-agents, update built-in tool validation metadata, and document `LSP` in the fresh install deny-list example.
<!-- END:describe_pr:autogen -->
