### PR TITLE
ENG-1117: establish native attention kernel foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Canonical repository guidance for AI-assisted work in this repository. Keep repo
 
 ### attention
 
+- `attention-kernel` (lib) - `crates/attention/kernel/`
 - `attention-protocol` (lib) - `crates/attention/protocol/`
 
 ### infra

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "attention-kernel"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "attention-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "bindings/node/agentic-tools-napi",
 
   # Attention family
+  "crates/attention/kernel",
   "crates/attention/protocol",
 
   # Agentic-tools family

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ opencode_rs = "0.13.3"
 
 ### attention
 
+- [`attention-kernel`](crates/attention/kernel) - Native Attention identities, roots, lifecycle invariants, reminders, and derived Inbox projections
 - [`attention-protocol`](crates/attention/protocol) - Strict Attention JSON-RPC wire types; use crate-root DTOs for envelopes, hello negotiation, IDs, versions, and canonical timestamps
 
 ### infra

--- a/crates/attention/kernel/CHANGELOG.md
+++ b/crates/attention/kernel/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- Initial private Attention native-kernel foundation.

--- a/crates/attention/kernel/CLAUDE.md
+++ b/crates/attention/kernel/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md - attention-kernel
+
+<!-- BEGIN:xtask:autogen header -->
+- Crate: attention-kernel
+- Path: crates/attention/kernel/
+- Role: lib
+- Family: attention
+- Integrations: mcp=false, logging=false, napi=false
+<!-- END:xtask:autogen -->
+
+## Overview
+
+Briefly describe the purpose of this crate and how to use it.
+
+## Quick Commands
+
+<!-- BEGIN:xtask:autogen commands -->
+```bash
+# Lint & Clippy
+just crate-check attention-kernel
+
+# Tests
+just crate-test attention-kernel
+
+# Build
+just crate-build attention-kernel
+```
+<!-- END:xtask:autogen -->
+
+## Notes
+
+Add any human-authored notes below. Content outside autogen blocks is preserved by xtask sync.

--- a/crates/attention/kernel/CLAUDE.md
+++ b/crates/attention/kernel/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Briefly describe the purpose of this crate and how to use it.
+Defines transport- and persistence-independent Attention domain types and invariants for identities, source records, work items, signals, reminders, lifecycle transitions, and default Inbox projections. Use the exported types to construct or reconstruct validated domain state, apply lifecycle methods, and derive Inbox membership with `is_in_default_inbox` or `inbox_entry`; keep I/O, scheduling, and protocol concerns in higher layers.
 
 ## Quick Commands
 

--- a/crates/attention/kernel/Cargo.toml
+++ b/crates/attention/kernel/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "attention-kernel"
+version = "0.1.0"
+edition = "2024"
+authors = ["Allison Durham"]
+description = "Native Attention identities, roots, lifecycle invariants, reminders, and derived Inbox projections"
+license = "MIT"
+repository = "https://github.com/allisoneer/agentic_auxilary"
+publish = false
+autotests = false
+
+[dependencies]
+chrono = { workspace = true }
+thiserror = { workspace = true }
+uuid = { version = "1", features = ["v7"] }
+
+[[test]]
+name = "ids"
+path = "tests/ids.rs"
+
+[[test]]
+name = "invariants"
+path = "tests/invariants.rs"
+
+[[test]]
+name = "inbox"
+path = "tests/inbox.rs"
+
+[[test]]
+name = "scenarios"
+path = "tests/scenarios.rs"
+
+[lints]
+workspace = true
+
+[package.metadata.repo]
+role = "lib"
+family = "attention"
+
+[package.metadata.repo.integrations]
+mcp = false
+logging = false
+napi = false

--- a/crates/attention/kernel/src/error.rs
+++ b/crates/attention/kernel/src/error.rs
@@ -1,0 +1,38 @@
+//! Native invariant failures.
+
+use crate::ReminderFireId;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum InvariantError {
+    #[error("UUID text is malformed: {0}")]
+    InvalidUuidText(String),
+    #[error("UUID text is not canonical lowercase hyphenated form: {0}")]
+    NonCanonicalUuidText(String),
+    #[error("UUID is not version 7")]
+    InvalidUuidVersion,
+    #[error("source component {component} cannot be empty")]
+    EmptySourceComponent { component: &'static str },
+    #[error("revision cannot be zero")]
+    RevisionZero,
+    #[error("revision overflow")]
+    RevisionOverflow,
+    #[error("invalid {entity} transition from {from} to {to}")]
+    InvalidTransition {
+        entity: &'static str,
+        from: &'static str,
+        to: &'static str,
+    },
+    #[error("reminder must retain at least one fire")]
+    MissingReminderFire,
+    #[error("duplicate reminder fire ID: {0}")]
+    DuplicateReminderFireId(ReminderFireId),
+    #[error("reminder has more than one scheduled or fired child")]
+    MultipleCurrentReminderFires,
+    #[error("unknown reminder fire ID: {0}")]
+    UnknownReminderFire(ReminderFireId),
+    #[error("duplicate reminder target")]
+    DuplicateReminderTarget,
+    #[error("snoozed reminder fire ID cannot be reused: {0}")]
+    SnoozeIdReuse(ReminderFireId),
+}

--- a/crates/attention/kernel/src/id.rs
+++ b/crates/attention/kernel/src/id.rs
@@ -1,0 +1,69 @@
+//! Distinct native durable identities.
+
+use crate::InvariantError;
+use std::fmt;
+use std::str::FromStr;
+use uuid::Uuid;
+use uuid::Version;
+
+macro_rules! define_uuid_v7_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            pub fn new() -> Self {
+                Self(Uuid::now_v7())
+            }
+
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl TryFrom<Uuid> for $name {
+            type Error = InvariantError;
+
+            fn try_from(value: Uuid) -> Result<Self, Self::Error> {
+                if value.get_version() != Some(Version::SortRand) {
+                    return Err(InvariantError::InvalidUuidVersion);
+                }
+                Ok(Self(value))
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = InvariantError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                let parsed = Uuid::parse_str(value)
+                    .map_err(|_| InvariantError::InvalidUuidText(value.to_string()))?;
+                if parsed.hyphenated().to_string() != value {
+                    return Err(InvariantError::NonCanonicalUuidText(value.to_string()));
+                }
+                Self::try_from(parsed)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+    };
+}
+
+define_uuid_v7_id!(WorkItemId);
+define_uuid_v7_id!(AttentionSignalId);
+define_uuid_v7_id!(ReminderId);
+define_uuid_v7_id!(ReminderFireId);
+define_uuid_v7_id!(SourceReceiptId);
+define_uuid_v7_id!(SourceEntityId);
+define_uuid_v7_id!(ChangeEventId);
+define_uuid_v7_id!(OutboxIntentId);

--- a/crates/attention/kernel/src/inbox.rs
+++ b/crates/attention/kernel/src/inbox.rs
@@ -1,0 +1,60 @@
+//! Pure default Inbox projections.
+
+use crate::AttentionSignal;
+use crate::AttentionSignalId;
+use crate::ReminderFire;
+use crate::ReminderFireId;
+use crate::ReminderFireState;
+use crate::SignalAttentionState;
+use crate::WorkItem;
+use crate::WorkItemId;
+use crate::WorkItemLifecycle;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InboxEntry {
+    WorkItem(WorkItemId),
+    AttentionSignal(AttentionSignalId),
+    ReminderFire(ReminderFireId),
+}
+
+impl WorkItem {
+    pub const fn is_in_default_inbox(&self) -> bool {
+        matches!(self.lifecycle(), WorkItemLifecycle::Open)
+    }
+
+    pub const fn inbox_entry(&self) -> Option<InboxEntry> {
+        if self.is_in_default_inbox() {
+            Some(InboxEntry::WorkItem(self.id()))
+        } else {
+            None
+        }
+    }
+}
+
+impl AttentionSignal {
+    pub const fn is_in_default_inbox(&self) -> bool {
+        matches!(self.attention_state(), SignalAttentionState::Unread)
+    }
+
+    pub const fn inbox_entry(&self) -> Option<InboxEntry> {
+        if self.is_in_default_inbox() {
+            Some(InboxEntry::AttentionSignal(self.id()))
+        } else {
+            None
+        }
+    }
+}
+
+impl ReminderFire {
+    pub const fn is_in_default_inbox(&self) -> bool {
+        matches!(self.state(), ReminderFireState::Fired)
+    }
+
+    pub const fn inbox_entry(&self) -> Option<InboxEntry> {
+        if self.is_in_default_inbox() {
+            Some(InboxEntry::ReminderFire(self.id()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/attention/kernel/src/lib.rs
+++ b/crates/attention/kernel/src/lib.rs
@@ -1,0 +1,42 @@
+//! Native semantic types and pure invariants for Attention.
+//!
+//! This crate is independent from transport, persistence, scheduling, providers, and UI.
+
+mod error;
+mod id;
+mod inbox;
+mod reminder;
+mod revision;
+mod signal;
+mod source;
+mod work_item;
+
+pub use error::InvariantError;
+pub use id::AttentionSignalId;
+pub use id::ChangeEventId;
+pub use id::OutboxIntentId;
+pub use id::ReminderFireId;
+pub use id::ReminderId;
+pub use id::SourceEntityId;
+pub use id::SourceReceiptId;
+pub use id::WorkItemId;
+pub use inbox::InboxEntry;
+pub use reminder::Reminder;
+pub use reminder::ReminderFire;
+pub use reminder::ReminderFireState;
+pub use reminder::ReminderTarget;
+pub use reminder::validate_unique_reminder_targets;
+pub use revision::Revision;
+pub use signal::AttentionSignal;
+pub use signal::SignalAttentionState;
+pub use signal::SignalSourceLifecycle;
+pub use source::ExternalEntityId;
+pub use source::OccurrenceId;
+pub use source::OccurrenceKey;
+pub use source::SourceEntity;
+pub use source::SourceEntityKey;
+pub use source::SourceInstance;
+pub use source::SourceKind;
+pub use source::SourceReceipt;
+pub use work_item::WorkItem;
+pub use work_item::WorkItemLifecycle;

--- a/crates/attention/kernel/src/reminder.rs
+++ b/crates/attention/kernel/src/reminder.rs
@@ -1,0 +1,245 @@
+//! Reminder root and retained durable fire children.
+
+use crate::AttentionSignalId;
+use crate::InvariantError;
+use crate::ReminderFireId;
+use crate::ReminderId;
+use crate::Revision;
+use crate::WorkItemId;
+use chrono::DateTime;
+use chrono::Utc;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReminderTarget {
+    WorkItem(WorkItemId),
+    AttentionSignal(AttentionSignalId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReminderFireState {
+    Scheduled,
+    Fired,
+    Acknowledged,
+    Snoozed,
+}
+
+impl ReminderFireState {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Scheduled => "scheduled",
+            Self::Fired => "fired",
+            Self::Acknowledged => "acknowledged",
+            Self::Snoozed => "snoozed",
+        }
+    }
+
+    const fn is_current(self) -> bool {
+        matches!(self, Self::Scheduled | Self::Fired)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReminderFire {
+    id: ReminderFireId,
+    trigger_at: DateTime<Utc>,
+    state: ReminderFireState,
+}
+
+impl ReminderFire {
+    pub const fn reconstruct(
+        id: ReminderFireId,
+        trigger_at: DateTime<Utc>,
+        state: ReminderFireState,
+    ) -> Result<Self, InvariantError> {
+        Ok(Self {
+            id,
+            trigger_at,
+            state,
+        })
+    }
+
+    const fn scheduled(id: ReminderFireId, trigger_at: DateTime<Utc>) -> Self {
+        Self {
+            id,
+            trigger_at,
+            state: ReminderFireState::Scheduled,
+        }
+    }
+
+    pub const fn id(&self) -> ReminderFireId {
+        self.id
+    }
+
+    pub const fn trigger_at(&self) -> &DateTime<Utc> {
+        &self.trigger_at
+    }
+
+    pub const fn state(&self) -> ReminderFireState {
+        self.state
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reminder {
+    id: ReminderId,
+    revision: Revision,
+    target: ReminderTarget,
+    trigger_at: DateTime<Utc>,
+    fires: Vec<ReminderFire>,
+}
+
+impl Reminder {
+    pub fn new(
+        id: ReminderId,
+        target: ReminderTarget,
+        trigger_at: DateTime<Utc>,
+        fire_id: ReminderFireId,
+    ) -> Self {
+        Self {
+            id,
+            revision: Revision::initial(),
+            target,
+            trigger_at,
+            fires: vec![ReminderFire::scheduled(fire_id, trigger_at)],
+        }
+    }
+
+    pub fn reconstruct(
+        id: ReminderId,
+        revision: Revision,
+        target: ReminderTarget,
+        trigger_at: DateTime<Utc>,
+        fires: Vec<ReminderFire>,
+    ) -> Result<Self, InvariantError> {
+        validate_fires(&fires)?;
+        Ok(Self {
+            id,
+            revision,
+            target,
+            trigger_at,
+            fires,
+        })
+    }
+
+    pub const fn id(&self) -> ReminderId {
+        self.id
+    }
+
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub const fn target(&self) -> ReminderTarget {
+        self.target
+    }
+
+    pub const fn trigger_at(&self) -> &DateTime<Utc> {
+        &self.trigger_at
+    }
+
+    pub fn fires(&self) -> &[ReminderFire] {
+        &self.fires
+    }
+
+    pub fn mark_fired(&mut self, fire_id: ReminderFireId) -> Result<(), InvariantError> {
+        let index = self.fire_index(fire_id)?;
+        self.require_state(
+            index,
+            ReminderFireState::Scheduled,
+            ReminderFireState::Fired,
+        )?;
+        let revision = self.revision.checked_increment()?;
+        self.fires[index].state = ReminderFireState::Fired;
+        self.revision = revision;
+        Ok(())
+    }
+
+    pub fn acknowledge_fire(&mut self, fire_id: ReminderFireId) -> Result<(), InvariantError> {
+        let index = self.fire_index(fire_id)?;
+        self.require_state(
+            index,
+            ReminderFireState::Fired,
+            ReminderFireState::Acknowledged,
+        )?;
+        let revision = self.revision.checked_increment()?;
+        self.fires[index].state = ReminderFireState::Acknowledged;
+        self.revision = revision;
+        Ok(())
+    }
+
+    pub fn snooze_fire(
+        &mut self,
+        fire_id: ReminderFireId,
+        new_fire_id: ReminderFireId,
+        trigger_at: DateTime<Utc>,
+    ) -> Result<(), InvariantError> {
+        if self.fires.iter().any(|fire| fire.id == new_fire_id) {
+            return Err(InvariantError::SnoozeIdReuse(new_fire_id));
+        }
+        let index = self.fire_index(fire_id)?;
+        self.require_state(index, ReminderFireState::Fired, ReminderFireState::Snoozed)?;
+        let revision = self.revision.checked_increment()?;
+        self.fires[index].state = ReminderFireState::Snoozed;
+        self.fires
+            .push(ReminderFire::scheduled(new_fire_id, trigger_at));
+        self.revision = revision;
+        Ok(())
+    }
+
+    fn fire_index(&self, fire_id: ReminderFireId) -> Result<usize, InvariantError> {
+        self.fires
+            .iter()
+            .position(|fire| fire.id == fire_id)
+            .ok_or(InvariantError::UnknownReminderFire(fire_id))
+    }
+
+    fn require_state(
+        &self,
+        index: usize,
+        required: ReminderFireState,
+        next: ReminderFireState,
+    ) -> Result<(), InvariantError> {
+        let current = self.fires[index].state;
+        if current != required {
+            return Err(InvariantError::InvalidTransition {
+                entity: "reminder fire",
+                from: current.name(),
+                to: next.name(),
+            });
+        }
+        Ok(())
+    }
+}
+
+pub fn validate_unique_reminder_targets(reminders: &[Reminder]) -> Result<(), InvariantError> {
+    let mut targets = HashSet::with_capacity(reminders.len());
+    for reminder in reminders {
+        if !targets.insert(reminder.target) {
+            return Err(InvariantError::DuplicateReminderTarget);
+        }
+    }
+    Ok(())
+}
+
+fn validate_fires(fires: &[ReminderFire]) -> Result<(), InvariantError> {
+    if fires.is_empty() {
+        return Err(InvariantError::MissingReminderFire);
+    }
+
+    let mut ids = HashSet::with_capacity(fires.len());
+    let mut current_count = 0;
+    for fire in fires {
+        if !ids.insert(fire.id) {
+            return Err(InvariantError::DuplicateReminderFireId(fire.id));
+        }
+        if fire.state.is_current() {
+            current_count += 1;
+        }
+    }
+
+    if current_count > 1 {
+        return Err(InvariantError::MultipleCurrentReminderFires);
+    }
+    Ok(())
+}

--- a/crates/attention/kernel/src/revision.rs
+++ b/crates/attention/kernel/src/revision.rs
@@ -1,0 +1,34 @@
+//! Root revision value.
+
+use crate::InvariantError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Revision(u64);
+
+impl Revision {
+    pub const fn initial() -> Self {
+        Self(1)
+    }
+
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+
+    pub fn checked_increment(self) -> Result<Self, InvariantError> {
+        self.0
+            .checked_add(1)
+            .map(Self)
+            .ok_or(InvariantError::RevisionOverflow)
+    }
+}
+
+impl TryFrom<u64> for Revision {
+    type Error = InvariantError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value == 0 {
+            return Err(InvariantError::RevisionZero);
+        }
+        Ok(Self(value))
+    }
+}

--- a/crates/attention/kernel/src/signal.rs
+++ b/crates/attention/kernel/src/signal.rs
@@ -1,0 +1,142 @@
+//! Attention signal root with independent source and human state.
+
+use crate::AttentionSignalId;
+use crate::InvariantError;
+use crate::Revision;
+use crate::SourceEntityId;
+use crate::SourceReceiptId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SignalSourceLifecycle {
+    Active,
+    Resolved,
+    Expired,
+}
+
+impl SignalSourceLifecycle {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Resolved => "resolved",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SignalAttentionState {
+    Unread,
+    Acknowledged,
+}
+
+impl SignalAttentionState {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Unread => "unread",
+            Self::Acknowledged => "acknowledged",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttentionSignal {
+    id: AttentionSignalId,
+    revision: Revision,
+    source_lifecycle: SignalSourceLifecycle,
+    attention_state: SignalAttentionState,
+    source_receipt_id: SourceReceiptId,
+    source_entity_id: Option<SourceEntityId>,
+}
+
+impl AttentionSignal {
+    pub const fn new(
+        id: AttentionSignalId,
+        source_receipt_id: SourceReceiptId,
+        source_entity_id: Option<SourceEntityId>,
+    ) -> Self {
+        Self {
+            id,
+            revision: Revision::initial(),
+            source_lifecycle: SignalSourceLifecycle::Active,
+            attention_state: SignalAttentionState::Unread,
+            source_receipt_id,
+            source_entity_id,
+        }
+    }
+
+    pub const fn reconstruct(
+        id: AttentionSignalId,
+        revision: Revision,
+        source_lifecycle: SignalSourceLifecycle,
+        attention_state: SignalAttentionState,
+        source_receipt_id: SourceReceiptId,
+        source_entity_id: Option<SourceEntityId>,
+    ) -> Result<Self, InvariantError> {
+        Ok(Self {
+            id,
+            revision,
+            source_lifecycle,
+            attention_state,
+            source_receipt_id,
+            source_entity_id,
+        })
+    }
+
+    pub const fn id(&self) -> AttentionSignalId {
+        self.id
+    }
+
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub const fn source_lifecycle(&self) -> SignalSourceLifecycle {
+        self.source_lifecycle
+    }
+
+    pub const fn attention_state(&self) -> SignalAttentionState {
+        self.attention_state
+    }
+
+    pub const fn source_receipt_id(&self) -> SourceReceiptId {
+        self.source_receipt_id
+    }
+
+    pub const fn source_entity_id(&self) -> Option<SourceEntityId> {
+        self.source_entity_id
+    }
+
+    pub fn resolve(&mut self) -> Result<(), InvariantError> {
+        self.transition_source_to(SignalSourceLifecycle::Resolved)
+    }
+
+    pub fn expire(&mut self) -> Result<(), InvariantError> {
+        self.transition_source_to(SignalSourceLifecycle::Expired)
+    }
+
+    pub fn acknowledge(&mut self) -> Result<(), InvariantError> {
+        if self.attention_state != SignalAttentionState::Unread {
+            return Err(InvariantError::InvalidTransition {
+                entity: "signal attention",
+                from: self.attention_state.name(),
+                to: SignalAttentionState::Acknowledged.name(),
+            });
+        }
+        self.revision = self.revision.checked_increment()?;
+        self.attention_state = SignalAttentionState::Acknowledged;
+        Ok(())
+    }
+
+    fn transition_source_to(&mut self, next: SignalSourceLifecycle) -> Result<(), InvariantError> {
+        if self.source_lifecycle != SignalSourceLifecycle::Active {
+            return Err(InvariantError::InvalidTransition {
+                entity: "signal source",
+                from: self.source_lifecycle.name(),
+                to: next.name(),
+            });
+        }
+        self.revision = self.revision.checked_increment()?;
+        self.source_lifecycle = next;
+        Ok(())
+    }
+}

--- a/crates/attention/kernel/src/source.rs
+++ b/crates/attention/kernel/src/source.rs
@@ -1,0 +1,169 @@
+//! Immutable source provenance values.
+
+use crate::InvariantError;
+use crate::SourceEntityId;
+use crate::SourceReceiptId;
+use chrono::DateTime;
+use chrono::Utc;
+
+macro_rules! define_source_component {
+    ($name:ident, $label:literal) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, InvariantError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(InvariantError::EmptySourceComponent { component: $label });
+                }
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+    };
+}
+
+define_source_component!(SourceKind, "source_kind");
+define_source_component!(SourceInstance, "source_instance");
+define_source_component!(OccurrenceId, "occurrence_id");
+define_source_component!(ExternalEntityId, "external_entity_id");
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OccurrenceKey {
+    source_kind: SourceKind,
+    source_instance: SourceInstance,
+    occurrence_id: OccurrenceId,
+}
+
+impl OccurrenceKey {
+    pub const fn new(
+        source_kind: SourceKind,
+        source_instance: SourceInstance,
+        occurrence_id: OccurrenceId,
+    ) -> Self {
+        Self {
+            source_kind,
+            source_instance,
+            occurrence_id,
+        }
+    }
+
+    pub const fn source_kind(&self) -> &SourceKind {
+        &self.source_kind
+    }
+
+    pub const fn source_instance(&self) -> &SourceInstance {
+        &self.source_instance
+    }
+
+    pub const fn occurrence_id(&self) -> &OccurrenceId {
+        &self.occurrence_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceEntityKey {
+    source_kind: SourceKind,
+    source_instance: SourceInstance,
+    external_entity_id: ExternalEntityId,
+}
+
+impl SourceEntityKey {
+    pub const fn new(
+        source_kind: SourceKind,
+        source_instance: SourceInstance,
+        external_entity_id: ExternalEntityId,
+    ) -> Self {
+        Self {
+            source_kind,
+            source_instance,
+            external_entity_id,
+        }
+    }
+
+    pub const fn source_kind(&self) -> &SourceKind {
+        &self.source_kind
+    }
+
+    pub const fn source_instance(&self) -> &SourceInstance {
+        &self.source_instance
+    }
+
+    pub const fn external_entity_id(&self) -> &ExternalEntityId {
+        &self.external_entity_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceReceipt {
+    id: SourceReceiptId,
+    occurrence_key: OccurrenceKey,
+    source_entity_key: Option<SourceEntityKey>,
+    occurred_at: DateTime<Utc>,
+    ingested_at: DateTime<Utc>,
+}
+
+impl SourceReceipt {
+    pub fn reconstruct(
+        id: SourceReceiptId,
+        occurrence_key: OccurrenceKey,
+        source_entity_key: Option<SourceEntityKey>,
+        occurred_at: DateTime<Utc>,
+        ingested_at: DateTime<Utc>,
+    ) -> Result<Self, InvariantError> {
+        Ok(Self {
+            id,
+            occurrence_key,
+            source_entity_key,
+            occurred_at,
+            ingested_at,
+        })
+    }
+
+    pub const fn id(&self) -> SourceReceiptId {
+        self.id
+    }
+
+    pub const fn occurrence_key(&self) -> &OccurrenceKey {
+        &self.occurrence_key
+    }
+
+    pub const fn source_entity_key(&self) -> Option<&SourceEntityKey> {
+        self.source_entity_key.as_ref()
+    }
+
+    pub const fn occurred_at(&self) -> &DateTime<Utc> {
+        &self.occurred_at
+    }
+
+    pub const fn ingested_at(&self) -> &DateTime<Utc> {
+        &self.ingested_at
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceEntity {
+    id: SourceEntityId,
+    key: SourceEntityKey,
+}
+
+impl SourceEntity {
+    pub const fn reconstruct(
+        id: SourceEntityId,
+        key: SourceEntityKey,
+    ) -> Result<Self, InvariantError> {
+        Ok(Self { id, key })
+    }
+
+    pub const fn id(&self) -> SourceEntityId {
+        self.id
+    }
+
+    pub const fn key(&self) -> &SourceEntityKey {
+        &self.key
+    }
+}

--- a/crates/attention/kernel/src/work_item.rs
+++ b/crates/attention/kernel/src/work_item.rs
@@ -1,0 +1,129 @@
+//! Work item root and lifecycle.
+
+use crate::InvariantError;
+use crate::Revision;
+use crate::SourceEntityKey;
+use crate::WorkItemId;
+use chrono::DateTime;
+use chrono::Utc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkItemLifecycle {
+    Open,
+    Completed,
+    Cancelled,
+}
+
+impl WorkItemLifecycle {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkItem {
+    id: WorkItemId,
+    revision: Revision,
+    lifecycle: WorkItemLifecycle,
+    due_at: Option<DateTime<Utc>>,
+    scheduled_at: Option<DateTime<Utc>>,
+    defer_until: Option<DateTime<Utc>>,
+    source_link: Option<SourceEntityKey>,
+}
+
+impl WorkItem {
+    pub const fn new(
+        id: WorkItemId,
+        due_at: Option<DateTime<Utc>>,
+        scheduled_at: Option<DateTime<Utc>>,
+        defer_until: Option<DateTime<Utc>>,
+        source_link: Option<SourceEntityKey>,
+    ) -> Self {
+        Self {
+            id,
+            revision: Revision::initial(),
+            lifecycle: WorkItemLifecycle::Open,
+            due_at,
+            scheduled_at,
+            defer_until,
+            source_link,
+        }
+    }
+
+    pub const fn reconstruct(
+        id: WorkItemId,
+        revision: Revision,
+        lifecycle: WorkItemLifecycle,
+        due_at: Option<DateTime<Utc>>,
+        scheduled_at: Option<DateTime<Utc>>,
+        defer_until: Option<DateTime<Utc>>,
+        source_link: Option<SourceEntityKey>,
+    ) -> Result<Self, InvariantError> {
+        Ok(Self {
+            id,
+            revision,
+            lifecycle,
+            due_at,
+            scheduled_at,
+            defer_until,
+            source_link,
+        })
+    }
+
+    pub const fn id(&self) -> WorkItemId {
+        self.id
+    }
+
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub const fn lifecycle(&self) -> WorkItemLifecycle {
+        self.lifecycle
+    }
+
+    pub const fn due_at(&self) -> Option<&DateTime<Utc>> {
+        self.due_at.as_ref()
+    }
+
+    pub const fn scheduled_at(&self) -> Option<&DateTime<Utc>> {
+        self.scheduled_at.as_ref()
+    }
+
+    pub const fn defer_until(&self) -> Option<&DateTime<Utc>> {
+        self.defer_until.as_ref()
+    }
+
+    pub const fn source_link(&self) -> Option<&SourceEntityKey> {
+        self.source_link.as_ref()
+    }
+
+    pub fn is_overdue(&self, now: DateTime<Utc>) -> bool {
+        self.lifecycle == WorkItemLifecycle::Open && self.due_at.is_some_and(|due_at| due_at < now)
+    }
+
+    pub fn complete(&mut self) -> Result<(), InvariantError> {
+        self.transition_to(WorkItemLifecycle::Completed)
+    }
+
+    pub fn cancel(&mut self) -> Result<(), InvariantError> {
+        self.transition_to(WorkItemLifecycle::Cancelled)
+    }
+
+    fn transition_to(&mut self, next: WorkItemLifecycle) -> Result<(), InvariantError> {
+        if self.lifecycle != WorkItemLifecycle::Open {
+            return Err(InvariantError::InvalidTransition {
+                entity: "work item",
+                from: self.lifecycle.name(),
+                to: next.name(),
+            });
+        }
+        self.revision = self.revision.checked_increment()?;
+        self.lifecycle = next;
+        Ok(())
+    }
+}

--- a/crates/attention/kernel/tests/ids.rs
+++ b/crates/attention/kernel/tests/ids.rs
@@ -1,0 +1,89 @@
+use attention_kernel::AttentionSignalId;
+use attention_kernel::ChangeEventId;
+use attention_kernel::ExternalEntityId;
+use attention_kernel::InvariantError;
+use attention_kernel::OccurrenceId;
+use attention_kernel::OccurrenceKey;
+use attention_kernel::OutboxIntentId;
+use attention_kernel::ReminderFireId;
+use attention_kernel::ReminderId;
+use attention_kernel::SourceEntityId;
+use attention_kernel::SourceEntityKey;
+use attention_kernel::SourceInstance;
+use attention_kernel::SourceKind;
+use attention_kernel::SourceReceiptId;
+use attention_kernel::WorkItemId;
+use std::str::FromStr;
+use uuid::Uuid;
+use uuid::Version;
+
+macro_rules! assert_native_id {
+    ($type:ty) => {{
+        let id = <$type>::new();
+        assert_eq!(id.as_uuid().get_version(), Some(Version::SortRand));
+        let text = id.to_string();
+        assert_eq!(<$type>::from_str(&text).expect("canonical ID"), id);
+        assert!(matches!(
+            <$type>::from_str(&text.to_uppercase()),
+            Err(InvariantError::NonCanonicalUuidText(_))
+        ));
+        assert!(matches!(
+            <$type>::try_from(Uuid::nil()),
+            Err(InvariantError::InvalidUuidVersion)
+        ));
+    }};
+}
+
+#[test]
+fn all_eight_native_ids_are_distinct_uuid_v7_types() {
+    assert_native_id!(WorkItemId);
+    assert_native_id!(AttentionSignalId);
+    assert_native_id!(ReminderId);
+    assert_native_id!(ReminderFireId);
+    assert_native_id!(SourceReceiptId);
+    assert_native_id!(SourceEntityId);
+    assert_native_id!(ChangeEventId);
+    assert_native_id!(OutboxIntentId);
+}
+
+#[test]
+fn malformed_and_non_v7_text_is_rejected() {
+    assert!(matches!(
+        WorkItemId::from_str("not-a-uuid"),
+        Err(InvariantError::InvalidUuidText(_))
+    ));
+    assert!(matches!(
+        WorkItemId::from_str("00000000-0000-0000-0000-000000000000"),
+        Err(InvariantError::InvalidUuidVersion)
+    ));
+    let id = WorkItemId::new().to_string().replace('-', "");
+    assert!(matches!(
+        WorkItemId::from_str(&id),
+        Err(InvariantError::NonCanonicalUuidText(_))
+    ));
+}
+
+#[test]
+fn source_components_and_composite_keys_are_validated_and_comparable() {
+    assert!(SourceKind::new("").is_err());
+    assert!(SourceInstance::new("  ").is_err());
+    assert!(OccurrenceId::new("").is_err());
+    assert!(ExternalEntityId::new("").is_err());
+
+    let kind = SourceKind::new("linear").expect("source kind");
+    let instance = SourceInstance::new("workspace").expect("source instance");
+    let occurrence = OccurrenceKey::new(
+        kind.clone(),
+        instance.clone(),
+        OccurrenceId::new("event-1").expect("occurrence ID"),
+    );
+    let same_occurrence = occurrence.clone();
+    assert_eq!(occurrence, same_occurrence);
+
+    let entity = SourceEntityKey::new(
+        kind,
+        instance,
+        ExternalEntityId::new("ENG-1117").expect("external entity ID"),
+    );
+    assert_eq!(entity.external_entity_id().as_str(), "ENG-1117");
+}

--- a/crates/attention/kernel/tests/inbox.rs
+++ b/crates/attention/kernel/tests/inbox.rs
@@ -1,0 +1,94 @@
+use attention_kernel::AttentionSignal;
+use attention_kernel::AttentionSignalId;
+use attention_kernel::InboxEntry;
+use attention_kernel::ReminderFire;
+use attention_kernel::ReminderFireId;
+use attention_kernel::ReminderFireState;
+use attention_kernel::Revision;
+use attention_kernel::SignalAttentionState;
+use attention_kernel::SignalSourceLifecycle;
+use attention_kernel::SourceReceiptId;
+use attention_kernel::WorkItem;
+use attention_kernel::WorkItemId;
+use attention_kernel::WorkItemLifecycle;
+use chrono::DateTime;
+use chrono::Utc;
+
+#[expect(clippy::expect_used, reason = "fixed timestamp test fixture")]
+fn at() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-07-23T12:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc)
+}
+
+#[test]
+fn only_open_work_items_are_visible() {
+    for lifecycle in [
+        WorkItemLifecycle::Open,
+        WorkItemLifecycle::Completed,
+        WorkItemLifecycle::Cancelled,
+    ] {
+        let id = WorkItemId::new();
+        let item =
+            WorkItem::reconstruct(id, Revision::initial(), lifecycle, None, None, None, None)
+                .expect("valid work item");
+        assert_eq!(
+            item.is_in_default_inbox(),
+            lifecycle == WorkItemLifecycle::Open
+        );
+        assert_eq!(
+            item.inbox_entry(),
+            (lifecycle == WorkItemLifecycle::Open).then_some(InboxEntry::WorkItem(id))
+        );
+    }
+}
+
+#[test]
+fn signal_visibility_depends_only_on_attention_state() {
+    for source in [
+        SignalSourceLifecycle::Active,
+        SignalSourceLifecycle::Resolved,
+        SignalSourceLifecycle::Expired,
+    ] {
+        for attention in [
+            SignalAttentionState::Unread,
+            SignalAttentionState::Acknowledged,
+        ] {
+            let id = AttentionSignalId::new();
+            let signal = AttentionSignal::reconstruct(
+                id,
+                Revision::initial(),
+                source,
+                attention,
+                SourceReceiptId::new(),
+                None,
+            )
+            .expect("valid signal");
+            let visible = attention == SignalAttentionState::Unread;
+            assert_eq!(signal.is_in_default_inbox(), visible);
+            assert_eq!(
+                signal.inbox_entry(),
+                visible.then_some(InboxEntry::AttentionSignal(id))
+            );
+        }
+    }
+}
+
+#[test]
+fn only_fired_reminder_children_are_visible() {
+    for state in [
+        ReminderFireState::Scheduled,
+        ReminderFireState::Fired,
+        ReminderFireState::Acknowledged,
+        ReminderFireState::Snoozed,
+    ] {
+        let id = ReminderFireId::new();
+        let fire = ReminderFire::reconstruct(id, at(), state).expect("valid fire");
+        let visible = state == ReminderFireState::Fired;
+        assert_eq!(fire.is_in_default_inbox(), visible);
+        assert_eq!(
+            fire.inbox_entry(),
+            visible.then_some(InboxEntry::ReminderFire(id))
+        );
+    }
+}

--- a/crates/attention/kernel/tests/invariants.rs
+++ b/crates/attention/kernel/tests/invariants.rs
@@ -1,0 +1,213 @@
+use attention_kernel::AttentionSignal;
+use attention_kernel::AttentionSignalId;
+use attention_kernel::InvariantError;
+use attention_kernel::Reminder;
+use attention_kernel::ReminderFire;
+use attention_kernel::ReminderFireId;
+use attention_kernel::ReminderFireState;
+use attention_kernel::ReminderId;
+use attention_kernel::ReminderTarget;
+use attention_kernel::Revision;
+use attention_kernel::SignalAttentionState;
+use attention_kernel::SignalSourceLifecycle;
+use attention_kernel::SourceReceiptId;
+use attention_kernel::WorkItem;
+use attention_kernel::WorkItemId;
+use attention_kernel::WorkItemLifecycle;
+use attention_kernel::validate_unique_reminder_targets;
+use chrono::DateTime;
+use chrono::Utc;
+
+#[expect(clippy::expect_used, reason = "fixed timestamp test fixture")]
+fn at(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("valid timestamp")
+        .with_timezone(&Utc)
+}
+
+#[expect(clippy::expect_used, reason = "validated reminder fire test fixture")]
+fn fire(id: ReminderFireId, state: ReminderFireState) -> ReminderFire {
+    ReminderFire::reconstruct(id, at("2026-07-23T12:00:00Z"), state).expect("valid fire")
+}
+
+#[test]
+fn revision_rejects_zero_and_overflow() {
+    assert_eq!(Revision::initial().value(), 1);
+    assert!(matches!(
+        Revision::try_from(0),
+        Err(InvariantError::RevisionZero)
+    ));
+    assert!(matches!(
+        Revision::try_from(u64::MAX)
+            .expect("nonzero revision")
+            .checked_increment(),
+        Err(InvariantError::RevisionOverflow)
+    ));
+}
+
+#[test]
+fn work_item_transitions_once_and_rejects_terminal_changes() {
+    let mut completed = WorkItem::new(WorkItemId::new(), None, None, None, None);
+    completed.complete().expect("complete open item");
+    assert_eq!(completed.lifecycle(), WorkItemLifecycle::Completed);
+    assert_eq!(completed.revision().value(), 2);
+    assert!(completed.complete().is_err());
+    assert_eq!(completed.revision().value(), 2);
+
+    let mut cancelled = WorkItem::new(WorkItemId::new(), None, None, None, None);
+    cancelled.cancel().expect("cancel open item");
+    assert_eq!(cancelled.lifecycle(), WorkItemLifecycle::Cancelled);
+}
+
+#[test]
+fn all_six_signal_combinations_are_reconstructable() {
+    for source in [
+        SignalSourceLifecycle::Active,
+        SignalSourceLifecycle::Resolved,
+        SignalSourceLifecycle::Expired,
+    ] {
+        for attention in [
+            SignalAttentionState::Unread,
+            SignalAttentionState::Acknowledged,
+        ] {
+            let signal = AttentionSignal::reconstruct(
+                AttentionSignalId::new(),
+                Revision::initial(),
+                source,
+                attention,
+                SourceReceiptId::new(),
+                None,
+            )
+            .expect("valid independent signal dimensions");
+            assert_eq!(signal.source_lifecycle(), source);
+            assert_eq!(signal.attention_state(), attention);
+        }
+    }
+}
+
+#[test]
+fn signal_transitions_are_independent_and_increment_once() {
+    let mut signal = AttentionSignal::new(AttentionSignalId::new(), SourceReceiptId::new(), None);
+    signal.acknowledge().expect("acknowledge unread signal");
+    assert_eq!(signal.source_lifecycle(), SignalSourceLifecycle::Active);
+    assert_eq!(signal.revision().value(), 2);
+    signal.resolve().expect("resolve active signal");
+    assert_eq!(signal.attention_state(), SignalAttentionState::Acknowledged);
+    assert_eq!(signal.revision().value(), 3);
+    assert!(signal.expire().is_err());
+    assert_eq!(signal.revision().value(), 3);
+}
+
+#[test]
+fn reminder_reconstruction_rejects_invalid_child_collections() {
+    let target = ReminderTarget::WorkItem(WorkItemId::new());
+    assert!(matches!(
+        Reminder::reconstruct(
+            ReminderId::new(),
+            Revision::initial(),
+            target,
+            at("2026-07-23T12:00:00Z"),
+            Vec::new(),
+        ),
+        Err(InvariantError::MissingReminderFire)
+    ));
+
+    let duplicate_id = ReminderFireId::new();
+    assert!(matches!(
+        Reminder::reconstruct(
+            ReminderId::new(),
+            Revision::initial(),
+            target,
+            at("2026-07-23T12:00:00Z"),
+            vec![
+                fire(duplicate_id, ReminderFireState::Acknowledged),
+                fire(duplicate_id, ReminderFireState::Snoozed),
+            ],
+        ),
+        Err(InvariantError::DuplicateReminderFireId(_))
+    ));
+
+    assert!(matches!(
+        Reminder::reconstruct(
+            ReminderId::new(),
+            Revision::initial(),
+            target,
+            at("2026-07-23T12:00:00Z"),
+            vec![
+                fire(ReminderFireId::new(), ReminderFireState::Scheduled),
+                fire(ReminderFireId::new(), ReminderFireState::Fired),
+            ],
+        ),
+        Err(InvariantError::MultipleCurrentReminderFires)
+    ));
+}
+
+#[test]
+fn reminder_acknowledgement_and_snooze_preserve_retained_children() {
+    let first_id = ReminderFireId::new();
+    let trigger = at("2026-07-23T12:00:00Z");
+    let mut acknowledged = Reminder::new(
+        ReminderId::new(),
+        ReminderTarget::WorkItem(WorkItemId::new()),
+        trigger,
+        first_id,
+    );
+    acknowledged
+        .mark_fired(first_id)
+        .expect("fire scheduled child");
+    acknowledged
+        .acknowledge_fire(first_id)
+        .expect("acknowledge fired child");
+    assert_eq!(
+        acknowledged.fires()[0].state(),
+        ReminderFireState::Acknowledged
+    );
+    assert_eq!(acknowledged.revision().value(), 3);
+    assert!(acknowledged.acknowledge_fire(first_id).is_err());
+
+    let original_id = ReminderFireId::new();
+    let refire_id = ReminderFireId::new();
+    let mut snoozed = Reminder::new(
+        ReminderId::new(),
+        ReminderTarget::AttentionSignal(AttentionSignalId::new()),
+        trigger,
+        original_id,
+    );
+    snoozed
+        .mark_fired(original_id)
+        .expect("fire original child");
+    snoozed
+        .snooze_fire(original_id, refire_id, at("2026-07-23T13:00:00Z"))
+        .expect("snooze fired child");
+    assert_eq!(snoozed.fires().len(), 2);
+    assert_eq!(snoozed.fires()[0].state(), ReminderFireState::Snoozed);
+    assert_eq!(snoozed.fires()[1].state(), ReminderFireState::Scheduled);
+    assert_eq!(snoozed.trigger_at(), &trigger);
+    assert!(matches!(
+        snoozed.snooze_fire(refire_id, original_id, at("2026-07-23T14:00:00Z")),
+        Err(InvariantError::SnoozeIdReuse(_))
+    ));
+}
+
+#[test]
+fn duplicate_reminder_targets_are_rejected() {
+    let target = ReminderTarget::WorkItem(WorkItemId::new());
+    let reminders = [
+        Reminder::new(
+            ReminderId::new(),
+            target,
+            at("2026-07-23T12:00:00Z"),
+            ReminderFireId::new(),
+        ),
+        Reminder::new(
+            ReminderId::new(),
+            target,
+            at("2026-07-23T13:00:00Z"),
+            ReminderFireId::new(),
+        ),
+    ];
+    assert!(matches!(
+        validate_unique_reminder_targets(&reminders),
+        Err(InvariantError::DuplicateReminderTarget)
+    ));
+}

--- a/crates/attention/kernel/tests/scenarios.rs
+++ b/crates/attention/kernel/tests/scenarios.rs
@@ -1,0 +1,209 @@
+//! T02-pure slices of accepted scenarios.
+//!
+//! Scenario 11 is non-applicable here because replay, persistence, protocol, server, and client
+//! behavior belongs to later tickets. Scenario 12 is non-applicable because Outbox, external
+//! delivery, checkpoints, and scheduling also belong to later tickets.
+
+use attention_kernel::AttentionSignal;
+use attention_kernel::AttentionSignalId;
+use attention_kernel::ExternalEntityId;
+use attention_kernel::OccurrenceId;
+use attention_kernel::OccurrenceKey;
+use attention_kernel::Reminder;
+use attention_kernel::ReminderFireId;
+use attention_kernel::ReminderFireState;
+use attention_kernel::ReminderId;
+use attention_kernel::ReminderTarget;
+use attention_kernel::Revision;
+use attention_kernel::SignalAttentionState;
+use attention_kernel::SignalSourceLifecycle;
+use attention_kernel::SourceEntity;
+use attention_kernel::SourceEntityId;
+use attention_kernel::SourceEntityKey;
+use attention_kernel::SourceInstance;
+use attention_kernel::SourceKind;
+use attention_kernel::SourceReceipt;
+use attention_kernel::SourceReceiptId;
+use attention_kernel::WorkItem;
+use attention_kernel::WorkItemId;
+use attention_kernel::WorkItemLifecycle;
+use chrono::DateTime;
+use chrono::Utc;
+
+#[expect(clippy::expect_used, reason = "fixed timestamp test fixture")]
+fn at(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("valid timestamp")
+        .with_timezone(&Utc)
+}
+
+#[expect(clippy::expect_used, reason = "validated source-key test fixtures")]
+fn source_keys(occurrence: &str) -> (OccurrenceKey, SourceEntityKey) {
+    let kind = SourceKind::new("agentic").expect("source kind");
+    let instance = SourceInstance::new("local").expect("source instance");
+    (
+        OccurrenceKey::new(
+            kind.clone(),
+            instance.clone(),
+            OccurrenceId::new(occurrence).expect("occurrence ID"),
+        ),
+        SourceEntityKey::new(
+            kind,
+            instance,
+            ExternalEntityId::new("run-42").expect("entity ID"),
+        ),
+    )
+}
+
+#[test]
+fn scenario_01_open_manual_work_item_is_in_default_inbox() {
+    let item = WorkItem::new(WorkItemId::new(), None, None, None, None);
+    assert_eq!(item.lifecycle(), WorkItemLifecycle::Open);
+    assert_eq!(item.revision(), Revision::initial());
+    assert!(item.source_link().is_none());
+    assert!(item.is_in_default_inbox());
+}
+
+#[test]
+fn scenario_02_due_without_reminder_stays_open_and_has_no_implicit_reminder() {
+    let due_at = at("2026-07-23T11:00:00Z");
+    let item = WorkItem::new(WorkItemId::new(), Some(due_at), None, None, None);
+    assert!(item.is_overdue(at("2026-07-23T12:00:00Z")));
+    assert_eq!(item.lifecycle(), WorkItemLifecycle::Open);
+    assert_eq!(item.revision(), Revision::initial());
+}
+
+#[test]
+fn scenario_03_scheduled_reminder_is_hidden_and_fired_child_is_visible() {
+    let fire_id = ReminderFireId::new();
+    let mut reminder = Reminder::new(
+        ReminderId::new(),
+        ReminderTarget::WorkItem(WorkItemId::new()),
+        at("2026-07-23T12:00:00Z"),
+        fire_id,
+    );
+    assert!(!reminder.fires()[0].is_in_default_inbox());
+    reminder.mark_fired(fire_id).expect("fire reminder");
+    assert!(reminder.fires()[0].is_in_default_inbox());
+}
+
+#[test]
+fn scenario_04_resolved_unread_signal_is_valid_and_visible() {
+    let (occurrence_key, entity_key) = source_keys("completion-1");
+    let receipt_id = SourceReceiptId::new();
+    let entity_id = SourceEntityId::new();
+    SourceReceipt::reconstruct(
+        receipt_id,
+        occurrence_key,
+        Some(entity_key.clone()),
+        at("2026-07-23T11:00:00Z"),
+        at("2026-07-23T12:00:00Z"),
+    )
+    .expect("receipt permits independent clocks");
+    SourceEntity::reconstruct(entity_id, entity_key).expect("source entity");
+    let signal = AttentionSignal::reconstruct(
+        AttentionSignalId::new(),
+        Revision::initial(),
+        SignalSourceLifecycle::Resolved,
+        SignalAttentionState::Unread,
+        receipt_id,
+        Some(entity_id),
+    )
+    .expect("resolved unread signal");
+    assert!(signal.is_in_default_inbox());
+    assert_ne!(receipt_id.to_string(), entity_id.to_string());
+}
+
+#[test]
+fn scenario_05_occurrence_key_is_distinct_and_value_comparable() {
+    let (first, _) = source_keys("occurrence-1");
+    let (same, _) = source_keys("occurrence-1");
+    let (different, _) = source_keys("occurrence-2");
+    assert_eq!(first, same);
+    assert_ne!(first, different);
+}
+
+#[test]
+fn scenario_06_new_receipt_can_share_entity_and_signal_identity() {
+    let (_, entity_key) = source_keys("first");
+    let entity_id = SourceEntityId::new();
+    let signal_id = AttentionSignalId::new();
+    let first_receipt = SourceReceiptId::new();
+    let second_receipt = SourceReceiptId::new();
+    let first = AttentionSignal::reconstruct(
+        signal_id,
+        Revision::initial(),
+        SignalSourceLifecycle::Active,
+        SignalAttentionState::Unread,
+        first_receipt,
+        Some(entity_id),
+    )
+    .expect("first signal view");
+    let second = AttentionSignal::reconstruct(
+        signal_id,
+        Revision::try_from(2).expect("revision two"),
+        SignalSourceLifecycle::Active,
+        SignalAttentionState::Unread,
+        second_receipt,
+        Some(entity_id),
+    )
+    .expect("updated signal view");
+    SourceEntity::reconstruct(entity_id, entity_key).expect("shared entity");
+    assert_eq!(first.id(), second.id());
+    assert_eq!(first.source_entity_id(), second.source_entity_id());
+    assert_ne!(first.source_receipt_id(), second.source_receipt_id());
+}
+
+#[test]
+fn scenario_07_active_acknowledged_signal_is_valid_and_hidden() {
+    let signal = AttentionSignal::reconstruct(
+        AttentionSignalId::new(),
+        Revision::initial(),
+        SignalSourceLifecycle::Active,
+        SignalAttentionState::Acknowledged,
+        SourceReceiptId::new(),
+        None,
+    )
+    .expect("active acknowledged signal");
+    assert!(!signal.is_in_default_inbox());
+}
+
+#[test]
+fn scenario_08_resolved_acknowledged_signal_is_valid_and_hidden() {
+    let mut signal = AttentionSignal::new(AttentionSignalId::new(), SourceReceiptId::new(), None);
+    signal.acknowledge().expect("acknowledge signal");
+    signal.resolve().expect("resolve acknowledged signal");
+    assert_eq!(signal.attention_state(), SignalAttentionState::Acknowledged);
+    assert_eq!(signal.source_lifecycle(), SignalSourceLifecycle::Resolved);
+    assert!(!signal.is_in_default_inbox());
+}
+
+#[test]
+fn scenario_09_snooze_consumes_fire_and_distinct_refire_reappears() {
+    let original_id = ReminderFireId::new();
+    let refire_id = ReminderFireId::new();
+    let original_trigger = at("2026-07-23T12:00:00Z");
+    let mut reminder = Reminder::new(
+        ReminderId::new(),
+        ReminderTarget::AttentionSignal(AttentionSignalId::new()),
+        original_trigger,
+        original_id,
+    );
+    reminder.mark_fired(original_id).expect("fire original");
+    reminder
+        .snooze_fire(original_id, refire_id, at("2026-07-23T13:00:00Z"))
+        .expect("snooze original");
+    assert_eq!(reminder.fires()[0].state(), ReminderFireState::Snoozed);
+    assert!(!reminder.fires()[0].is_in_default_inbox());
+    assert_eq!(reminder.trigger_at(), &original_trigger);
+    reminder.mark_fired(refire_id).expect("fire replacement");
+    assert!(reminder.fires()[1].is_in_default_inbox());
+}
+
+#[test]
+fn scenario_10_revision_starts_at_one_and_checked_increment_is_monotonic() {
+    let first = Revision::initial();
+    let second = first.checked_increment().expect("revision two");
+    let third = second.checked_increment().expect("revision three");
+    assert_eq!([first.value(), second.value(), third.value()], [1, 2, 3]);
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -270,6 +270,14 @@ release = false
 publish = false
 
 [[package]]
+name = "attention-kernel"
+changelog_path = "crates/attention/kernel/CHANGELOG.md"
+git_tag_name = "attention-kernel-v{{ version }}"
+git_tag_enable = false
+release = false
+publish = false
+
+[[package]]
 name = "attention-protocol"
 changelog_path = "crates/attention/protocol/CHANGELOG.md"
 git_tag_name = "attention-protocol-v{{ version }}"


### PR DESCRIPTION
## Summary
- add the private `attention-kernel` workspace package
- define native UUIDv7 identities, roots, lifecycle and revision invariants, ReminderFire ownership, and derived Inbox projections
- add pure invariant and scenario coverage plus generated workspace metadata

## Verification
- `just check`
- `just test`

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-1117 is T02 of the ENG-1110 Attention program. The repository had the wire-only `attention-protocol` package, but no native semantic layer for later commands, persistence, server mapping, or UI work to depend on.

This PR establishes that missing native boundary before downstream layers encode competing meanings. It defines authoritative identities, roots, lifecycle and revision rules, Reminder-owned durable fire children, immutable source provenance, and a derived default Inbox while keeping kernel semantics independent from transport and storage concerns.

## What user-facing changes did I ship?

There is no direct runtime or UI change in this ticket. The shipped capability is an internal, validated Attention domain foundation that later user-facing work can build on without redefining core behavior.

Specifically, downstream Attention layers can now rely on:

- exactly three roots: `WorkItem`, `AttentionSignal`, and `Reminder`;
- distinct native UUIDv7 identities for roots, reminder fires, source records, change events, and outbox intents;
- nonzero revisions starting at 1 with checked monotonic increments;
- exact WorkItem lifecycle states (`Open`, `Completed`, `Cancelled`);
- independent signal source lifecycle (`Active`, `Resolved`, `Expired`) and human attention state (`Unread`, `Acknowledged`);
- explicit Reminder targets and retained durable `ReminderFire` children;
- pure default Inbox projections for open work items, unread signals, and fired reminder children;
- due dates that remain timing facts and never imply Reminder creation.

No migration or breaking consumer change is required because `attention-kernel` is a new private package with no existing consumers.

## How I implemented it

### Native package boundary

- Added private workspace package `attention-kernel` under `crates/attention/kernel/`.
- Kept dependencies limited to `chrono`, `thiserror`, and crate-local UUIDv7 support.
- Used private modules and explicit crate-root re-exports.
- Added generated workspace, README, per-crate guidance, release-plz, and lockfile metadata.

### Identities, provenance, and revisions

- Added eight distinct UUIDv7 newtypes with canonical lowercase hyphenated parsing, version validation, display, and native UUID access.
- Added validated nonempty source components and typed occurrence/entity composite keys.
- Added immutable `SourceReceipt` and `SourceEntity` reconstruction APIs without provider behavior or cross-clock ordering constraints.
- Added `Revision` validation for zero and overflow.

### Roots and lifecycle invariants

- Added `WorkItem` construction/reconstruction, due/scheduled/defer facts, terminal lifecycle transitions, overdue derivation, and one-revision-per-transition behavior.
- Added `AttentionSignal` with independent source and human-attention dimensions so valid states such as resolved+unread and active+acknowledged remain representable.
- Added Reminder as the sole mutation boundary for retained `ReminderFire` children.
- Enforced at least one retained fire, unique child IDs, at most one current scheduled-or-fired child, unique Reminder targets, valid fire transitions, snooze ID uniqueness, and revision increments exactly once per accepted mutation.
- Kept Inbox as a pure per-entity projection rather than persisted or ordered state.

### Tests

Added four explicit pure test targets with 23 passing tests:

- `ids`: all eight UUIDv7 identities, canonical parsing, version rejection, source-key validation, and type distinction;
- `invariants`: revision bounds, all six signal combinations, independent transitions, Reminder reconstruction/cardinality, acknowledgement, snooze retention, and duplicate-target rejection;
- `inbox`: every WorkItem lifecycle, all signal lifecycle/attention combinations, and every ReminderFire state;
- `scenarios`: the exact T02-pure slices of accepted scenarios 1–10, with scenarios 11–12 explicitly documented as deferred to protocol, storage, delivery, server/client, and scheduler work.

### Explicit non-goals

This PR intentionally does not add commands, ports, repositories, SQLx, migrations, transactions, idempotency, ChangeEvent or Outbox behavior, protocol DTOs, Serde/Schemars wire derives, scheduler behavior, server/client code, Tauri/UI code, provider adapters, recurrence, automatic repeats, signal-level snooze, hard deletion, persisted Inbox state, implicit due-to-Reminder creation, or ReminderFire-to-AttentionSignal conversion.

### Review guidance

Reviewers should focus on:

1. whether private fields and fallible reconstruction prevent bypassing the stated invariants;
2. whether signal source lifecycle and human acknowledgement remain fully independent;
3. whether Reminder owns all fire lifecycle mutation and retains consumed/snoozed children correctly;
4. whether Inbox visibility exactly matches open WorkItems, unread signals, and fired ReminderFire children;
5. whether any transport, storage, provider, scheduler, or UI concern leaked into the kernel;
6. whether generated metadata changes are limited to registering the new private package.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_cli_just_execute`) and they passed
- [x] `just crate-check attention-kernel` — passed formatting and Clippy checks
- [x] `just crate-test attention-kernel` — 23/23 tests passed
- [x] `just crate-build attention-kernel` — passed
- [x] `just xtask-sync` — passed; final run reported no changes needed
- [x] Generated diff inspection — only the expected package registration, lockfile, root/per-crate guidance, README, and release-plz outputs changed
- [x] `just xtask-verify-check` — all checks passed and generated files were current
- [x] `just check` — passed workspace formatting and Clippy checks
- [x] `just test` — 2409/2409 tests passed; 100 tests skipped by configured filters; MCP schema validation passed

No manual runtime verification is required because this package has no executable, UI, database, network, or external-service surface.

## Description for the changelog

Add the private native Attention kernel with distinct UUIDv7 identities, validated roots and lifecycle invariants, Reminder-owned durable fire children, immutable source provenance, checked revisions, and derived default Inbox projections.
<!-- END:describe_pr:autogen -->
