### PR TITLE
ENG-1075: Onboard agentic-outer-dag-bin to managed mise

### DIFF
--- a/apps/agentic-outer-dag/Cargo.toml
+++ b/apps/agentic-outer-dag/Cargo.toml
@@ -16,6 +16,12 @@ mcp = false
 logging = false
 napi = false
 
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/{name}-v{version}/{name}-{target}.tar.xz"
+pkg-fmt = "txz"
+bin-dir = "{name}-{target}/{bin}{binary-ext}"
+disabled-strategies = ["quick-install", "compile"]
+
 [[bin]]
 name = "agentic-outer-dag"
 path = "src/main.rs"

--- a/crates/meta/xtask/src/managed_mise.rs
+++ b/crates/meta/xtask/src/managed_mise.rs
@@ -22,10 +22,11 @@ pub const PLATFORM_TARGETS: [(&str, &str); 4] = [
     ("macos-arm64", "aarch64-apple-darwin"),
 ];
 
-pub const BINARY_SPECS: [BinarySpec; 4] = [
+pub const BINARY_SPECS: [BinarySpec; 5] = [
     BinarySpec::new("thoughts-bin", "thoughts-bin-v"),
     BinarySpec::new("agentic-bin", "agentic-bin-v"),
     BinarySpec::new("agentic-mcp", "agentic-mcp-v"),
+    BinarySpec::new("agentic-outer-dag-bin", "agentic-outer-dag-bin-v"),
     BinarySpec::new("opencode-orchestrator-mcp", "opencode-orchestrator-mcp-v"),
 ];
 

--- a/crates/meta/xtask/src/mise.rs
+++ b/crates/meta/xtask/src/mise.rs
@@ -139,6 +139,16 @@ linux-arm64 = { asset_pattern = "agentic-mcp-aarch64-unknown-linux-gnu.tar.xz" }
 macos-x64 = { asset_pattern = "agentic-mcp-x86_64-apple-darwin.tar.xz" }
 macos-arm64 = { asset_pattern = "agentic-mcp-aarch64-apple-darwin.tar.xz" }
 
+[tools.agentic-outer-dag-bin]
+version = "0.1.0"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin.platforms]
+linux-x64 = { asset_pattern = "agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz" }
+linux-arm64 = { asset_pattern = "agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz" }
+macos-x64 = { asset_pattern = "agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz" }
+macos-arm64 = { asset_pattern = "agentic-outer-dag-bin-aarch64-apple-darwin.tar.xz" }
+
 [tools.opencode-orchestrator-mcp]
 version = "0.7.9"
 version_prefix = "opencode-orchestrator-mcp-v"
@@ -167,6 +177,11 @@ macos-arm64 = { asset_pattern = "opencode-orchestrator-mcp-aarch64-apple-darwin.
                 tool_name: "agentic-mcp",
                 version_prefix: "agentic-mcp-v",
                 version: "0.2.42".to_string(),
+            },
+            ResolvedBinarySpec {
+                tool_name: "agentic-outer-dag-bin",
+                version_prefix: "agentic-outer-dag-bin-v",
+                version: "0.1.0".to_string(),
             },
             ResolvedBinarySpec {
                 tool_name: "opencode-orchestrator-mcp",
@@ -263,6 +278,7 @@ _.path = ["tools/bin"]
 [binaries]
 agentic-bin = "0.1.15"
 agentic-mcp = "0.2.42"
+agentic-outer-dag-bin = "0.1.0"
 opencode-orchestrator-mcp = "0.7.9"
 thoughts-bin = "0.1.24"
 "#,

--- a/crates/meta/xtask/src/published_versions.rs
+++ b/crates/meta/xtask/src/published_versions.rs
@@ -238,6 +238,7 @@ mod tests {
 [binaries]
 agentic-bin = "0.1.15"
 agentic-mcp = "0.2.42"
+agentic-outer-dag-bin = "0.1.0"
 opencode-orchestrator-mcp = "0.7.9"
 thoughts-bin = "0.1.24"
 "#
@@ -265,7 +266,7 @@ opencode-orchestrator-mcp = "0.7.9"
         )
         .expect_err("missing key should fail")
         .to_string();
-        assert!(err.contains("Missing required managed binary `thoughts-bin`"));
+        assert!(err.contains("Missing required managed binary `agentic-outer-dag-bin`"));
     }
 
     #[test]
@@ -294,6 +295,7 @@ thoughts-bin = "0.1.24"
 [binaries]
 agentic-bin = "not-semver"
 agentic-mcp = "0.2.42"
+agentic-outer-dag-bin = "0.1.0"
 opencode-orchestrator-mcp = "0.7.9"
 thoughts-bin = "0.1.24"
 "#,
@@ -324,6 +326,21 @@ thoughts-bin = "0.1.24"
         assert_eq!(
             parse_managed_tag("message-optimizer-bin-v0.1.0").expect("parse"),
             None
+        );
+
+        let outer_dag = parse_managed_tag("agentic-outer-dag-bin-v0.1.0")
+            .expect("tag parse")
+            .expect("managed tag");
+        assert_eq!(outer_dag.tool_name, "agentic-outer-dag-bin");
+        assert_eq!(outer_dag.version, "0.1.0");
+        assert_eq!(
+            outer_dag.required_asset_names,
+            vec![
+                "agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz",
+                "agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz",
+                "agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz",
+                "agentic-outer-dag-bin-aarch64-apple-darwin.tar.xz",
+            ]
         );
     }
 

--- a/crates/meta/xtask/src/verify.rs
+++ b/crates/meta/xtask/src/verify.rs
@@ -659,6 +659,7 @@ mod tests {
 [binaries]
 agentic-bin = "0.1.15"
 agentic-mcp = "0.2.42"
+agentic-outer-dag-bin = "0.1.0"
 opencode-orchestrator-mcp = "0.7.9"
 thoughts-bin = "0.1.24"
 "#,
@@ -682,6 +683,10 @@ version_prefix = "agentic-bin-v"
 [tools.agentic-mcp]
 version = "0.2.42"
 version_prefix = "agentic-mcp-v"
+
+[tools.agentic-outer-dag-bin]
+version = "0.1.0"
+version_prefix = "agentic-outer-dag-bin-v"
 
 [tools.opencode-orchestrator-mcp]
 version = "0.7.9"
@@ -708,6 +713,10 @@ version_prefix = "agentic-bin-v"
 [tools.agentic-mcp]
 version = "0.2.42"
 version_prefix = "agentic-mcp-v"
+
+[tools.agentic-outer-dag-bin]
+version = "0.1.0"
+version_prefix = "agentic-outer-dag-bin-v"
 
 [tools.opencode-orchestrator-mcp]
 version = "0.7.9"
@@ -741,6 +750,12 @@ version = "0.2.42"
 [tools.agentic-mcp.options]
 version_prefix = "agentic-mcp-v"
 
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+
+[tools.agentic-outer-dag-bin.options]
+version_prefix = "agentic-outer-dag-bin-v"
+
 [[tools.opencode-orchestrator-mcp]]
 version = "0.7.9"
 
@@ -772,6 +787,12 @@ version = "0.2.42"
 
 [tools.agentic-mcp.options]
 version_prefix = "agentic-mcp-v"
+
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+
+[tools.agentic-outer-dag-bin.options]
+version_prefix = "agentic-outer-dag-bin-v"
 
 [[tools.opencode-orchestrator-mcp]]
 version = "0.7.9"

--- a/mise.lock
+++ b/mise.lock
@@ -236,6 +236,100 @@ checksum = "sha256:17d6cbd3f5b59bb23d4e9895e8475e14ecf296554c6a884644f83c3e3227f
 url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-mcp-v0.2.42/source.tar.gz"
 url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/471538494"
 
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-outer-dag-bin.options]
+asset_pattern = "agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin."platforms.linux-arm64"]
+checksum = "sha256:2df25d895d2c98bf9c234fdf9e06467ffe0d555cbdd0738a9f23d460a321acaf"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734323"
+
+[tools.agentic-outer-dag-bin."platforms.linux-arm64-musl"]
+checksum = "sha256:2df25d895d2c98bf9c234fdf9e06467ffe0d555cbdd0738a9f23d460a321acaf"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734323"
+
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-outer-dag-bin.options]
+asset_pattern = "agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin."platforms.linux-x64"]
+checksum = "sha256:7d19dacb06b501c877749de12f4baa37be35184e9e0272273455c3b85427339b"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734337"
+
+[tools.agentic-outer-dag-bin."platforms.linux-x64-baseline"]
+checksum = "sha256:7d19dacb06b501c877749de12f4baa37be35184e9e0272273455c3b85427339b"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734337"
+
+[tools.agentic-outer-dag-bin."platforms.linux-x64-musl"]
+checksum = "sha256:7d19dacb06b501c877749de12f4baa37be35184e9e0272273455c3b85427339b"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734337"
+
+[tools.agentic-outer-dag-bin."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:7d19dacb06b501c877749de12f4baa37be35184e9e0272273455c3b85427339b"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734337"
+
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-outer-dag-bin.options]
+asset_pattern = "agentic-outer-dag-bin-aarch64-apple-darwin.tar.xz"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin."platforms.macos-arm64"]
+checksum = "sha256:74f6edcf1826127bd83c008fc67fc91ca414d38d2f0370af97eea0a9de756fa7"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734327"
+
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-outer-dag-bin.options]
+asset_pattern = "agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin."platforms.macos-x64"]
+checksum = "sha256:bbea1a1d0c771e463b3c805646fbfad84c641de574d43e414d010a86b076fe1a"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734333"
+
+[tools.agentic-outer-dag-bin."platforms.macos-x64-baseline"]
+checksum = "sha256:bbea1a1d0c771e463b3c805646fbfad84c641de574d43e414d010a86b076fe1a"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734333"
+
+[[tools.agentic-outer-dag-bin]]
+version = "0.1.0"
+backend = "github:allisoneer/agentic_auxilary"
+
+[tools.agentic-outer-dag-bin.options]
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin."platforms.windows-x64"]
+checksum = "sha256:722413724664f96f97c83da07ae99983dfab4704d6fe5228fe32bfa86e9b59c2"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734348"
+
+[tools.agentic-outer-dag-bin."platforms.windows-x64-baseline"]
+checksum = "sha256:722413724664f96f97c83da07ae99983dfab4704d6fe5228fe32bfa86e9b59c2"
+url = "https://github.com/allisoneer/agentic_auxilary/releases/download/agentic-outer-dag-bin-v0.1.0/source.tar.gz"
+url_api = "https://api.github.com/repos/allisoneer/agentic_auxilary/releases/assets/463734348"
+
 [[tools."aqua:taiki-e/cargo-llvm-cov"]]
 version = "0.6.14"
 backend = "aqua:taiki-e/cargo-llvm-cov"

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ diesel = "cargo:diesel_cli"
 thoughts-bin = "github:allisoneer/agentic_auxilary"
 agentic-bin = "github:allisoneer/agentic_auxilary"
 agentic-mcp = "github:allisoneer/agentic_auxilary"
+agentic-outer-dag-bin = "github:allisoneer/agentic_auxilary"
 opencode-orchestrator-mcp = "github:allisoneer/agentic_auxilary"
 
 [settings]
@@ -90,6 +91,16 @@ linux-x64 = { asset_pattern = "agentic-mcp-x86_64-unknown-linux-gnu.tar.xz" }
 linux-arm64 = { asset_pattern = "agentic-mcp-aarch64-unknown-linux-gnu.tar.xz" }
 macos-x64 = { asset_pattern = "agentic-mcp-x86_64-apple-darwin.tar.xz" }
 macos-arm64 = { asset_pattern = "agentic-mcp-aarch64-apple-darwin.tar.xz" }
+
+[tools.agentic-outer-dag-bin]
+version = "0.1.0"
+version_prefix = "agentic-outer-dag-bin-v"
+
+[tools.agentic-outer-dag-bin.platforms]
+linux-x64 = { asset_pattern = "agentic-outer-dag-bin-x86_64-unknown-linux-gnu.tar.xz" }
+linux-arm64 = { asset_pattern = "agentic-outer-dag-bin-aarch64-unknown-linux-gnu.tar.xz" }
+macos-x64 = { asset_pattern = "agentic-outer-dag-bin-x86_64-apple-darwin.tar.xz" }
+macos-arm64 = { asset_pattern = "agentic-outer-dag-bin-aarch64-apple-darwin.tar.xz" }
 
 [tools.opencode-orchestrator-mcp]
 version = "0.7.9"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -76,7 +76,7 @@ release = true
 name = "agentic-outer-dag-bin"
 changelog_path = "apps/agentic-outer-dag/CHANGELOG.md"
 git_tag_name = "agentic-outer-dag-bin-v{{ version }}"
-git_tag_enable = false
+git_tag_enable = true
 release = true
 
 [[package]]

--- a/tools/policy.toml
+++ b/tools/policy.toml
@@ -136,6 +136,9 @@ git_tag_enable = true
 [release_plz.overrides.opencode-orchestrator-mcp]
 git_tag_enable = true
 
+[release_plz.overrides.agentic-outer-dag-bin]
+git_tag_enable = true
+
 # Per-crate overrides to match current practices
 [release_plz.overrides.universal-tool-core]
 git_tag_enable = false

--- a/tools/published-versions.toml
+++ b/tools/published-versions.toml
@@ -3,5 +3,6 @@ schema_version = 1
 [binaries]
 agentic-bin = "0.1.15"
 agentic-mcp = "0.2.42"
+agentic-outer-dag-bin = "0.1.0"
 opencode-orchestrator-mcp = "0.7.9"
 thoughts-bin = "0.1.24"


### PR DESCRIPTION
## What problem(s) was I solving?

`agentic-outer-dag-bin` was not yet part of the repository's managed `mise` binary contract, so developers could not install it through the same generated `mise.toml` / `mise.lock` path used by the other distributed internal binaries.

This also meant release metadata was incomplete for managed-binary automation:

- release-plz did not emit GitHub-facing tags for `agentic-outer-dag-bin`
- xtask's managed binary list and tests did not include `agentic-outer-dag-bin`
- `tools/published-versions.toml`, generated `mise.toml`, generated lock data, and xtask fixtures could not verify the new binary as part of the managed contract

## What user-facing changes did I ship?

- `agentic-outer-dag-bin` is now available as a managed `mise` tool sourced from `github:allisoneer/agentic_auxilary` at version `0.1.0`.
- `mise.toml` now aliases and pins `agentic-outer-dag-bin` with platform asset patterns for Linux x64, Linux arm64, macOS x64, and macOS arm64.
- `mise.lock` now records the verified `agentic-outer-dag-bin-v0.1.0` release asset URLs and checksums.
- release-plz now enables GitHub tag generation for `agentic-outer-dag-bin` using the `agentic-outer-dag-bin-v{{ version }}` tag format.

## How I implemented it

- Added `package.metadata.binstall` to `apps/agentic-outer-dag/Cargo.toml` so `cargo-binstall` can resolve the prebuilt `.tar.xz` release archives and avoid source compilation for this binary.
- Added `agentic-outer-dag-bin` to xtask's managed binary specs with the `agentic-outer-dag-bin-v` tag prefix.
- Seeded `tools/published-versions.toml` with `agentic-outer-dag-bin = "0.1.0"` using the verified Stage B `agentic-outer-dag-bin-v0.1.0` release assets.
- Regenerated `mise.toml`, `mise.lock`, and release-plz metadata so the checked-in generated files match the managed-binary contract.
- Updated xtask tests and fixtures covering managed version parsing, required release assets, generated mise output, and verify checks.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

Additional verification completed:

- [x] `just xtask-sync`
- [x] `just crate-test xtask`
- [x] `just xtask-verify-check`
- [x] `just check`
- [x] `just test`

Verification note: Stage B seed data used verified `agentic-outer-dag-bin-v0.1.0` release assets.

## Description for the changelog

Onboard `agentic-outer-dag-bin` into the managed `mise` binary workflow with release-plz tagging, binstall metadata, published-version seed data, generated mise lock entries, and xtask verification coverage.
