### PR TITLE
ENG-926 hide wait_for_activity from run schema

### DIFF
--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -1159,7 +1159,7 @@ Examples:
 - New session with prompt and agent: run(message="explain this code", agent="Plan")
 - New session with command: run(command="research", message="caching strategies")
 - Resume session: run(session_id="...", message="continue")
-- Check status: run(session_id="...")"#;
+- Check status (snapshot; returns immediately if already idle): run(session_id="...")"#;
 
     fn call(
         &self,

--- a/apps/opencode-orchestrator-mcp/src/types.rs
+++ b/apps/opencode-orchestrator-mcp/src/types.rs
@@ -34,9 +34,10 @@ pub struct OrchestratorRunInput {
     #[serde(default)]
     pub message: Option<String>,
 
-    /// When true, do not early-exit simply because the session is currently idle.
-    /// Used by permission replies to wait for post-permission activity.
+    /// Internal continuation flag used by interruption replies.
+    /// Not part of the public MCP contract; still accepted for backward compatibility.
     #[serde(default)]
+    #[schemars(skip)]
     pub wait_for_activity: Option<bool>,
 }
 

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -10,6 +10,7 @@ use agentic_tools_core::ToolError;
 use opencode_orchestrator_mcp::config::OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS;
 use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
 use opencode_orchestrator_mcp::tools::RespondPermissionTool;
+use opencode_orchestrator_mcp::tools::build_registry;
 use opencode_orchestrator_mcp::types::OrchestratorRunInput;
 use opencode_orchestrator_mcp::types::PermissionReply;
 use opencode_orchestrator_mcp::types::RespondPermissionInput;
@@ -305,6 +306,92 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
 
     assert!(matches!(result.status, RunStatus::Completed));
     assert_eq!(result.response.as_deref(), Some("RESUME_DONE"));
+}
+
+#[tokio::test]
+async fn run_dispatch_json_accepts_wait_for_activity_and_subscribes_sse() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "0") };
+
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let registry = build_registry(&server);
+    let sid = "legacy-wait-wire";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("OK"))))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(2),
+        registry.dispatch_json(
+            "run",
+            serde_json::json!({
+                "session_id": sid,
+                "wait_for_activity": true,
+            }),
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("dispatch_json should not hang")
+    .expect("run should succeed");
+
+    assert_eq!(result["status"], serde_json::json!("completed"));
+    assert_eq!(result["response"], serde_json::json!("OK"));
+
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("wiremock should capture requests");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.url.path() == "/event"),
+        "expected SSE subscription (/event) when wait_for_activity=true; got paths: {:?}",
+        requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/run_schema_surface.rs
+++ b/apps/opencode-orchestrator-mcp/tests/run_schema_surface.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
-
 use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
 use opencode_orchestrator_mcp::tools::build_registry;
 use std::sync::Arc;
@@ -9,10 +7,18 @@ fn run_input_schema_does_not_advertise_wait_for_activity() {
     let handle = Arc::new(OrchestratorServerHandle::new());
     let registry = build_registry(&handle);
 
-    let run_tool = registry.get("run").expect("run tool must be registered");
+    let Some(run_tool) = registry.get("run") else {
+        panic!("run tool must be registered");
+    };
     let schema = run_tool.input_schema();
-    let json = serde_json::to_value(&schema).expect("schema must serialize");
-    let json_str = serde_json::to_string(&json).expect("schema JSON must serialize");
+    let json = match serde_json::to_value(&schema) {
+        Ok(value) => value,
+        Err(error) => panic!("schema must serialize: {error}"),
+    };
+    let json_str = match serde_json::to_string(&json) {
+        Ok(value) => value,
+        Err(error) => panic!("schema JSON must serialize: {error}"),
+    };
 
     assert!(
         !json_str.contains("wait_for_activity"),

--- a/apps/opencode-orchestrator-mcp/tests/run_schema_surface.rs
+++ b/apps/opencode-orchestrator-mcp/tests/run_schema_surface.rs
@@ -1,0 +1,21 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
+use opencode_orchestrator_mcp::tools::build_registry;
+use std::sync::Arc;
+
+#[test]
+fn run_input_schema_does_not_advertise_wait_for_activity() {
+    let handle = Arc::new(OrchestratorServerHandle::new());
+    let registry = build_registry(&handle);
+
+    let run_tool = registry.get("run").expect("run tool must be registered");
+    let schema = run_tool.input_schema();
+    let json = serde_json::to_value(&schema).expect("schema must serialize");
+    let json_str = serde_json::to_string(&json).expect("schema JSON must serialize");
+
+    assert!(
+        !json_str.contains("wait_for_activity"),
+        "run inputSchema must not contain wait_for_activity; got: {json_str}"
+    );
+}


### PR DESCRIPTION
Temporary PR body for ENG-926. Orchestrator will replace with describe_pr output.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-926: the `run` tool's public MCP input schema advertised `wait_for_activity`, even though that flag is an internal continuation control used by interruption/permission reply flows rather than a public wait contract.

This made the `run` surface look like callers should use `wait_for_activity` directly for status polling or waiting semantics. The fix needs to remove that field from the advertised schema without breaking existing continuation callers or backward-compatible JSON dispatch paths that may still send it.

## What user-facing changes did I ship?

- The `run` MCP input schema no longer advertises `wait_for_activity`.
- The `run` tool examples now describe `run(session_id="...")` as an immediate status snapshot when the session is already idle, rather than implying a blocking wait operation.
- Existing callers that still pass `wait_for_activity` in JSON remain supported.

## How I implemented it

- Added `#[schemars(skip)]` to `OrchestratorRunInput::wait_for_activity` so schema generation omits the field while serde still accepts it at runtime.
- Updated the field documentation to clarify that `wait_for_activity` is an internal continuation flag retained for backward compatibility.
- Updated the `run` tool help text for the status-check example to make the immediate snapshot behavior explicit.
- Added regression coverage that asserts the generated `run` input schema does not contain `wait_for_activity`.
- Added regression coverage that dispatches `run` via JSON with legacy `wait_for_activity: true` and verifies it still succeeds and subscribes to `/event` for SSE activity handling.

Commit: `60b7f1496ba1357a0693143d1371006a9f2f5982`

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-check opencode-orchestrator-mcp` passed
- [x] `just crate-test opencode-orchestrator-mcp` passed
- [x] `just check` passed
- [x] `just test` passed

## Description for the changelog

Hide the internal `opencode-orchestrator-mcp` `run.wait_for_activity` flag from the public MCP schema while preserving backward-compatible JSON dispatch behavior.
<!-- END:describe_pr:autogen -->
