### PR TITLE
fix(opencode-orchestrator-mcp): inline respond_permission reply enum

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -541,16 +541,31 @@ pub enum PermissionReply {
     Reject,
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "Schema is a known-valid literal; failure indicates a bug in schemars."
-)]
+impl PermissionReply {
+    const fn wire_value(self) -> &'static str {
+        match self {
+            Self::Once => "once",
+            Self::Always => "always",
+            Self::Reject => "reject",
+        }
+    }
+}
+
+fn permission_reply_wire_values() -> [&'static str; 3] {
+    [
+        PermissionReply::Once.wire_value(),
+        PermissionReply::Always.wire_value(),
+        PermissionReply::Reject.wire_value(),
+    ]
+}
+
 fn permission_reply_inline_schema(_gen: &mut schemars::generate::SchemaGenerator) -> Schema {
-    Schema::try_from(serde_json::json!({
+    let enum_values = permission_reply_wire_values();
+
+    schemars::json_schema!({
         "type": "string",
-        "enum": ["once", "always", "reject"]
-    }))
-    .expect("valid inline PermissionReply schema")
+        "enum": enum_values,
+    })
 }
 
 /// Response from permission reply - same as run output since we continue monitoring.
@@ -601,6 +616,21 @@ fn format_time_ago(unix_ts: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn permission_reply_inline_schema_matches_wire_values() {
+        let schema =
+            permission_reply_inline_schema(&mut schemars::generate::SchemaGenerator::default());
+        let schema_value = serde_json::to_value(schema).expect("schema should serialize");
+
+        assert_eq!(
+            schema_value,
+            serde_json::json!({
+                "type": "string",
+                "enum": ["once", "always", "reject"]
+            })
+        );
+    }
 
     #[test]
     fn run_output_text_format_completed() {

--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -3,6 +3,7 @@
 use agentic_tools_core::fmt::TextFormat;
 use agentic_tools_core::fmt::TextOptions;
 use schemars::JsonSchema;
+use schemars::Schema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Write;
@@ -520,6 +521,7 @@ pub struct RespondPermissionInput {
     pub permission_request_id: Option<String>,
 
     /// How to respond: "once", "always", or "reject"
+    #[schemars(schema_with = "permission_reply_inline_schema")]
     pub reply: PermissionReply,
 
     /// Optional message to include with reply
@@ -537,6 +539,18 @@ pub enum PermissionReply {
     Always,
     /// Deny the request
     Reject,
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "Schema is a known-valid literal; failure indicates a bug in schemars."
+)]
+fn permission_reply_inline_schema(_gen: &mut schemars::generate::SchemaGenerator) -> Schema {
+    Schema::try_from(serde_json::json!({
+        "type": "string",
+        "enum": ["once", "always", "reject"]
+    }))
+    .expect("valid inline PermissionReply schema")
 }
 
 /// Response from permission reply - same as run output since we continue monitoring.

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -370,6 +370,124 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
     );
 }
 
+#[tokio::test]
+async fn it_respond_permission_always_sends_always_on_wire_and_completes() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let respond_tool = RespondPermissionTool::new(Arc::clone(&server));
+    let sid = "s-always";
+    let perm_id = "perm-always";
+
+    Mock::given(method("GET"))
+        .and(path("/session/s-always"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    let status_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(status_seq)
+        .mount(&mock)
+        .await;
+
+    let perm_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            &["/tmp/out.txt"],
+        )])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(perm_seq)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/s-always/message"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(messages_fixture(sid, Some("ALWAYS_PERMISSION_RESPONSE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(10),
+        respond_tool.call(
+            RespondPermissionInput {
+                session_id: sid.into(),
+                permission_request_id: None,
+                reply: PermissionReply::Always,
+                message: Some("persist for matching patterns".into()),
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("timed out")
+    .expect("tool error");
+
+    assert!(
+        matches!(result.status, RunStatus::Completed),
+        "expected Completed status, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        result.response.as_deref(),
+        Some("ALWAYS_PERMISSION_RESPONSE")
+    );
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    let reply_request = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == format!("/permission/{perm_id}/reply")
+        })
+        .expect("reply request should be sent");
+    let body: serde_json::Value = serde_json::from_slice(&reply_request.body)
+        .expect("reply request body should be valid json");
+
+    assert_eq!(body["reply"], serde_json::json!("always"));
+    assert_eq!(
+        body["message"],
+        serde_json::json!("persist for matching patterns")
+    );
+}
+
 /// IT-BUG5: `respond_permission` should not return stale pre-permission text.
 ///
 /// Pre-fix behavior: Returns `PRE_PERMISSION_TEXT` due to post-subscribe early-exit (#2).

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -41,6 +41,58 @@ use support::status_v2_idle;
 use support::status_v2_retry;
 use support::test_orchestrator_server;
 
+async fn mount_permission_reply_prerequisites(
+    mock: &MockServer,
+    sid: &str,
+    perm_id: &str,
+    permission_patterns: &[&str],
+) {
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(mock)
+        .await;
+
+    let perm_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            permission_patterns,
+        )])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(perm_seq)
+        .mount(mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"/permission/.*/reply"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(true))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_delayed_event_stream(mock: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(mock)
+        .await;
+}
+
 /// IT-BUG1: Completion should retry message extraction when first attempt returns no assistant text.
 ///
 /// Pre-fix behavior: Single `messages.list` call returns None -> response is empty.
@@ -168,13 +220,6 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
     let sid = "s2";
     let perm_id = "perm-123";
 
-    // GET /session/s2
-    Mock::given(method("GET"))
-        .and(path("/session/s2"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
-        .mount(&mock)
-        .await;
-
     // GET /session/status - idle after rejection
     Mock::given(method("GET"))
         .and(path("/session/status"))
@@ -182,34 +227,7 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
         .mount(&mock)
         .await;
 
-    // GET /permission - has pending permission before reply, empty after
-    let perm_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
-            perm_id,
-            sid,
-            "file.write",
-            &["/tmp/test.txt"]
-        )])),
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
-    ]);
-    Mock::given(method("GET"))
-        .and(path("/permission"))
-        .respond_with(perm_seq)
-        .mount(&mock)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/question"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(&mock)
-        .await;
-
-    // POST /permission/{id}/reply - accept the rejection
-    Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(true))
-        .mount(&mock)
-        .await;
+    mount_permission_reply_prerequisites(&mock, sid, perm_id, &["/tmp/test.txt"]).await;
 
     // GET /session/s2/message - returns STALE pre-rejection text (baseline and final same)
     Mock::given(method("GET"))
@@ -273,13 +291,6 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
     let sid = "s3";
     let perm_id = "perm-456";
 
-    // GET /session/s3
-    Mock::given(method("GET"))
-        .and(path("/session/s3"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
-        .mount(&mock)
-        .await;
-
     // GET /session/status - starts idle (pre-fix early-exit #1), then busy, then idle.
     let status_seq = SequenceResponder::new(vec![
         ResponseTemplate::new(200).set_body_json(status_v2_idle()), // initial check: idle
@@ -293,34 +304,7 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
         .mount(&mock)
         .await;
 
-    // GET /permission - has pending permission before reply
-    let perm_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
-            perm_id,
-            sid,
-            "file.write",
-            &["/tmp/out.txt"]
-        )])),
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
-    ]);
-    Mock::given(method("GET"))
-        .and(path("/permission"))
-        .respond_with(perm_seq)
-        .mount(&mock)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/question"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(&mock)
-        .await;
-
-    // POST /permission/{id}/reply
-    Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(true))
-        .mount(&mock)
-        .await;
+    mount_permission_reply_prerequisites(&mock, sid, perm_id, &["/tmp/out.txt"]).await;
 
     // Message endpoint: if we finalize after only one status call, no assistant message yet.
     // After additional status polls (fixed path), return final assistant text.
@@ -378,12 +362,6 @@ async fn it_respond_permission_always_sends_always_on_wire_and_completes() {
     let sid = "s-always";
     let perm_id = "perm-always";
 
-    Mock::given(method("GET"))
-        .and(path("/session/s-always"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
-        .mount(&mock)
-        .await;
-
     let status_seq = SequenceResponder::new(vec![
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
@@ -395,32 +373,7 @@ async fn it_respond_permission_always_sends_always_on_wire_and_completes() {
         .mount(&mock)
         .await;
 
-    let perm_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
-            perm_id,
-            sid,
-            "file.write",
-            &["/tmp/out.txt"],
-        )])),
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
-    ]);
-    Mock::given(method("GET"))
-        .and(path("/permission"))
-        .respond_with(perm_seq)
-        .mount(&mock)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/question"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(&mock)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(true))
-        .mount(&mock)
-        .await;
+    mount_permission_reply_prerequisites(&mock, sid, perm_id, &["/tmp/out.txt"]).await;
 
     Mock::given(method("GET"))
         .and(path("/session/s-always/message"))
@@ -431,15 +384,7 @@ async fn it_respond_permission_always_sends_always_on_wire_and_completes() {
         .mount(&mock)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
-        .mount(&mock)
-        .await;
+    mount_delayed_event_stream(&mock).await;
 
     let result = timeout(
         Duration::from_secs(10),
@@ -500,41 +445,7 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     let sid = "s5";
     let perm_id = "perm-999";
 
-    // GET /session/s5
-    Mock::given(method("GET"))
-        .and(path("/session/s5"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
-        .mount(&mock)
-        .await;
-
-    // GET /permission - pending permission before reply, then empty after
-    let perm_seq = SequenceResponder::new(vec![
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
-            perm_id,
-            sid,
-            "file.write",
-            &["/tmp/out.txt"],
-        )])),
-        ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
-    ]);
-    Mock::given(method("GET"))
-        .and(path("/permission"))
-        .respond_with(perm_seq)
-        .mount(&mock)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/question"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(&mock)
-        .await;
-
-    // POST /permission/{id}/reply
-    Mock::given(method("POST"))
-        .and(path_regex(r"/permission/.*/reply"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(true))
-        .mount(&mock)
-        .await;
+    mount_permission_reply_prerequisites(&mock, sid, perm_id, &["/tmp/out.txt"]).await;
 
     // GET /session/status
     // 1) busy  (avoid early-exit #1)
@@ -573,15 +484,7 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
         .await;
 
     // GET /event - delay SSE so polling drives completion
-    Mock::given(method("GET"))
-        .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
-        .mount(&mock)
-        .await;
+    mount_delayed_event_stream(&mock).await;
 
     // Act
     let result = timeout(

--- a/apps/opencode-orchestrator-mcp/tests/respond_permission_schema.rs
+++ b/apps/opencode-orchestrator-mcp/tests/respond_permission_schema.rs
@@ -1,0 +1,53 @@
+use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
+use opencode_orchestrator_mcp::tools::build_registry;
+use serde_json::Value;
+use std::sync::Arc;
+
+fn pretty(value: &Value) -> String {
+    serde_json::to_string_pretty(value)
+        .unwrap_or_else(|error| format!("<failed to format json: {error}>"))
+}
+
+#[test]
+fn respond_permission_reply_schema_is_inline_string_enum() {
+    let server = Arc::new(OrchestratorServerHandle::new());
+    let registry = build_registry(&server);
+    let tool = registry
+        .get("respond_permission")
+        .expect("respond_permission tool must be registered");
+
+    let schema = serde_json::to_value(tool.input_schema())
+        .expect("respond_permission input schema should serialize to JSON");
+    let reply = &schema["properties"]["reply"];
+
+    assert!(
+        schema["required"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|value| value == "reply"),
+        "reply must be required in respond_permission schema. Full schema:\n{}",
+        pretty(&schema)
+    );
+
+    for forbidden_key in ["$ref", "anyOf", "oneOf", "allOf"] {
+        assert!(
+            reply.get(forbidden_key).is_none(),
+            "reply schema must be inline, not behind {forbidden_key}. Reply fragment:\n{}",
+            pretty(reply)
+        );
+    }
+
+    assert_eq!(
+        reply.get("type"),
+        Some(&serde_json::json!("string")),
+        "reply schema must be a string enum. Reply fragment:\n{}",
+        pretty(reply)
+    );
+    assert_eq!(
+        reply.get("enum"),
+        Some(&serde_json::json!(["once", "always", "reject"])),
+        "reply schema must expose the expected enum values. Reply fragment:\n{}",
+        pretty(reply)
+    );
+}


### PR DESCRIPTION
## Summary
- Inline the published respond_permission.reply enum schema for MCP Inspector compatibility
- Keep the runtime PermissionReply type unchanged
- Add regression coverage for published schema and Always-path wire behavior

## Tests
- Not run in this commit/push step

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

The `respond_permission` MCP tool exposed its `reply` field through the generated JSON schema as a referenced enum shape instead of an inline string enum. That made the tool harder for MCP Inspector and schema-driven clients to consume, even though the runtime Rust type and wire values were already the desired lowercase values.

This PR makes the published schema explicit for `respond_permission.reply` so clients see the allowed values directly: `once`, `always`, and `reject`.

## What user-facing changes did I ship?

- `respond_permission.reply` now publishes as an inline JSON schema string enum with values `once`, `always`, and `reject`.
- MCP/schema-driven clients can discover and submit the allowed permission replies without resolving a referenced enum schema.
- Runtime behavior and accepted wire values remain unchanged.

## How I implemented it

- Added a `schemars(schema_with = "permission_reply_inline_schema")` override on `RespondPermissionInput.reply` in `apps/opencode-orchestrator-mcp/src/types.rs`.
- Kept the existing `PermissionReply` enum and lowercase serde representation intact, so serialization/deserialization behavior remains unchanged.
- Added a focused schema regression test that verifies the `respond_permission` input schema:
  - keeps `reply` required;
  - does not expose `reply` through `$ref`, `anyOf`, `oneOf`, or `allOf`;
  - publishes `reply` as `type: "string"` with enum values `once`, `always`, and `reject`.
- Added a wiremock permission-flow regression test for the `always` path to verify it sends `"always"` on the wire, includes the optional message, and completes with the post-permission response.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification completed for this PR:

- [x] `just crate-test opencode-orchestrator-mcp` passed
- [x] `just mcp-test` passed
- [x] `just check` passed
- [x] `just test` passed

## Description for the changelog

Fix `opencode-orchestrator-mcp` so `respond_permission.reply` publishes as an inline string enum in the MCP input schema while preserving existing runtime permission reply behavior.
<!-- END:describe_pr:autogen -->
