### PR TITLE
ENG-1085: Stream live progress during outer-dag runs

### DIFF
--- a/apps/agentic-outer-dag/src/cli.rs
+++ b/apps/agentic-outer-dag/src/cli.rs
@@ -15,9 +15,13 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Suppress output except errors
+    /// Reduce log output to errors only (does not suppress final status output)
     #[arg(short, long)]
     pub quiet: bool,
+
+    /// Suppress live progress output; print only final status
+    #[arg(long)]
+    pub final_only: bool,
 
     /// Do not run side-effecting operations.
     #[arg(long)]
@@ -142,6 +146,7 @@ mod tests {
             "handoff",
             "reset",
             "--dry-run",
+            "--final-only",
             "--quiet",
             "--verbose",
         ] {
@@ -220,6 +225,20 @@ mod tests {
                 ..
             } if ticket == "ENG-992" && branch == "feature/eng-992"
         ));
+    }
+
+    #[test]
+    fn parses_final_only_flag_before_subcommand() {
+        let cli = Cli::try_parse_from([
+            "agentic-outer-dag",
+            "--final-only",
+            "start",
+            "--ticket",
+            "ENG-992",
+        ])
+        .expect("final-only should parse");
+
+        assert!(cli.final_only);
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -333,6 +333,20 @@ fn poll_interval_sleep_duration(poll_interval_seconds: u64) -> std::time::Durati
     std::time::Duration::from_secs(poll_interval_seconds.max(1))
 }
 
+fn coderabbit_waiting_details(
+    pr_number: u64,
+    head_sha: &str,
+    cycle: u32,
+    elapsed_seconds: i64,
+    timeout_seconds: i64,
+    poll_interval_seconds: u64,
+) -> String {
+    let remaining = (timeout_seconds - elapsed_seconds).max(0);
+    format!(
+        "waiting for CodeRabbit completion (cycle={cycle}, pr=#{pr_number}, head={head_sha}); elapsed={elapsed_seconds}s; timeout_in={remaining}s; next_poll_in={poll_interval_seconds}s"
+    )
+}
+
 fn should_reset_coderabbit_timeout_baseline(was_recovered: bool, now_recovered: bool) -> bool {
     !was_recovered && now_recovered
 }
@@ -1030,9 +1044,10 @@ impl DagEngine {
                                 }
                             }
                             CodeRabbitPoll::Waiting => {
-                                if (chrono::Utc::now() - started_at).num_seconds()
-                                    >= timeout_seconds
-                                {
+                                let elapsed_seconds =
+                                    (chrono::Utc::now() - started_at).num_seconds().max(0);
+
+                                if elapsed_seconds >= timeout_seconds {
                                     state.stage.kind = StageKind::StoppedTimedOut;
                                     state.stage.details = Some(
                                         "timed out waiting for CodeRabbit completion".to_string(),
@@ -1040,6 +1055,18 @@ impl DagEngine {
                                     ThoughtsStateStore::save(&state)?;
                                     return Ok(());
                                 }
+
+                                state.stage.kind = StageKind::WaitingForCoderabbit;
+                                state.stage.details = Some(coderabbit_waiting_details(
+                                    pr_number,
+                                    &head_sha,
+                                    state.coderabbit.current_cycle,
+                                    elapsed_seconds,
+                                    timeout_seconds,
+                                    state.settings.poll_interval_seconds,
+                                ));
+                                ThoughtsStateStore::save(&state)?;
+
                                 tokio::time::sleep(poll_interval_sleep_duration(
                                     state.settings.poll_interval_seconds,
                                 ))
@@ -1605,6 +1632,7 @@ mod tests {
     use super::UnresolvedReviewThreadsSnapshot;
     use super::baseline_last_described_head_sha_after_pr_create;
     use super::classify_resolve_progress;
+    use super::coderabbit_waiting_details;
     use super::decide_resolve_post_dispatch;
     use super::decide_resolve_pre_dispatch;
     use super::detecting_pr_retry_attempt_number;
@@ -1856,6 +1884,18 @@ mod tests {
         assert_eq!(detecting_pr_retry_attempt_number(0), 2);
         assert_eq!(detecting_pr_retry_attempt_number(1), 3);
         assert_eq!(detecting_pr_retry_attempt_number(3), 5);
+    }
+
+    #[test]
+    fn coderabbit_waiting_details_includes_required_context() {
+        let details = coderabbit_waiting_details(42, "abc123", 3, 120, 600, 30);
+
+        assert!(details.contains("cycle=3"));
+        assert!(details.contains("pr=#42"));
+        assert!(details.contains("head=abc123"));
+        assert!(details.contains("elapsed=120s"));
+        assert!(details.contains("timeout_in=480s"));
+        assert!(details.contains("next_poll_in=30s"));
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use tracing::debug;
 use tracing::info;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -229,7 +230,9 @@ async fn run_engine_until_stop_with_progress(
 
     let result = engine.run_until_stop(stop_after).await;
     stop.store(true, Ordering::Relaxed);
-    let _ = progress_task.await;
+    if let Err(err) = progress_task.await {
+        debug!(error = %err, "progress renderer task ended abnormally");
+    }
     result
 }
 

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -5,6 +5,9 @@ use anyhow::Result;
 use clap::Parser;
 use serde_json::json;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use tracing::info;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -15,6 +18,7 @@ mod github;
 mod linear;
 mod opencode;
 mod preview;
+mod progress;
 mod state;
 #[cfg(test)]
 mod test_support;
@@ -32,6 +36,7 @@ struct StartOptions<'a> {
     coderabbit_timeout_seconds: Option<u64>,
     opencode_session_deadline_seconds: Option<u64>,
     opencode_inactivity_timeout_seconds: Option<u64>,
+    final_only: bool,
 }
 
 struct ResumeOptions<'a> {
@@ -44,6 +49,7 @@ struct ResumeOptions<'a> {
     coderabbit_timeout_seconds: Option<u64>,
     opencode_session_deadline_seconds: Option<u64>,
     opencode_inactivity_timeout_seconds: Option<u64>,
+    final_only: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -96,6 +102,7 @@ async fn main() -> Result<()> {
 
     let cli = cli::Cli::parse();
     let dry_run = cli.dry_run;
+    let final_only = cli.final_only;
     let command = cli.command;
     ensure_supported_dry_run_usage(dry_run, &command)?;
 
@@ -152,6 +159,7 @@ async fn main() -> Result<()> {
                     coderabbit_timeout_seconds,
                     opencode_session_deadline_seconds,
                     opencode_inactivity_timeout_seconds,
+                    final_only,
                 },
             )
             .await
@@ -177,17 +185,52 @@ async fn main() -> Result<()> {
                 coderabbit_timeout_seconds,
                 opencode_session_deadline_seconds,
                 opencode_inactivity_timeout_seconds,
+                final_only,
             })
             .await
         }
         cli::Commands::Status { json } => handle_status(json),
         cli::Commands::RespondPermission { allow, deny } => {
-            handle_respond_permission(allow, deny).await
+            handle_respond_permission(allow, deny, final_only).await
         }
-        cli::Commands::RespondQuestion { answer } => handle_respond_question(&answer).await,
+        cli::Commands::RespondQuestion { answer } => {
+            handle_respond_question(&answer, final_only).await
+        }
         cli::Commands::Handoff { message } => handle_handoff(message.as_deref()).await,
         cli::Commands::Reset { yes } => handle_reset(yes),
     }
+}
+
+async fn run_engine_until_stop_with_progress(
+    engine: &mut dag::engine::DagEngine,
+    stop_after: Option<state::StageKind>,
+    final_only: bool,
+) -> Result<()> {
+    if final_only {
+        return engine.run_until_stop(stop_after).await;
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let progress_stop = Arc::clone(&stop);
+    let progress_task = tokio::spawn(async move {
+        let mut renderer = crate::progress::ProgressRenderer::new();
+        renderer.tick_best_effort();
+
+        let mut ticker = tokio::time::interval(crate::progress::ProgressRenderer::poll_interval());
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        while !progress_stop.load(Ordering::Relaxed) {
+            ticker.tick().await;
+            renderer.tick_best_effort();
+        }
+
+        renderer.tick_best_effort();
+    });
+
+    let result = engine.run_until_stop(stop_after).await;
+    stop.store(true, Ordering::Relaxed);
+    let _ = progress_task.await;
+    result
 }
 
 fn apply_settings_overrides(
@@ -301,7 +344,8 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
     state::store::ThoughtsStateStore::save(&state)?;
 
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(options.stop_after).await?;
+    run_engine_until_stop_with_progress(&mut engine, options.stop_after, options.final_only)
+        .await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after start"))?;
     print_status(&state, false)
@@ -328,7 +372,8 @@ async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
         state::store::ThoughtsStateStore::save(&state)?;
     }
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(options.stop_after).await?;
+    run_engine_until_stop_with_progress(&mut engine, options.stop_after, options.final_only)
+        .await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after resume"))?;
     print_status(&state, false)
@@ -388,7 +433,7 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
     })
 }
 
-async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
+async fn handle_respond_permission(allow: bool, deny: bool, final_only: bool) -> Result<()> {
     anyhow::ensure!(allow ^ deny, "exactly one of --allow or --deny is required");
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
@@ -426,13 +471,13 @@ async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
     state::store::ThoughtsStateStore::save(&state)?;
 
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(None).await?;
+    run_engine_until_stop_with_progress(&mut engine, None, final_only).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
     print_status(&state, false)
 }
 
-async fn handle_respond_question(answer: &str) -> Result<()> {
+async fn handle_respond_question(answer: &str, final_only: bool) -> Result<()> {
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
     anyhow::ensure!(
@@ -466,7 +511,7 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
     state::store::ThoughtsStateStore::save(&state)?;
 
     let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    engine.run_until_stop(None).await?;
+    run_engine_until_stop_with_progress(&mut engine, None, final_only).await?;
     let state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
     print_status(&state, false)
@@ -900,6 +945,7 @@ mod tests {
                 coderabbit_timeout_seconds: None,
                 opencode_session_deadline_seconds: None,
                 opencode_inactivity_timeout_seconds: None,
+                final_only: false,
             },
         )
         .await
@@ -935,6 +981,7 @@ mod tests {
                 coderabbit_timeout_seconds: None,
                 opencode_session_deadline_seconds: None,
                 opencode_inactivity_timeout_seconds: None,
+                final_only: false,
             },
         )
         .await
@@ -965,6 +1012,7 @@ mod tests {
                 coderabbit_timeout_seconds: None,
                 opencode_session_deadline_seconds: None,
                 opencode_inactivity_timeout_seconds: None,
+                final_only: false,
             },
         )
         .await

--- a/apps/agentic-outer-dag/src/progress.rs
+++ b/apps/agentic-outer-dag/src/progress.rs
@@ -142,14 +142,7 @@ impl ProgressRenderer {
     }
 
     fn render_opencode_line_if_needed(&self, snap: &ProgressSnapshot) {
-        let changed = match self.last.as_ref() {
-            Some(last) => {
-                last.opencode_dispatch_attempt != snap.opencode_dispatch_attempt
-                    || last.opencode_last_command != snap.opencode_last_command
-            }
-            None => snap.opencode_last_command.is_some(),
-        };
-        if !changed {
+        if !opencode_line_changed(self.last.as_ref(), snap) {
             return;
         }
 
@@ -262,10 +255,21 @@ fn planned_action_id_for_command(command: &str) -> Option<&'static str> {
     }
 }
 
+fn opencode_line_changed(last: Option<&ProgressSnapshot>, snap: &ProgressSnapshot) -> bool {
+    match last {
+        Some(last) => {
+            last.opencode_dispatch_attempt != snap.opencode_dispatch_attempt
+                || last.opencode_last_command != snap.opencode_last_command
+        }
+        None => snap.opencode_last_command.is_some(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ProgressSnapshot;
     use super::normalize_details;
+    use super::opencode_line_changed;
     use super::planned_action_id_for_command;
     use super::planned_action_id_for_stage;
     use super::stage_kind_label;
@@ -380,14 +384,6 @@ mod tests {
         let renderer = super::ProgressRenderer::new();
         let snapshot = ProgressSnapshot::from_state(&sample_state());
 
-        let changed = match renderer.last.as_ref() {
-            Some(last) => {
-                last.opencode_dispatch_attempt != snapshot.opencode_dispatch_attempt
-                    || last.opencode_last_command != snapshot.opencode_last_command
-            }
-            None => snapshot.opencode_last_command.is_some(),
-        };
-
-        assert!(changed);
+        assert!(opencode_line_changed(renderer.last.as_ref(), &snapshot));
     }
 }

--- a/apps/agentic-outer-dag/src/progress.rs
+++ b/apps/agentic-outer-dag/src/progress.rs
@@ -1,0 +1,356 @@
+use crate::dag::engine::planned_actions_for_start;
+use crate::state::RunState;
+use crate::state::StageKind;
+use crate::state::store::ThoughtsStateStore;
+use std::collections::HashMap;
+use std::time::Duration;
+
+pub const PROGRESS_PREFIX: &str = "outer-dag:";
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProgressSnapshot {
+    stage_kind: StageKind,
+    stage_details: Option<String>,
+    opencode_dispatch_attempt: u32,
+    opencode_last_command: Option<String>,
+    pending_permission_type: Option<String>,
+    pending_question_prompt: Option<String>,
+    pr_url: Option<String>,
+    updated_at: String,
+}
+
+pub struct ProgressRenderer {
+    actions: HashMap<&'static str, (usize, &'static str)>,
+    total_actions: usize,
+    last: Option<ProgressSnapshot>,
+    last_output_at: tokio::time::Instant,
+    warned_load_error: bool,
+}
+
+impl ProgressRenderer {
+    pub fn new() -> Self {
+        let actions_vec = planned_actions_for_start();
+        let total_actions = actions_vec.len();
+        let mut actions = HashMap::new();
+        for (idx, action) in actions_vec.into_iter().enumerate() {
+            actions.insert(action.id, (idx, action.summary));
+        }
+
+        Self {
+            actions,
+            total_actions,
+            last: None,
+            last_output_at: tokio::time::Instant::now(),
+            warned_load_error: false,
+        }
+    }
+
+    pub fn poll_interval() -> Duration {
+        POLL_INTERVAL
+    }
+
+    pub fn tick_best_effort(&mut self) {
+        let loaded = match ThoughtsStateStore::load() {
+            Ok(state) => {
+                self.warned_load_error = false;
+                state
+            }
+            Err(err) => {
+                if !self.warned_load_error {
+                    eprintln!(
+                        "{PROGRESS_PREFIX} progress: failed to load state (will retry): {err}"
+                    );
+                    self.warned_load_error = true;
+                }
+                return;
+            }
+        };
+
+        let Some(state) = loaded else {
+            return;
+        };
+
+        let snapshot = ProgressSnapshot::from_state(&state);
+        self.maybe_render(&snapshot);
+    }
+
+    fn maybe_render(&mut self, snap: &ProgressSnapshot) {
+        let now = tokio::time::Instant::now();
+        let changed = self.last.as_ref() != Some(snap);
+        let should_heartbeat = now.duration_since(self.last_output_at) >= HEARTBEAT_INTERVAL;
+
+        if changed {
+            self.render_stage_line(snap);
+            self.render_pr_line_if_needed(snap);
+            self.render_opencode_line_if_needed(snap);
+            Self::render_interrupt_details_if_needed(snap);
+            self.last_output_at = now;
+            self.last = Some(snap.clone());
+            return;
+        }
+
+        if should_heartbeat {
+            Self::render_heartbeat(snap);
+            self.last_output_at = now;
+        }
+    }
+
+    fn render_stage_line(&self, snap: &ProgressSnapshot) {
+        let kind = stage_kind_label(&snap.stage_kind);
+        let details_suffix = snap
+            .stage_details
+            .as_ref()
+            .map(|details| format!(": {details}"))
+            .unwrap_or_default();
+
+        if let Some(action_id) = planned_action_id_for_stage(&snap.stage_kind)
+            && let Some((idx, summary)) = self.actions.get(action_id)
+        {
+            eprintln!(
+                "{PROGRESS_PREFIX} [{}/{}] {} — {}{}",
+                idx + 1,
+                self.total_actions,
+                kind,
+                summary,
+                details_suffix,
+            );
+            return;
+        }
+
+        eprintln!("{PROGRESS_PREFIX} {kind}{details_suffix}");
+    }
+
+    fn render_pr_line_if_needed(&self, snap: &ProgressSnapshot) {
+        let pr_changed = if let Some(last) = self.last.as_ref() {
+            last.pr_url != snap.pr_url
+        } else {
+            snap.pr_url.is_some()
+        };
+
+        if pr_changed && let Some(url) = snap.pr_url.as_deref() {
+            eprintln!("{PROGRESS_PREFIX} pr: {url}");
+        }
+    }
+
+    fn render_opencode_line_if_needed(&self, snap: &ProgressSnapshot) {
+        let Some(last) = self.last.as_ref() else {
+            return;
+        };
+
+        let dispatch_changed = last.opencode_dispatch_attempt != snap.opencode_dispatch_attempt;
+        let command_changed = last.opencode_last_command != snap.opencode_last_command;
+        if !(dispatch_changed || command_changed) {
+            return;
+        }
+
+        let Some(command) = snap.opencode_last_command.as_deref() else {
+            return;
+        };
+
+        if let Some(action_id) = planned_action_id_for_command(command)
+            && let Some((idx, summary)) = self.actions.get(action_id)
+        {
+            eprintln!(
+                "{PROGRESS_PREFIX} [{}/{}] opencode — {} (attempt={}): {}",
+                idx + 1,
+                self.total_actions,
+                command,
+                snap.opencode_dispatch_attempt,
+                summary,
+            );
+            return;
+        }
+
+        eprintln!(
+            "{PROGRESS_PREFIX} opencode — {} (attempt={})",
+            command, snap.opencode_dispatch_attempt,
+        );
+    }
+
+    fn render_interrupt_details_if_needed(snap: &ProgressSnapshot) {
+        if matches!(snap.stage_kind, StageKind::StoppedPermissionRequired)
+            && let Some(permission_type) = snap.pending_permission_type.as_deref()
+        {
+            eprintln!("{PROGRESS_PREFIX} opencode: permission required ({permission_type})");
+        }
+
+        if matches!(snap.stage_kind, StageKind::StoppedQuestionRequired)
+            && let Some(prompt) = snap.pending_question_prompt.as_deref()
+        {
+            eprintln!("{PROGRESS_PREFIX} opencode: question required: {prompt}");
+        }
+    }
+
+    fn render_heartbeat(snap: &ProgressSnapshot) {
+        eprintln!(
+            "{PROGRESS_PREFIX} (still running) stage={} last_update={}",
+            stage_kind_label(&snap.stage_kind),
+            snap.updated_at,
+        );
+    }
+}
+
+impl ProgressSnapshot {
+    fn from_state(state: &RunState) -> Self {
+        Self {
+            stage_kind: state.stage.kind.clone(),
+            stage_details: normalize_details(state.stage.details.as_deref()),
+            opencode_dispatch_attempt: state.opencode.dispatch_attempt,
+            opencode_last_command: state.opencode.last_command.clone(),
+            pending_permission_type: state
+                .opencode
+                .pending_permission
+                .as_ref()
+                .map(|pending| pending.permission_type.clone()),
+            pending_question_prompt: state
+                .opencode
+                .pending_question
+                .as_ref()
+                .map(|pending| pending.prompt.clone()),
+            pr_url: state.pr.url.clone(),
+            updated_at: state.updated_at.clone(),
+        }
+    }
+}
+
+fn normalize_details(details: Option<&str>) -> Option<String> {
+    let details = details?;
+    let collapsed = details.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
+}
+
+fn stage_kind_label(kind: &StageKind) -> String {
+    serde_json::to_value(kind)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{kind:?}"))
+}
+
+fn planned_action_id_for_stage(kind: &StageKind) -> Option<&'static str> {
+    match kind {
+        StageKind::FreshnessBeforeTicketToPr => Some("freshness.before_ticket_to_pr"),
+        StageKind::DispatchingTicketToPr => Some("github.pr.detect_existing"),
+        StageKind::DetectingPr => Some("github.pr.detect_after_ticket_to_pr"),
+        StageKind::FreshnessBeforeCoderabbitWait => Some("freshness.before_coderabbit_wait"),
+        StageKind::WaitingForCoderabbit => Some("github.coderabbit.wait"),
+        StageKind::DispatchingResolvePrComments => Some("opencode.run.resolve_pr_comments"),
+        StageKind::DispatchingDescribePr => Some("opencode.run.describe_pr_refresh"),
+        StageKind::WaitingForCi => Some("github.ci.wait"),
+        StageKind::DispatchingResolvePrCiFailures => Some("opencode.run.resolve_pr_ci_failures"),
+        StageKind::StoppedReadyForHumanReview => Some("stop.ready_for_human_review"),
+        _ => None,
+    }
+}
+
+fn planned_action_id_for_command(command: &str) -> Option<&'static str> {
+    match command {
+        "linear_ticket_2_pr" => Some("opencode.run.linear_ticket_2_pr"),
+        "resolve_pr_comments" => Some("opencode.run.resolve_pr_comments"),
+        "describe_pr" => Some("opencode.run.describe_pr_refresh"),
+        "resolve_pr_ci_failures" => Some("opencode.run.resolve_pr_ci_failures"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProgressSnapshot;
+    use super::normalize_details;
+    use super::planned_action_id_for_command;
+    use super::planned_action_id_for_stage;
+    use super::stage_kind_label;
+    use crate::state;
+    use crate::worktree::TargetWorktree;
+
+    fn sample_state() -> state::RunState {
+        let mut state = state::RunState::for_start(
+            "ENG-992",
+            &TargetWorktree {
+                path: std::env::current_dir().expect("cwd available for progress test"),
+                branch: "feature/eng-992".to_string(),
+                base_ref: "origin/main".to_string(),
+            },
+            false,
+        )
+        .expect("sample state builds");
+        state.stage.kind = state::StageKind::WaitingForCoderabbit;
+        state.stage.details = Some("  waiting\nfor   CodeRabbit  ".to_string());
+        state.opencode.dispatch_attempt = 3;
+        state.opencode.last_command = Some("resolve_pr_comments".to_string());
+        state.opencode.pending_permission = Some(state::PendingPermission {
+            request_id: "perm-1".to_string(),
+            permission_type: "git_push".to_string(),
+        });
+        state.opencode.pending_question = Some(state::PendingQuestion {
+            request_id: "question-1".to_string(),
+            prompt: "Proceed?".to_string(),
+        });
+        state.pr.url = Some("https://example.invalid/pr/1".to_string());
+        state.updated_at = "2026-01-01T00:00:00Z".to_string();
+        state
+    }
+
+    #[test]
+    fn normalize_details_collapses_whitespace_to_single_line() {
+        assert_eq!(
+            normalize_details(Some("  line one\n\tline   two  ")),
+            Some("line one line two".to_string())
+        );
+        assert_eq!(normalize_details(Some("   \n\t  ")), None);
+        assert_eq!(normalize_details(None), None);
+    }
+
+    #[test]
+    fn stage_and_command_mappings_cover_expected_progress_surfaces() {
+        assert_eq!(
+            planned_action_id_for_stage(&state::StageKind::WaitingForCoderabbit),
+            Some("github.coderabbit.wait")
+        );
+        assert_eq!(
+            planned_action_id_for_command("resolve_pr_ci_failures"),
+            Some("opencode.run.resolve_pr_ci_failures")
+        );
+        assert_eq!(planned_action_id_for_command("unknown"), None);
+    }
+
+    #[test]
+    fn stage_kind_label_uses_snake_case_serialization() {
+        assert_eq!(
+            stage_kind_label(&state::StageKind::StoppedPermissionRequired),
+            "stopped_permission_required"
+        );
+    }
+
+    #[test]
+    fn snapshot_extraction_uses_normalized_state_fields() {
+        let state = sample_state();
+        let snapshot = ProgressSnapshot::from_state(&state);
+
+        assert_eq!(snapshot.stage_kind, state::StageKind::WaitingForCoderabbit);
+        assert_eq!(
+            snapshot.stage_details,
+            Some("waiting for CodeRabbit".to_string())
+        );
+        assert_eq!(snapshot.opencode_dispatch_attempt, 3);
+        assert_eq!(
+            snapshot.opencode_last_command.as_deref(),
+            Some("resolve_pr_comments")
+        );
+        assert_eq!(
+            snapshot.pending_permission_type.as_deref(),
+            Some("git_push")
+        );
+        assert_eq!(
+            snapshot.pending_question_prompt.as_deref(),
+            Some("Proceed?")
+        );
+        assert_eq!(
+            snapshot.pr_url.as_deref(),
+            Some("https://example.invalid/pr/1")
+        );
+        assert_eq!(snapshot.updated_at, "2026-01-01T00:00:00Z");
+    }
+}

--- a/apps/agentic-outer-dag/src/progress.rs
+++ b/apps/agentic-outer-dag/src/progress.rs
@@ -30,6 +30,12 @@ pub struct ProgressRenderer {
     warned_load_error: bool,
 }
 
+impl Default for ProgressRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ProgressRenderer {
     pub fn new() -> Self {
         let actions_vec = planned_actions_for_start();
@@ -136,13 +142,14 @@ impl ProgressRenderer {
     }
 
     fn render_opencode_line_if_needed(&self, snap: &ProgressSnapshot) {
-        let Some(last) = self.last.as_ref() else {
-            return;
+        let changed = match self.last.as_ref() {
+            Some(last) => {
+                last.opencode_dispatch_attempt != snap.opencode_dispatch_attempt
+                    || last.opencode_last_command != snap.opencode_last_command
+            }
+            None => snap.opencode_last_command.is_some(),
         };
-
-        let dispatch_changed = last.opencode_dispatch_attempt != snap.opencode_dispatch_attempt;
-        let command_changed = last.opencode_last_command != snap.opencode_last_command;
-        if !(dispatch_changed || command_changed) {
+        if !changed {
             return;
         }
 
@@ -352,5 +359,35 @@ mod tests {
             Some("https://example.invalid/pr/1")
         );
         assert_eq!(snapshot.updated_at, "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn progress_renderer_default_matches_new() {
+        let renderer = super::ProgressRenderer::new();
+        let default_renderer = super::ProgressRenderer::default();
+
+        assert_eq!(renderer.actions, default_renderer.actions);
+        assert_eq!(renderer.total_actions, default_renderer.total_actions);
+        assert_eq!(renderer.last, default_renderer.last);
+        assert_eq!(
+            renderer.warned_load_error,
+            default_renderer.warned_load_error
+        );
+    }
+
+    #[test]
+    fn resumed_snapshot_with_existing_opencode_command_counts_as_changed() {
+        let renderer = super::ProgressRenderer::new();
+        let snapshot = ProgressSnapshot::from_state(&sample_state());
+
+        let changed = match renderer.last.as_ref() {
+            Some(last) => {
+                last.opencode_dispatch_attempt != snapshot.opencode_dispatch_attempt
+                    || last.opencode_last_command != snapshot.opencode_last_command
+            }
+            None => snapshot.opencode_last_command.is_some(),
+        };
+
+        assert!(changed);
     }
 }

--- a/apps/agentic-outer-dag/tests/progress_output.rs
+++ b/apps/agentic-outer-dag/tests/progress_output.rs
@@ -1,0 +1,213 @@
+use anyhow::Context;
+use anyhow::Result;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin_path() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_agentic-outer-dag") {
+        return Ok(PathBuf::from(path));
+    }
+
+    let current_exe = std::env::current_exe().context("current test binary path should resolve")?;
+    current_exe
+        .parent()
+        .and_then(Path::parent)
+        .map(|dir| dir.join("agentic-outer-dag"))
+        .context("test binary should live under target/<profile>/deps")
+}
+
+#[test]
+fn start_emits_progress_on_stderr_and_final_status_on_stdout() -> Result<()> {
+    let fixture = GitFixture::new()?;
+
+    let output = Command::new(bin_path()?)
+        .current_dir(fixture.repo_path())
+        .env("HOME", fixture.home_dir())
+        .env("XDG_CONFIG_HOME", fixture.xdg_config_home())
+        .env_remove("RUST_LOG")
+        .args(base_start_args(&fixture))
+        .output()
+        .context("process should run")?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "stderr was: {}",
+        lossy(&output.stderr)
+    );
+
+    let stdout = lossy(&output.stdout);
+    let stderr = lossy(&output.stderr);
+
+    let _: serde_json::Value = serde_json::from_str(&stdout).context("stdout should be JSON")?;
+    anyhow::ensure!(stderr.contains("outer-dag:"), "stderr was: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn final_only_suppresses_progress_lines() -> Result<()> {
+    let fixture = GitFixture::new()?;
+
+    let output = Command::new(bin_path()?)
+        .current_dir(fixture.repo_path())
+        .env("HOME", fixture.home_dir())
+        .env("XDG_CONFIG_HOME", fixture.xdg_config_home())
+        .env_remove("RUST_LOG")
+        .args(final_only_start_args(&fixture))
+        .output()
+        .context("process should run")?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "stderr was: {}",
+        lossy(&output.stderr)
+    );
+
+    let stdout = lossy(&output.stdout);
+    let stderr = lossy(&output.stderr);
+
+    let _: serde_json::Value = serde_json::from_str(&stdout).context("stdout should be JSON")?;
+    anyhow::ensure!(!stderr.contains("outer-dag:"), "stderr was: {stderr}");
+    Ok(())
+}
+
+fn base_start_args(fixture: &GitFixture) -> Vec<String> {
+    vec![
+        "--quiet".to_string(),
+        "start".to_string(),
+        "--ticket".to_string(),
+        "ENG-992".to_string(),
+        "--branch".to_string(),
+        fixture.branch().to_string(),
+        "--worktree".to_string(),
+        fixture.repo_path().display().to_string(),
+        "--stop-after".to_string(),
+        "freshness_before_ticket_to_pr".to_string(),
+        "--no-opencode-dispatch".to_string(),
+        "--no-linear-handoff".to_string(),
+        "--force".to_string(),
+    ]
+}
+
+fn final_only_start_args(fixture: &GitFixture) -> Vec<String> {
+    let mut args = vec!["--quiet".to_string(), "--final-only".to_string()];
+    args.extend(base_start_args(fixture).into_iter().skip(1));
+    args
+}
+
+fn lossy(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+struct GitFixture {
+    _temp: TempDir,
+    repo: PathBuf,
+    branch: String,
+    home: PathBuf,
+    xdg_config_home: PathBuf,
+}
+
+impl GitFixture {
+    fn new() -> Result<Self> {
+        let temp = TempDir::new().context("tempdir should create")?;
+        let origin = temp.path().join("origin.git");
+        let repo = temp.path().join("repo");
+        let home = temp.path().join("home");
+        let xdg_config_home = home.join(".config");
+        let thoughts_repo = temp.path().join("thoughts-data");
+        let branch = "feature/progress-test".to_string();
+        let remote = "https://github.com/example/thoughts-data.git".to_string();
+
+        run_git(temp.path(), ["init", "--bare", path_str(&origin)?])?;
+        run_git(temp.path(), ["clone", path_str(&origin)?, path_str(&repo)?])?;
+        std::fs::create_dir_all(repo.join(".thoughts"))?;
+        std::fs::create_dir_all(&thoughts_repo)?;
+        std::fs::create_dir_all(xdg_config_home.join("agentic"))?;
+
+        run_git(&repo, ["config", "user.name", "Test User"])?;
+        run_git(&repo, ["config", "user.email", "test@example.com"])?;
+        std::fs::write(repo.join("README.md"), "base\n")?;
+        run_git(&repo, ["add", "README.md"])?;
+        run_git(&repo, ["commit", "-m", "initial"])?;
+        run_git(&repo, ["branch", "-M", "main"])?;
+        run_git(&repo, ["push", "-u", "origin", "main"])?;
+        run_git(&repo, ["remote", "set-url", "origin", &remote])?;
+        run_git(&repo, ["checkout", "-b", &branch])?;
+
+        std::fs::write(
+            repo.join(".thoughts").join("config.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "version": "2.0",
+                "mount_dirs": {
+                    "thoughts": "thoughts",
+                    "context": "context",
+                    "references": "references"
+                },
+                "thoughts_mount": {
+                    "remote": &remote,
+                    "sync": "none"
+                },
+                "context_mounts": [],
+                "references": []
+            }))?,
+        )?;
+        std::fs::write(
+            xdg_config_home.join("agentic").join("repos.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "version": "1.0",
+                "mappings": {
+                    remote: {
+                        "path": thoughts_repo,
+                        "auto_managed": false
+                    }
+                }
+            }))?,
+        )?;
+
+        Ok(Self {
+            _temp: temp,
+            repo,
+            branch,
+            home,
+            xdg_config_home,
+        })
+    }
+
+    fn repo_path(&self) -> &Path {
+        &self.repo
+    }
+
+    fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    fn home_dir(&self) -> &Path {
+        &self.home
+    }
+
+    fn xdg_config_home(&self) -> &Path {
+        &self.xdg_config_home
+    }
+}
+
+fn path_str(path: &Path) -> Result<&str> {
+    path.to_str()
+        .context("fixture path should be valid UTF-8 for git CLI")
+}
+
+fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .context("git command should start")?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        lossy(&output.stderr)
+    );
+    Ok(())
+}


### PR DESCRIPTION
Placeholder; describe_pr will update later.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

`agentic-outer-dag` could look stalled during long-running runs because operators only saw the final status payload after the engine stopped. This was especially confusing while waiting on CodeRabbit or while OpenCode-driven stages were running, where useful state was already persisted but not surfaced live.

This PR makes outer-DAG runs stream operator progress as they advance, while preserving the existing machine-readable final status output contract.

## What user-facing changes did I ship?

- `agentic-outer-dag start`, `resume`, `respond-permission`, and `respond-question` now emit live progress lines to stderr while the DAG engine is running.
- Progress lines are prefixed with `outer-dag:` and include stage changes, planned-action progress, PR URL discovery, OpenCode command/attempt updates, permission/question stop details, and periodic still-running heartbeats.
- Final status output remains on stdout as JSON, so callers that parse stdout keep the same channel contract.
- Added global `--final-only` to suppress live progress and keep the previous final-status-only behavior.
- Clarified `--quiet`: it now reduces tracing/log output to errors only, but it does not suppress final status output or the new live progress stream.
- CodeRabbit polling now persists refreshed `waiting_for_coderabbit` details during each wait cycle, including cycle, PR number, head SHA, elapsed time, remaining timeout, and next poll interval.

## How I implemented it

- Added `apps/agentic-outer-dag/src/progress.rs` with a `ProgressRenderer` that polls the persisted `RunState` every 500ms and renders best-effort stderr updates only when the relevant progress snapshot changes.
- Reused `planned_actions_for_start()` so progress output maps stages and OpenCode commands onto the same ordered DAG action list users already rely on.
- Added a 30-second heartbeat for unchanged states so long waits still show liveness without spamming output.
- Wrapped `DagEngine::run_until_stop` in `run_engine_until_stop_with_progress`, which runs the progress renderer concurrently and stops it once the engine completes.
- Threaded the new `final_only` CLI option through `start`, `resume`, `respond-permission`, and `respond-question` flows.
- Updated CodeRabbit waiting behavior to save structured wait details before sleeping on each poll, giving the progress renderer fresh state to report.
- Added unit coverage for CLI parsing, progress snapshot normalization/mapping, and CodeRabbit wait-detail formatting.
- Added subprocess integration coverage that verifies progress goes to stderr, final JSON remains on stdout, and `--final-only` suppresses progress lines.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification completed:

- [x] `just crate-check agentic-outer-dag-bin`
- [x] `just crate-test agentic-outer-dag-bin`
- [x] `just check`
- [x] `just test`

No manual verification is required for this PR.

## Description for the changelog

`agentic-outer-dag` now streams live stderr progress during long-running DAG runs, keeps final JSON status on stdout, and supports `--final-only` for callers that want the previous final-status-only behavior.
<!-- END:describe_pr:autogen -->
