### PR TITLE
feat(agentic-bin): add repo-local opencode install command

### DIFF
--- a/apps/agentic/CLAUDE.md
+++ b/apps/agentic/CLAUDE.md
@@ -59,6 +59,14 @@ Check configuration for errors and warnings without modifying.
 - Shows advisory warnings for deprecated keys, invalid values, etc.
 - Exit code 0 even with warnings (non-fatal)
 
+### `install [--path PATH] [--force]`
+Install `OpenCode` configuration assets into the containing git repository root.
+- Installs managed `.opencode/**` assets first, then `opencode.json` last
+- Fails if any managed destination exists unless `--force` is supplied
+- With `--force`, overwrites managed files only and never deletes unrelated `.opencode` content
+- Requires running inside a git repository, or passing `--path` inside one
+- Does not install `.mcp.json`, Claude settings, or binaries
+
 ## How Config Loading Works
 
 The CLI uses `agentic_config::loader::load_merged()` which:
@@ -111,6 +119,8 @@ export AGENTIC_REASONING_OPTIMIZER_MODEL=anthropic/claude-sonnet-4.6
 ## Module Structure
 
 - `commands/config.rs`: All config subcommand implementations
+- `commands/install.rs`: `agentic install` implementation
+- `commands/install_manifest.rs`: Embedded install-managed `OpenCode` assets
 - `commands/mod.rs`: Command routing
 - `main.rs`: CLI entry point with clap
 

--- a/apps/agentic/CLAUDE.md
+++ b/apps/agentic/CLAUDE.md
@@ -60,6 +60,7 @@ Check configuration for errors and warnings without modifying.
 - Exit code 0 even with warnings (non-fatal)
 
 ### `install [--path PATH] [--force]`
+
 Install `OpenCode` configuration assets into the containing git repository root.
 - Installs managed `.opencode/**` assets first, then `opencode.json` last
 - Fails if any managed destination exists unless `--force` is supplied

--- a/apps/agentic/src/commands/install.rs
+++ b/apps/agentic/src/commands/install.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use atomicwrites::AtomicFile;
 use atomicwrites::OverwriteBehavior;
 use colored::Colorize;
+use std::io::ErrorKind;
 use std::io::Write;
 use std::path::Component;
 use std::path::Path;
@@ -85,11 +86,9 @@ fn preflight(repo_root: &Path, force: bool) -> Result<()> {
             })?;
         }
 
-        if dst.exists() {
-            let meta = std::fs::symlink_metadata(&dst).with_context(|| {
-                format!("Failed to read metadata for managed path {}", dst.display())
-            })?;
-
+        if let Some(meta) = symlink_metadata_if_present(&dst).with_context(|| {
+            format!("Failed to read metadata for managed path {}", dst.display())
+        })? {
             if meta.file_type().is_symlink() {
                 fatal_conflicts.push(format!("{} (refusing to write to symlink)", asset.rel_path));
                 continue;
@@ -153,9 +152,9 @@ fn preflight_parent_dirs(repo_root: &Path, parent: &Path) -> Result<()> {
 
     for component in rel_parent.components() {
         current.push(component);
-        if current.exists() {
-            let meta = std::fs::symlink_metadata(&current)
-                .with_context(|| format!("Failed to inspect {}", current.display()))?;
+        if let Some(meta) = symlink_metadata_if_present(&current)
+            .with_context(|| format!("Failed to inspect {}", current.display()))?
+        {
             if meta.file_type().is_symlink() {
                 anyhow::bail!(
                     "refusing to traverse symlink directory: {}",
@@ -169,6 +168,14 @@ fn preflight_parent_dirs(repo_root: &Path, parent: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn symlink_metadata_if_present(path: &Path) -> Result<Option<std::fs::Metadata>, std::io::Error> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 fn ensure_parent_dir(path: &Path) -> Result<()> {

--- a/apps/agentic/src/commands/install.rs
+++ b/apps/agentic/src/commands/install.rs
@@ -1,0 +1,195 @@
+use crate::commands::install_manifest::INSTALL_MANIFEST;
+use anyhow::Context;
+use anyhow::Result;
+use atomicwrites::AtomicFile;
+use atomicwrites::OverwriteBehavior;
+use colored::Colorize;
+use std::io::Write;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn execute(path: Option<PathBuf>, force: bool) -> Result<()> {
+    let start_dir = resolve_dir(path)?;
+    let repo_root = find_git_root(&start_dir)?;
+
+    preflight(&repo_root, force)?;
+
+    if INSTALL_MANIFEST.last().map(|asset| asset.rel_path) != Some("opencode.json") {
+        anyhow::bail!("internal error: INSTALL_MANIFEST must end with opencode.json");
+    }
+
+    for asset in INSTALL_MANIFEST {
+        let dst = repo_root.join(asset.rel_path);
+        ensure_parent_dir(&dst)?;
+        write_atomic_str(&dst, asset.contents, force)?;
+    }
+
+    println!(
+        "{} Installed {} managed file(s) into {}",
+        "OK".green(),
+        INSTALL_MANIFEST.len(),
+        repo_root.display().to_string().cyan()
+    );
+
+    Ok(())
+}
+
+fn resolve_dir(path: Option<PathBuf>) -> Result<PathBuf> {
+    match path {
+        None => std::env::current_dir().context("Failed to determine current directory"),
+        Some(path) => {
+            if !path.exists() {
+                anyhow::bail!("--path does not exist: {}", path.display());
+            }
+            if !path.is_dir() {
+                anyhow::bail!("--path is not a directory: {}", path.display());
+            }
+            Ok(path)
+        }
+    }
+}
+
+fn find_git_root(start: &Path) -> Result<PathBuf> {
+    let mut current = start
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", start.display()))?;
+
+    loop {
+        let marker = current.join(".git");
+        if marker.exists() {
+            return Ok(current);
+        }
+
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent.to_path_buf();
+    }
+
+    anyhow::bail!("Not in a git repository. Run 'git init' first.")
+}
+
+fn preflight(repo_root: &Path, force: bool) -> Result<()> {
+    let mut existing_conflicts = Vec::new();
+    let mut fatal_conflicts = Vec::new();
+
+    for asset in INSTALL_MANIFEST {
+        ensure_safe_rel_path(asset.rel_path)?;
+
+        let dst = repo_root.join(asset.rel_path);
+
+        if let Some(parent) = dst.parent() {
+            preflight_parent_dirs(repo_root, parent).with_context(|| {
+                format!("Preflight failed for parent dirs of {}", asset.rel_path)
+            })?;
+        }
+
+        if dst.exists() {
+            let meta = std::fs::symlink_metadata(&dst).with_context(|| {
+                format!("Failed to read metadata for managed path {}", dst.display())
+            })?;
+
+            if meta.file_type().is_symlink() {
+                fatal_conflicts.push(format!("{} (refusing to write to symlink)", asset.rel_path));
+                continue;
+            }
+
+            if meta.is_dir() {
+                fatal_conflicts.push(format!(
+                    "{} (expected file, found directory)",
+                    asset.rel_path
+                ));
+                continue;
+            }
+
+            if !force {
+                existing_conflicts.push(asset.rel_path.to_string());
+            }
+        }
+    }
+
+    if !fatal_conflicts.is_empty() {
+        let details = fatal_conflicts
+            .into_iter()
+            .map(|path| format!("  - {path}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!("Install cannot proceed due to path conflicts:\n{details}");
+    }
+
+    if !existing_conflicts.is_empty() {
+        let details = existing_conflicts
+            .into_iter()
+            .map(|path| format!("  - {path}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "Managed file(s) already exist:\n{details}\nRe-run with --force to overwrite managed files."
+        );
+    }
+
+    Ok(())
+}
+
+fn ensure_safe_rel_path(rel_path: &str) -> Result<()> {
+    let path = Path::new(rel_path);
+    if path.is_absolute() {
+        anyhow::bail!("internal error: manifest path is absolute: {rel_path}");
+    }
+
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            anyhow::bail!("internal error: manifest path contains '..': {rel_path}");
+        }
+    }
+
+    Ok(())
+}
+
+fn preflight_parent_dirs(repo_root: &Path, parent: &Path) -> Result<()> {
+    let rel_parent = parent.strip_prefix(repo_root).unwrap_or(parent);
+    let mut current = repo_root.to_path_buf();
+
+    for component in rel_parent.components() {
+        current.push(component);
+        if current.exists() {
+            let meta = std::fs::symlink_metadata(&current)
+                .with_context(|| format!("Failed to inspect {}", current.display()))?;
+            if meta.file_type().is_symlink() {
+                anyhow::bail!(
+                    "refusing to traverse symlink directory: {}",
+                    current.display()
+                );
+            }
+            if !meta.is_dir() {
+                anyhow::bail!("expected directory but found file: {}", current.display());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+
+    Ok(())
+}
+
+fn write_atomic_str(path: &Path, contents: &str, force: bool) -> Result<()> {
+    let overwrite_behavior = if force {
+        OverwriteBehavior::AllowOverwrite
+    } else {
+        OverwriteBehavior::DisallowOverwrite
+    };
+
+    AtomicFile::new(path, overwrite_behavior)
+        .write(|file| file.write_all(contents.as_bytes()))
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    Ok(())
+}

--- a/apps/agentic/src/commands/install_manifest.rs
+++ b/apps/agentic/src/commands/install_manifest.rs
@@ -1,0 +1,210 @@
+pub struct InstallAsset {
+    pub rel_path: &'static str,
+    pub contents: &'static str,
+}
+
+macro_rules! include_repo_str {
+    ($path:literal) => {
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../", $path))
+    };
+}
+
+// Order matters: .opencode assets first, opencode.json last.
+pub const INSTALL_MANIFEST: &[InstallAsset] = &[
+    InstallAsset {
+        rel_path: ".opencode/sysprompt.md",
+        contents: include_repo_str!(".opencode/sysprompt.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/sysprompt_gpt54.md",
+        contents: include_repo_str!(".opencode/sysprompt_gpt54.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/orchestrator_sysprompt.md",
+        contents: include_repo_str!(".opencode/orchestrator_sysprompt.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/orchestrator_sysprompt_gpt54.md",
+        contents: include_repo_str!(".opencode/orchestrator_sysprompt_gpt54.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/review_sysprompt.md",
+        contents: include_repo_str!(".opencode/review_sysprompt.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/review_sysprompt_gpt54.md",
+        contents: include_repo_str!(".opencode/review_sysprompt_gpt54.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/bash.md",
+        contents: include_repo_str!(".opencode/command/bash.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/capture_pr_comments_openai.md",
+        contents: include_repo_str!(".opencode/command/capture_pr_comments_openai.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/commit.md",
+        contents: include_repo_str!(".opencode/command/commit.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/create_plan_final.md",
+        contents: include_repo_str!(".opencode/command/create_plan_final.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/create_plan_init.md",
+        contents: include_repo_str!(".opencode/command/create_plan_init.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/decide_findings_openai.md",
+        contents: include_repo_str!(".opencode/command/decide_findings_openai.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/describe_pr.md",
+        contents: include_repo_str!(".opencode/command/describe_pr.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/discord.md",
+        contents: include_repo_str!(".opencode/command/discord.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/frame_openai.md",
+        contents: include_repo_str!(".opencode/command/frame_openai.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/implement_plan.md",
+        contents: include_repo_str!(".opencode/command/implement_plan.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/linear.md",
+        contents: include_repo_str!(".opencode/command/linear.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/linear_ticket_2_pr.md",
+        contents: include_repo_str!(".opencode/command/linear_ticket_2_pr.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/linear_ticket_design_brief.md",
+        contents: include_repo_str!(".opencode/command/linear_ticket_design_brief.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/openai.md",
+        contents: include_repo_str!(".opencode/command/openai.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/playwright.md",
+        contents: include_repo_str!(".opencode/command/playwright.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/research.md",
+        contents: include_repo_str!(".opencode/command/research.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/resolve_pr_comments.md",
+        contents: include_repo_str!(".opencode/command/resolve_pr_comments.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/resume_work_openai.md",
+        contents: include_repo_str!(".opencode/command/resume_work_openai.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/review.md",
+        contents: include_repo_str!(".opencode/command/review.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/review_pr_comments.md",
+        contents: include_repo_str!(".opencode/command/review_pr_comments.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/sync_with_main_and_resolve_conflicts.md",
+        contents: include_repo_str!(".opencode/command/sync_with_main_and_resolve_conflicts.md"),
+    },
+    InstallAsset {
+        rel_path: ".opencode/command/unwind_openai.md",
+        contents: include_repo_str!(".opencode/command/unwind_openai.md"),
+    },
+    InstallAsset {
+        rel_path: "opencode.json",
+        contents: include_repo_str!("opencode.json"),
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::collections::HashSet;
+
+    #[test]
+    fn manifest_ends_with_opencode_json() {
+        assert_eq!(
+            INSTALL_MANIFEST.last().map(|asset| asset.rel_path),
+            Some("opencode.json")
+        );
+    }
+
+    #[test]
+    fn manifest_paths_are_relative_and_do_not_escape() {
+        for asset in INSTALL_MANIFEST {
+            let path = std::path::Path::new(asset.rel_path);
+            assert!(
+                !path.is_absolute(),
+                "manifest path is absolute: {}",
+                asset.rel_path
+            );
+            assert!(
+                !path
+                    .components()
+                    .any(|component| matches!(component, std::path::Component::ParentDir)),
+                "manifest path escapes repo root: {}",
+                asset.rel_path
+            );
+        }
+    }
+
+    #[test]
+    fn opencode_json_file_refs_are_in_manifest() {
+        let opencode = INSTALL_MANIFEST
+            .iter()
+            .find(|asset| asset.rel_path == "opencode.json")
+            .expect("manifest should include opencode.json");
+
+        let parsed: Value =
+            serde_json::from_str(opencode.contents).expect("opencode.json should be valid JSON");
+        let mut file_refs = Vec::new();
+        collect_file_refs(&parsed, &mut file_refs);
+
+        let manifest_paths = INSTALL_MANIFEST
+            .iter()
+            .map(|asset| asset.rel_path)
+            .collect::<HashSet<_>>();
+
+        for file_ref in file_refs {
+            let normalized = file_ref.strip_prefix("./").unwrap_or(&file_ref);
+            assert!(
+                manifest_paths.contains(normalized),
+                "missing manifest entry for file ref: {file_ref} (normalized: {normalized})"
+            );
+        }
+    }
+
+    fn collect_file_refs(value: &Value, output: &mut Vec<String>) {
+        match value {
+            Value::String(string) => {
+                if let Some(inner) = string
+                    .strip_prefix("{file:")
+                    .and_then(|value| value.strip_suffix('}'))
+                {
+                    output.push(inner.to_string());
+                }
+            }
+            Value::Array(values) => values
+                .iter()
+                .for_each(|value| collect_file_refs(value, output)),
+            Value::Object(object) => object
+                .values()
+                .for_each(|value| collect_file_refs(value, output)),
+            Value::Null | Value::Bool(_) | Value::Number(_) => {}
+        }
+    }
+}

--- a/apps/agentic/src/commands/mod.rs
+++ b/apps/agentic/src/commands/mod.rs
@@ -1,3 +1,5 @@
 //! CLI command implementations.
 
 pub mod config;
+pub mod install;
+pub mod install_manifest;

--- a/apps/agentic/src/main.rs
+++ b/apps/agentic/src/main.rs
@@ -31,6 +31,17 @@ enum Commands {
         #[command(subcommand)]
         command: commands::config::ConfigCommands,
     },
+
+    /// Install `OpenCode` configuration assets into the containing git repository
+    Install {
+        /// Path inside the target repo (defaults to current directory)
+        #[arg(long)]
+        path: Option<std::path::PathBuf>,
+
+        /// Overwrite existing managed files
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -52,5 +63,6 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Config { command } => commands::config::execute(command),
+        Commands::Install { path, force } => commands::install::execute(path, force),
     }
 }

--- a/apps/agentic/tests/config_commands.rs
+++ b/apps/agentic/tests/config_commands.rs
@@ -232,7 +232,18 @@ fn test_help_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("config"))
+        .stdout(predicate::str::contains("install"))
         .stdout(predicate::str::contains("Configuration"));
+}
+
+#[test]
+fn test_install_help_flag() {
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--path"))
+        .stdout(predicate::str::contains("--force"));
 }
 
 #[test]

--- a/apps/agentic/tests/install_command.rs
+++ b/apps/agentic/tests/install_command.rs
@@ -2,6 +2,8 @@ use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use serde_json::Value;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use tempfile::TempDir;
 
 fn agentic_cmd() -> Command {
@@ -136,6 +138,48 @@ fn install_force_overwrites_managed_preserves_unmanaged() {
     let new_managed = std::fs::read_to_string(&managed).unwrap();
     assert!(new_managed.contains("# Agent System Prompt"));
     assert_eq!(std::fs::read_to_string(&unmanaged).unwrap(), "keep me");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_refuses_dangling_symlink_at_managed_destination() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+
+    std::fs::create_dir_all(temp.path().join(".opencode")).unwrap();
+    symlink(
+        temp.path().join("missing-target.md"),
+        temp.path().join(".opencode/sysprompt.md"),
+    )
+    .unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--path", temp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("refusing to write to symlink"))
+        .stderr(predicate::str::contains(".opencode/sysprompt.md"));
+}
+
+#[cfg(unix)]
+#[test]
+fn install_refuses_dangling_symlink_in_parent_directory() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+    let symlink_path = temp.path().join(".opencode");
+
+    symlink(temp.path().join("missing-dir"), &symlink_path).unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--path", temp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to traverse symlink directory",
+        ))
+        .stderr(predicate::str::contains(
+            symlink_path.to_string_lossy().as_ref(),
+        ));
 }
 
 fn assert_installed_file_refs_resolve(repo_root: &std::path::Path) {

--- a/apps/agentic/tests/install_command.rs
+++ b/apps/agentic/tests/install_command.rs
@@ -1,0 +1,180 @@
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn agentic_cmd() -> Command {
+    cargo_bin_cmd!("agentic")
+}
+
+fn init_fake_git_repo(dir: &std::path::Path) {
+    assert!(std::fs::create_dir_all(dir.join(".git")).is_ok());
+}
+
+const EXPECTED_FILES: &[&str] = &[
+    ".opencode/sysprompt.md",
+    ".opencode/sysprompt_gpt54.md",
+    ".opencode/orchestrator_sysprompt.md",
+    ".opencode/orchestrator_sysprompt_gpt54.md",
+    ".opencode/review_sysprompt.md",
+    ".opencode/review_sysprompt_gpt54.md",
+    ".opencode/command/bash.md",
+    ".opencode/command/capture_pr_comments_openai.md",
+    ".opencode/command/commit.md",
+    ".opencode/command/create_plan_final.md",
+    ".opencode/command/create_plan_init.md",
+    ".opencode/command/decide_findings_openai.md",
+    ".opencode/command/describe_pr.md",
+    ".opencode/command/discord.md",
+    ".opencode/command/frame_openai.md",
+    ".opencode/command/implement_plan.md",
+    ".opencode/command/linear.md",
+    ".opencode/command/linear_ticket_2_pr.md",
+    ".opencode/command/linear_ticket_design_brief.md",
+    ".opencode/command/openai.md",
+    ".opencode/command/playwright.md",
+    ".opencode/command/research.md",
+    ".opencode/command/resolve_pr_comments.md",
+    ".opencode/command/resume_work_openai.md",
+    ".opencode/command/review.md",
+    ".opencode/command/review_pr_comments.md",
+    ".opencode/command/sync_with_main_and_resolve_conflicts.md",
+    ".opencode/command/unwind_openai.md",
+    "opencode.json",
+];
+
+#[test]
+fn install_succeeds_into_git_repo_root() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--path", temp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed"));
+
+    for rel_path in EXPECTED_FILES {
+        assert!(temp.path().join(rel_path).exists(), "missing {rel_path}");
+    }
+
+    assert_installed_file_refs_resolve(temp.path());
+}
+
+#[test]
+fn install_fails_outside_git_repo() {
+    let temp = TempDir::new().unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--path", temp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not in a git repository"));
+}
+
+#[test]
+fn install_from_nested_dir_targets_repo_root() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+
+    let nested = temp.path().join("a/b/c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.current_dir(&nested)
+        .args(["install"])
+        .assert()
+        .success();
+
+    assert!(temp.path().join("opencode.json").exists());
+    assert!(!nested.join("opencode.json").exists());
+}
+
+#[test]
+fn install_preflight_blocks_without_force_and_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+
+    std::fs::create_dir_all(temp.path().join(".opencode")).unwrap();
+    std::fs::write(temp.path().join(".opencode/sysprompt.md"), "user version").unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.args(["install", "--path", temp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Managed file(s) already exist"))
+        .stderr(predicate::str::contains(".opencode/sysprompt.md"));
+
+    assert!(!temp.path().join("opencode.json").exists());
+    assert!(!temp.path().join(".opencode/command/bash.md").exists());
+}
+
+#[test]
+fn install_force_overwrites_managed_preserves_unmanaged() {
+    let temp = TempDir::new().unwrap();
+    init_fake_git_repo(temp.path());
+
+    std::fs::create_dir_all(temp.path().join(".opencode")).unwrap();
+
+    let unmanaged = temp.path().join(".opencode/custom.md");
+    std::fs::write(&unmanaged, "keep me").unwrap();
+
+    let managed = temp.path().join(".opencode/sysprompt.md");
+    std::fs::write(&managed, "old").unwrap();
+
+    let mut cmd = agentic_cmd();
+    cmd.args([
+        "install",
+        "--force",
+        "--path",
+        temp.path().to_str().unwrap(),
+    ])
+    .assert()
+    .success();
+
+    let new_managed = std::fs::read_to_string(&managed).unwrap();
+    assert!(new_managed.contains("# Agent System Prompt"));
+    assert_eq!(std::fs::read_to_string(&unmanaged).unwrap(), "keep me");
+}
+
+fn assert_installed_file_refs_resolve(repo_root: &std::path::Path) {
+    let opencode = match std::fs::read_to_string(repo_root.join("opencode.json")) {
+        Ok(contents) => contents,
+        Err(error) => panic!("failed to read installed opencode.json: {error}"),
+    };
+    let parsed: Value = match serde_json::from_str(&opencode) {
+        Ok(parsed) => parsed,
+        Err(error) => panic!("failed to parse installed opencode.json: {error}"),
+    };
+    let mut file_refs = Vec::new();
+    collect_file_refs(&parsed, &mut file_refs);
+
+    for file_ref in file_refs {
+        let normalized = file_ref.strip_prefix("./").unwrap_or(&file_ref);
+        assert!(
+            repo_root.join(normalized).exists(),
+            "missing file ref target {normalized}"
+        );
+    }
+}
+
+fn collect_file_refs(value: &Value, output: &mut Vec<String>) {
+    match value {
+        Value::String(string) => {
+            if let Some(inner) = string
+                .strip_prefix("{file:")
+                .and_then(|value| value.strip_suffix('}'))
+            {
+                output.push(inner.to_string());
+            }
+        }
+        Value::Array(values) => values
+            .iter()
+            .for_each(|value| collect_file_refs(value, output)),
+        Value::Object(object) => object
+            .values()
+            .for_each(|value| collect_file_refs(value, output)),
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}

--- a/docs/setup/fresh_install.md
+++ b/docs/setup/fresh_install.md
@@ -62,6 +62,22 @@ cargo binstall opencode-orchestrator-mcp
 
 If you prefer prebuilt binaries, this repo publishes release artifacts. Grab the right one for your platform and put it somewhere on `PATH`.
 
+## Install OpenCode config (repo-local)
+
+Once `agentic` is on `PATH`, install the repo-local `OpenCode` config surface with:
+
+```bash
+agentic install
+# or from elsewhere:
+agentic install --path /path/to/repo
+```
+
+Notes:
+- The target must be inside a git repository; installation resolves to the repo root
+- It installs managed `.opencode/**` assets plus root `opencode.json`
+- Use `--force` to overwrite managed files only; unrelated `.opencode` files are preserved
+- It does not install binaries, so `opencode`, `agentic-mcp`, and `opencode-orchestrator-mcp` must already be on `PATH`
+
 ## Log into Claude Code and OpenCode
 
 Do this before you start blaming MCP wiring.


### PR DESCRIPTION
Bundle the managed OpenCode config surface into the agentic binary so
released builds can install a deterministic repo-local setup without
depending on a source checkout. The command preflights all managed
paths, requires explicit force for overwrites, and preserves unrelated
.opencode contents.


<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

Released `agentic` binaries did not have a first-class way to install the repository-managed OpenCode configuration surface into another git repository. Users had to copy `opencode.json` and the matching `.opencode/**` prompt/command files from a source checkout, which made fresh setup error-prone and could leave `opencode.json` pointing at missing prompt files.

This PR adds a deterministic `agentic install` workflow that installs only the managed OpenCode assets into the target repository root while avoiding accidental overwrites by default.

## What user-facing changes did I ship?

- Added `agentic install` to install repo-local OpenCode assets into the containing git repository.
- Added `--path PATH` so users can run installation from outside the target repo, as long as the path is inside a git repository.
- Added `--force` to overwrite existing managed files while preserving unrelated `.opencode` content.
- Added clear failure behavior when:
  - the target path does not exist or is not a directory,
  - the path is not inside a git repository,
  - managed files already exist and `--force` was not supplied,
  - a managed path or parent directory would traverse a symlink or incompatible file/directory.
- Updated `agentic` crate docs and fresh install docs with the new setup command and its constraints.

## How I implemented it

- Added a new clap subcommand in `agentic` that routes `agentic install [--path PATH] [--force]` into the install command implementation.
- Added an embedded install manifest containing the managed OpenCode config files:
  - `.opencode/*.md` system/review/orchestrator prompts,
  - `.opencode/command/*.md` command prompts,
  - root `opencode.json`.
- The manifest embeds assets at compile time with `include_str!`, so released binaries can install the managed config without requiring a source checkout.
- The installer resolves the target git root from the current directory or `--path`, preflights every managed destination, and writes all assets only after conflicts are checked.
- Writes use atomic file replacement semantics and install `.opencode/**` assets before `opencode.json`, so the root config is written last after referenced files are in place.
- Added tests for help output, successful installation, nested-directory repo root resolution, outside-repo failure, no-force conflict behavior, `--force` overwrite behavior, preservation of unmanaged `.opencode` files, manifest path safety, and `opencode.json` file-reference coverage.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification completed:

- [x] `just crate-check agentic-bin` passed
- [x] `just crate-test agentic-bin` passed
- [x] `just check` passed
- [x] `just test` passed

## Description for the changelog

Add `agentic install` to install managed repo-local OpenCode configuration assets from released `agentic` binaries, with safe preflight checks, optional forced overwrites of managed files, and documentation for fresh setup.
<!-- END:describe_pr:autogen -->
