### PR TITLE
feat(attention): implement durable reminder delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "chrono",
  "fs2",
  "futures",
+ "getrandom 0.3.4",
  "rustix 1.1.4",
  "serde",
  "serde_json",

--- a/crates/attention/turso/Cargo.toml
+++ b/crates/attention/turso/Cargo.toml
@@ -14,6 +14,7 @@ attention-kernel = { version = "0.1.0", path = "../kernel" }
 chrono = { workspace = true }
 fs2 = "0.4"
 futures = "0.3"
+getrandom = "0.3"
 rustix = { version = "1", features = ["process"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -69,6 +70,18 @@ path = "tests/codec_fixtures.rs"
 [[test]]
 name = "reader_ports"
 path = "tests/reader_ports.rs"
+
+[[test]]
+name = "reminder_schedule_port"
+path = "tests/reminder_schedule_port.rs"
+
+[[test]]
+name = "delivery_port"
+path = "tests/delivery_port.rs"
+
+[[test]]
+name = "delivery_checkpoint_port"
+path = "tests/delivery_checkpoint_port.rs"
 
 [[test]]
 name = "commit_conformance"

--- a/crates/attention/turso/README.md
+++ b/crates/attention/turso/README.md
@@ -25,6 +25,8 @@ The operational threshold is 64 MiB for any regular database file under this wor
 
 Backup is accepted only from `Closed`. It reacquires directory ownership, copies the complete regular-file set without following links into an owner-only staging directory, syncs files/directories on Unix, writes a checksummed compatibility manifest, and atomically publishes the completed backup directory. Restore validates the exact adapter/Turso versions, migration head/checksum, sorted relative inventory, sizes, and SHA-256 checksums, then copies only into an empty validated directory and reopens through the adapter.
 
+For duplicate current reminder fires that block migration 0003, follow the [backup-first stopped-database repair runbook](maintenance/repair_duplicate_current_reminder_fires.md). No repair CLI or SQL shell ships.
+
 ## Exact-version limitations
 
 The pinned local API exposes no high-level close, engine cancellation/interrupt, migration, backup, or local checkpoint primitive. Dropping a transaction defers rollback until later connection use, so this crate promises adapter-visible quarantine and sanitation rather than synchronous engine cancellation. `cacheflush` writes dirty pages to WAL and is not a checkpoint or backup boundary. Online backup is unsupported. Full/quota and filesystem permission fixtures are platform-dependent; typed policies are retained without parsing upstream error messages, while destructive process-kill, corruption, symlink, and Unix permission tests run on the current Linux qualification platform.

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires.md
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires.md
@@ -1,0 +1,84 @@
+# Repair duplicate current reminder fires before migration 0003
+
+Use this procedure only when migration 0003 cannot create
+`reminder_fires_one_current_per_reminder` because a head-two database contains
+more than one `reminder_fires` row in state `0` or `1` for a reminder. Migration
+0003 and its ledger insertion share one immediate transaction, so this failure
+leaves the database at head two and the migration retryable.
+
+This repository ships no repair CLI, SQL shell, maintenance recipe, example
+binary, or public raw-SQL API. The procedure requires an operator-supplied Rust
+maintenance client using exactly `turso-db` `0.8.0-pre.1` with the local
+`Builder::new_local` API. Generic SQLite tools and other Turso versions are not
+supported and must not be substituted.
+
+## Preconditions
+
+Do not begin unless every precondition is satisfied:
+
+1. Stop the process that owns the database and guarantee that no other process
+   or client can access the database throughout the repair. The adapter's
+   directory ownership lock is private and is not acquired by the external
+   maintenance client.
+2. Using the same `Config`, open the database with `AttentionDatabase::open`
+   without invoking startup migrations, close it with `AttentionDatabase::close`,
+   and create a uniquely named backup with `AttentionDatabase::backup`. Verify
+   that the backup completed successfully and retain it until the repaired
+   database has passed migration and semantic-read checks.
+3. Ensure the maintenance client embeds or reads these repository artifacts
+   without modifying them:
+   - [`repair_duplicate_current_reminder_fires_setup.sql`](repair_duplicate_current_reminder_fires_setup.sql)
+   - [`repair_duplicate_current_reminder_fires_apply.sql`](repair_duplicate_current_reminder_fires_apply.sql)
+4. Establish domain evidence sufficient to choose one authoritative current
+   fire and a truthful terminal state for every other current fire. If any
+   prerequisite or decision is unavailable, stop and restore or escalate.
+
+## Transaction procedure
+
+The maintenance client owns the transaction. Neither SQL artifact begins,
+commits, or rolls back one.
+
+1. Connect to the stopped database through exact-pinned local
+   `turso_db::Builder::new_local` and begin one
+   `TransactionBehavior::Immediate` transaction.
+2. Execute the complete setup artifact. It creates only TEMP inspection,
+   snapshot, and decision objects; it does not modify persistent data.
+3. Inspect `temp.__attention_repair_duplicate_reminders` and the complete
+   `temp.__attention_repair_affected_fire_history`, reading the history in
+   `reminder_id`, `ordinal`, then `fire_id` order. Review every row for every
+   affected reminder. Ordinal, timestamp, state, and
+   `reminders.current_fire_id` are evidence only and are never automatic winner
+   rules.
+4. For each affected reminder, choose exactly one authoritative fire that is
+   currently in state `0` (Scheduled) or `1` (Fired). For every other current
+   fire, choose the evidence-backed terminal state `2` (Acknowledged) or `3`
+   (Snoozed). These terminal states have different domain meanings; never guess
+   or select one merely to make migration succeed.
+5. Use prepared statements and bound parameters to populate
+   `temp.__attention_repair_authoritative` with each reminder ID and its
+   authoritative fire ID, and `temp.__attention_repair_retire` with each
+   reminder ID, retired fire ID, and chosen terminal state. Never interpolate
+   an identifier or stored value into SQL text.
+6. Execute the complete apply artifact. It validates the live rows against the
+   setup snapshots, requires exact decision sets, updates only selected fire
+   states and reminder pointers, and checks history and consistency
+   postconditions. Its assertion failures are static and do not include stored
+   IDs.
+7. Commit only if setup, all bound decision inserts, apply, and all operator
+   checks succeed. On any error or uncertainty, explicitly roll back the
+   transaction, stop, and restore the verified backup or escalate. Do not edit
+   decisions and continue within a transaction after a failed apply.
+
+## After a successful commit
+
+Close the maintenance client before returning ownership to the application.
+Open the database through `AttentionDatabase`, invoke
+`run_startup_migrations`, and verify that migration head 3 is reached. A second
+migration invocation must apply zero migrations. Perform a semantic reminder
+read for every repaired reminder and confirm the selected current fire and all
+retained fire history reconstruct successfully before removing the backup or
+resuming normal processing.
+
+If migration or semantic verification fails, stop the process again, preserve
+the failed database for investigation, restore the verified pre-repair backup,
+and escalate. Do not attempt an unqualified direct edit.

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires.md
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires.md
@@ -41,8 +41,10 @@ commits, or rolls back one.
 1. Connect to the stopped database through exact-pinned local
    `turso_db::Builder::new_local` and begin one
    `TransactionBehavior::Immediate` transaction.
-2. Execute the complete setup artifact. It creates only TEMP inspection,
-   snapshot, and decision objects; it does not modify persistent data.
+2. Within that transaction, execute the complete setup artifact with
+   `transaction.execute_batch(setup_sql).await?`. It creates only TEMP
+   inspection, snapshot, and decision objects; it does not modify persistent
+   data.
 3. Inspect `temp.__attention_repair_duplicate_reminders` and the complete
    `temp.__attention_repair_affected_fire_history`, reading the history in
    `reminder_id`, `ordinal`, then `fire_id` order. Review every row for every
@@ -59,11 +61,12 @@ commits, or rolls back one.
    authoritative fire ID, and `temp.__attention_repair_retire` with each
    reminder ID, retired fire ID, and chosen terminal state. Never interpolate
    an identifier or stored value into SQL text.
-6. Execute the complete apply artifact. It validates the live rows against the
-   setup snapshots, requires exact decision sets, updates only selected fire
-   states and reminder pointers, and checks history and consistency
-   postconditions. Its assertion failures are static and do not include stored
-   IDs.
+6. Within the same transaction, execute the complete apply artifact with
+   `transaction.execute_batch(apply_sql).await?`. It validates the live rows
+   against the setup snapshots, requires exact decision sets, updates only
+   selected fire states and reminder pointers, and checks history and
+   consistency postconditions. Its assertion failures are static and do not
+   include stored IDs.
 7. Commit only if setup, all bound decision inserts, apply, and all operator
    checks succeed. On any error or uncertainty, explicitly roll back the
    transaction, stop, and restore the verified backup or escalate. Do not edit

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_apply.sql
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_apply.sql
@@ -1,0 +1,316 @@
+DROP TABLE IF EXISTS temp.__attention_repair_assertions;
+
+CREATE TEMP TABLE __attention_repair_assertions (
+    affected_set_drift INTEGER NOT NULL,
+    reminder_snapshot_drift INTEGER NOT NULL,
+    fire_snapshot_drift INTEGER NOT NULL,
+    authoritative_set_invalid INTEGER NOT NULL,
+    authoritative_fire_invalid INTEGER NOT NULL,
+    retirement_fire_invalid INTEGER NOT NULL,
+    authoritative_fire_retired INTEGER NOT NULL,
+    retirement_set_invalid INTEGER NOT NULL,
+    terminal_state_invalid INTEGER NOT NULL,
+    CONSTRAINT repair_affected_set_unchanged CHECK(affected_set_drift = 0),
+    CONSTRAINT repair_reminder_snapshot_unchanged CHECK(reminder_snapshot_drift = 0),
+    CONSTRAINT repair_fire_snapshot_unchanged CHECK(fire_snapshot_drift = 0),
+    CONSTRAINT repair_authoritative_set_exact CHECK(authoritative_set_invalid = 0),
+    CONSTRAINT repair_authoritative_fires_current CHECK(authoritative_fire_invalid = 0),
+    CONSTRAINT repair_retirement_fires_current CHECK(retirement_fire_invalid = 0),
+    CONSTRAINT repair_authoritative_not_retired CHECK(authoritative_fire_retired = 0),
+    CONSTRAINT repair_retirement_set_exact CHECK(retirement_set_invalid = 0),
+    CONSTRAINT repair_terminal_states_valid CHECK(terminal_state_invalid = 0)
+);
+
+INSERT INTO temp.__attention_repair_assertions
+SELECT
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_reminders AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminders AS r
+            WHERE r.id = b.reminder_id
+              AND 1 < (
+                  SELECT count(*)
+                  FROM reminder_fires AS f
+                  WHERE f.reminder_id = r.id
+                    AND f.state IN (0, 1)
+              )
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM reminders AS r
+        WHERE 1 < (
+            SELECT count(*)
+            FROM reminder_fires AS f
+            WHERE f.reminder_id = r.id
+              AND f.state IN (0, 1)
+        )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM temp.__attention_repair_baseline_reminders AS b
+              WHERE b.reminder_id = r.id
+          )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_reminders AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminders AS r
+            WHERE r.id = b.reminder_id
+              AND r.revision = b.revision
+              AND r.current_fire_id IS b.current_fire_id
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_fires AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = b.fire_id
+              AND f.reminder_id = b.reminder_id
+              AND f.ordinal = b.ordinal
+              AND f.trigger_at = b.trigger_at
+              AND f.state = b.state
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM reminder_fires AS f
+        JOIN temp.__attention_repair_baseline_reminders AS r
+          ON r.reminder_id = f.reminder_id
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_baseline_fires AS b
+            WHERE b.fire_id = f.id
+              AND b.reminder_id = f.reminder_id
+              AND b.ordinal = f.ordinal
+              AND b.trigger_at = f.trigger_at
+              AND b.state = f.state
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_reminders AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_authoritative AS a
+            WHERE a.reminder_id = b.reminder_id
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_authoritative AS a
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_baseline_reminders AS b
+            WHERE b.reminder_id = a.reminder_id
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_authoritative AS a
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = a.authoritative_fire_id
+              AND f.reminder_id = a.reminder_id
+              AND f.state IN (0, 1)
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_retire AS d
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = d.retired_fire_id
+              AND f.reminder_id = d.reminder_id
+              AND f.state IN (0, 1)
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_authoritative AS a
+        JOIN temp.__attention_repair_retire AS d
+          ON d.reminder_id = a.reminder_id
+         AND d.retired_fire_id = a.authoritative_fire_id
+    ),
+    EXISTS (
+        SELECT 1
+        FROM reminder_fires AS f
+        JOIN temp.__attention_repair_authoritative AS a
+          ON a.reminder_id = f.reminder_id
+        WHERE f.state IN (0, 1)
+          AND f.id != a.authoritative_fire_id
+          AND NOT EXISTS (
+              SELECT 1
+              FROM temp.__attention_repair_retire AS d
+              WHERE d.reminder_id = f.reminder_id
+                AND d.retired_fire_id = f.id
+          )
+    ) OR EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_retire AS d
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            JOIN temp.__attention_repair_authoritative AS a
+              ON a.reminder_id = f.reminder_id
+            WHERE f.reminder_id = d.reminder_id
+              AND f.id = d.retired_fire_id
+              AND f.state IN (0, 1)
+              AND f.id != a.authoritative_fire_id
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_retire
+        WHERE terminal_state IS NULL
+           OR terminal_state NOT BETWEEN 2 AND 3
+    );
+
+UPDATE reminder_fires
+SET state = (
+    SELECT d.terminal_state
+    FROM temp.__attention_repair_retire AS d
+    WHERE d.retired_fire_id = reminder_fires.id
+      AND d.reminder_id = reminder_fires.reminder_id
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM temp.__attention_repair_retire AS d
+    WHERE d.retired_fire_id = reminder_fires.id
+      AND d.reminder_id = reminder_fires.reminder_id
+);
+
+UPDATE reminders
+SET current_fire_id = (
+    SELECT a.authoritative_fire_id
+    FROM temp.__attention_repair_authoritative AS a
+    WHERE a.reminder_id = reminders.id
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM temp.__attention_repair_authoritative AS a
+    WHERE a.reminder_id = reminders.id
+);
+
+CREATE TEMP TABLE __attention_repair_postconditions (
+    current_fire_invalid INTEGER NOT NULL,
+    retirement_state_invalid INTEGER NOT NULL,
+    row_identity_changed INTEGER NOT NULL,
+    fire_shape_changed INTEGER NOT NULL,
+    reminder_revision_changed INTEGER NOT NULL,
+    unselected_fire_state_changed INTEGER NOT NULL,
+    CONSTRAINT repair_one_current_fire_matching_pointer CHECK(current_fire_invalid = 0),
+    CONSTRAINT repair_retirement_states_applied CHECK(retirement_state_invalid = 0),
+    CONSTRAINT repair_row_identity_preserved CHECK(row_identity_changed = 0),
+    CONSTRAINT repair_fire_history_shape_preserved CHECK(fire_shape_changed = 0),
+    CONSTRAINT repair_reminder_revisions_preserved CHECK(reminder_revision_changed = 0),
+    CONSTRAINT repair_unselected_fire_states_preserved CHECK(unselected_fire_state_changed = 0)
+);
+
+INSERT INTO temp.__attention_repair_postconditions
+SELECT
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_authoritative AS a
+        JOIN reminders AS r
+          ON r.id = a.reminder_id
+        WHERE r.current_fire_id IS NOT a.authoritative_fire_id
+           OR 1 != (
+               SELECT count(*)
+               FROM reminder_fires AS f
+               WHERE f.reminder_id = a.reminder_id
+                 AND f.state IN (0, 1)
+           )
+           OR NOT EXISTS (
+               SELECT 1
+               FROM reminder_fires AS f
+               WHERE f.id = a.authoritative_fire_id
+                 AND f.reminder_id = a.reminder_id
+                 AND f.state IN (0, 1)
+           )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_retire AS d
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = d.retired_fire_id
+              AND f.reminder_id = d.reminder_id
+              AND f.state = d.terminal_state
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_reminder_ids AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminders AS r
+            WHERE r.id = b.reminder_id
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM reminders AS r
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_baseline_reminder_ids AS b
+            WHERE b.reminder_id = r.id
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_fire_ids AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = b.fire_id
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM reminder_fires AS f
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_baseline_fire_ids AS b
+            WHERE b.fire_id = f.id
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_fires AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminder_fires AS f
+            WHERE f.id = b.fire_id
+              AND f.reminder_id = b.reminder_id
+              AND f.ordinal = b.ordinal
+              AND f.trigger_at = b.trigger_at
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_reminders AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM reminders AS r
+            WHERE r.id = b.reminder_id
+              AND r.revision = b.revision
+        )
+    ),
+    EXISTS (
+        SELECT 1
+        FROM temp.__attention_repair_baseline_fire_ids AS b
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM temp.__attention_repair_retire AS d
+            WHERE d.retired_fire_id = b.fire_id
+        )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM reminder_fires AS f
+              WHERE f.id = b.fire_id
+                AND f.state = b.state
+          )
+    );

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_apply.sql
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_apply.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS temp.__attention_repair_assertions;
+DROP TABLE IF EXISTS temp.__attention_repair_postconditions;
 
 CREATE TEMP TABLE __attention_repair_assertions (
     affected_set_drift INTEGER NOT NULL,
@@ -21,7 +22,17 @@ CREATE TEMP TABLE __attention_repair_assertions (
     CONSTRAINT repair_terminal_states_valid CHECK(terminal_state_invalid = 0)
 );
 
-INSERT INTO temp.__attention_repair_assertions
+INSERT INTO temp.__attention_repair_assertions (
+    affected_set_drift,
+    reminder_snapshot_drift,
+    fire_snapshot_drift,
+    authoritative_set_invalid,
+    authoritative_fire_invalid,
+    retirement_fire_invalid,
+    authoritative_fire_retired,
+    retirement_set_invalid,
+    terminal_state_invalid
+)
 SELECT
     EXISTS (
         SELECT 1
@@ -211,7 +222,14 @@ CREATE TEMP TABLE __attention_repair_postconditions (
     CONSTRAINT repair_unselected_fire_states_preserved CHECK(unselected_fire_state_changed = 0)
 );
 
-INSERT INTO temp.__attention_repair_postconditions
+INSERT INTO temp.__attention_repair_postconditions (
+    current_fire_invalid,
+    retirement_state_invalid,
+    row_identity_changed,
+    fire_shape_changed,
+    reminder_revision_changed,
+    unselected_fire_state_changed
+)
 SELECT
     EXISTS (
         SELECT 1

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_setup.sql
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_setup.sql
@@ -1,0 +1,125 @@
+DROP TABLE IF EXISTS temp.__attention_repair_duplicate_reminders;
+DROP TABLE IF EXISTS temp.__attention_repair_affected_fire_history;
+DROP TABLE IF EXISTS temp.__attention_repair_postconditions;
+DROP TABLE IF EXISTS temp.__attention_repair_assertions;
+DROP TABLE IF EXISTS temp.__attention_repair_authoritative;
+DROP TABLE IF EXISTS temp.__attention_repair_retire;
+DROP TABLE IF EXISTS temp.__attention_repair_baseline_fires;
+DROP TABLE IF EXISTS temp.__attention_repair_baseline_reminders;
+DROP TABLE IF EXISTS temp.__attention_repair_baseline_fire_ids;
+DROP TABLE IF EXISTS temp.__attention_repair_baseline_reminder_ids;
+
+CREATE TEMP TABLE __attention_repair_baseline_reminder_ids (
+    reminder_id TEXT PRIMARY KEY NOT NULL
+);
+
+INSERT INTO temp.__attention_repair_baseline_reminder_ids (reminder_id)
+SELECT id
+FROM reminders;
+
+CREATE TEMP TABLE __attention_repair_baseline_fire_ids (
+    fire_id TEXT PRIMARY KEY NOT NULL,
+    state INTEGER NOT NULL
+);
+
+INSERT INTO temp.__attention_repair_baseline_fire_ids (fire_id, state)
+SELECT id, state
+FROM reminder_fires;
+
+CREATE TEMP TABLE __attention_repair_baseline_reminders (
+    reminder_id TEXT PRIMARY KEY NOT NULL,
+    revision BLOB NOT NULL,
+    current_fire_id TEXT
+);
+
+INSERT INTO temp.__attention_repair_baseline_reminders (
+    reminder_id,
+    revision,
+    current_fire_id
+)
+SELECT r.id, r.revision, r.current_fire_id
+FROM reminders AS r
+WHERE 1 < (
+    SELECT count(*)
+    FROM reminder_fires AS f
+    WHERE f.reminder_id = r.id
+      AND f.state IN (0, 1)
+);
+
+CREATE TEMP TABLE __attention_repair_baseline_fires (
+    fire_id TEXT PRIMARY KEY NOT NULL,
+    reminder_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    trigger_at TEXT NOT NULL,
+    state INTEGER NOT NULL
+);
+
+INSERT INTO temp.__attention_repair_baseline_fires (
+    fire_id,
+    reminder_id,
+    ordinal,
+    trigger_at,
+    state
+)
+SELECT f.id, f.reminder_id, f.ordinal, f.trigger_at, f.state
+FROM reminder_fires AS f
+JOIN temp.__attention_repair_baseline_reminders AS b
+  ON b.reminder_id = f.reminder_id;
+
+CREATE TEMP TABLE __attention_repair_duplicate_reminders (
+    reminder_id TEXT PRIMARY KEY NOT NULL,
+    revision BLOB NOT NULL,
+    current_fire_id TEXT,
+    scheduled_fire_count INTEGER NOT NULL,
+    fired_fire_count INTEGER NOT NULL,
+    current_fire_count INTEGER NOT NULL
+);
+
+INSERT INTO temp.__attention_repair_duplicate_reminders
+SELECT
+    b.reminder_id,
+    b.revision,
+    b.current_fire_id,
+    sum(CASE WHEN f.state = 0 THEN 1 ELSE 0 END) AS scheduled_fire_count,
+    sum(CASE WHEN f.state = 1 THEN 1 ELSE 0 END) AS fired_fire_count,
+    sum(CASE WHEN f.state IN (0, 1) THEN 1 ELSE 0 END) AS current_fire_count
+FROM __attention_repair_baseline_reminders AS b
+JOIN __attention_repair_baseline_fires AS f
+  ON f.reminder_id = b.reminder_id
+GROUP BY b.reminder_id, b.revision, b.current_fire_id
+ORDER BY b.reminder_id;
+
+CREATE TEMP TABLE __attention_repair_affected_fire_history (
+    reminder_id TEXT NOT NULL,
+    revision BLOB NOT NULL,
+    current_fire_id TEXT,
+    fire_id TEXT PRIMARY KEY NOT NULL,
+    ordinal INTEGER NOT NULL,
+    trigger_at TEXT NOT NULL,
+    state INTEGER NOT NULL
+);
+
+INSERT INTO temp.__attention_repair_affected_fire_history
+SELECT
+    b.reminder_id,
+    b.revision,
+    b.current_fire_id,
+    f.fire_id,
+    f.ordinal,
+    f.trigger_at,
+    f.state
+FROM __attention_repair_baseline_reminders AS b
+JOIN __attention_repair_baseline_fires AS f
+  ON f.reminder_id = b.reminder_id
+ORDER BY b.reminder_id, f.ordinal, f.fire_id;
+
+CREATE TEMP TABLE __attention_repair_authoritative (
+    reminder_id TEXT PRIMARY KEY NOT NULL,
+    authoritative_fire_id TEXT NOT NULL
+);
+
+CREATE TEMP TABLE __attention_repair_retire (
+    reminder_id TEXT NOT NULL,
+    retired_fire_id TEXT PRIMARY KEY NOT NULL,
+    terminal_state INTEGER NOT NULL CHECK(terminal_state IN (2, 3))
+);

--- a/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_setup.sql
+++ b/crates/attention/turso/maintenance/repair_duplicate_current_reminder_fires_setup.sql
@@ -75,7 +75,14 @@ CREATE TEMP TABLE __attention_repair_duplicate_reminders (
     current_fire_count INTEGER NOT NULL
 );
 
-INSERT INTO temp.__attention_repair_duplicate_reminders
+INSERT INTO temp.__attention_repair_duplicate_reminders (
+    reminder_id,
+    revision,
+    current_fire_id,
+    scheduled_fire_count,
+    fired_fire_count,
+    current_fire_count
+)
 SELECT
     b.reminder_id,
     b.revision,
@@ -99,7 +106,15 @@ CREATE TEMP TABLE __attention_repair_affected_fire_history (
     state INTEGER NOT NULL
 );
 
-INSERT INTO temp.__attention_repair_affected_fire_history
+INSERT INTO temp.__attention_repair_affected_fire_history (
+    reminder_id,
+    revision,
+    current_fire_id,
+    fire_id,
+    ordinal,
+    trigger_at,
+    state
+)
 SELECT
     b.reminder_id,
     b.revision,

--- a/crates/attention/turso/migrations/0003_durable_delivery.sql
+++ b/crates/attention/turso/migrations/0003_durable_delivery.sql
@@ -1,0 +1,73 @@
+CREATE TABLE delivery_states (
+    intent_id TEXT PRIMARY KEY NOT NULL,
+    status INTEGER NOT NULL CHECK(status IN (0, 1, 2, 3, 4, 5)),
+    lease_token BLOB CHECK(lease_token IS NULL OR length(lease_token) = 32),
+    lease_expires_at TEXT,
+    attempt INTEGER CHECK(attempt IS NULL OR attempt BETWEEN 0 AND 4294967295),
+    error TEXT CHECK(error IS NULL OR length(CAST(error AS BLOB)) <= 65536),
+    next_retry_at TEXT,
+    provider_message_id TEXT CHECK(
+        provider_message_id IS NULL OR length(CAST(provider_message_id AS BLOB)) <= 65536
+    ),
+    succeeded_at TEXT,
+    reason TEXT CHECK(reason IS NULL OR length(CAST(reason AS BLOB)) <= 65536),
+    skipped_at TEXT,
+    failed_at TEXT,
+    CHECK(status != 0 OR (
+        lease_token IS NULL AND lease_expires_at IS NULL
+        AND attempt IS NULL AND error IS NULL AND next_retry_at IS NULL
+        AND provider_message_id IS NULL AND succeeded_at IS NULL
+        AND reason IS NULL AND skipped_at IS NULL AND failed_at IS NULL
+    )),
+    CHECK(status != 1 OR (
+        lease_token IS NOT NULL AND lease_expires_at IS NOT NULL
+        AND attempt IS NULL AND error IS NULL AND next_retry_at IS NULL
+        AND provider_message_id IS NULL AND succeeded_at IS NULL
+        AND reason IS NULL AND skipped_at IS NULL AND failed_at IS NULL
+    )),
+    CHECK(status != 2 OR (
+        lease_token IS NULL AND lease_expires_at IS NULL
+        AND attempt IS NOT NULL AND error IS NOT NULL AND next_retry_at IS NOT NULL
+        AND provider_message_id IS NULL AND succeeded_at IS NULL
+        AND reason IS NULL AND skipped_at IS NULL AND failed_at IS NULL
+    )),
+    CHECK(status != 3 OR (
+        lease_token IS NULL AND lease_expires_at IS NULL
+        AND attempt IS NULL AND error IS NULL AND next_retry_at IS NULL
+        AND provider_message_id IS NOT NULL AND succeeded_at IS NOT NULL
+        AND reason IS NULL AND skipped_at IS NULL AND failed_at IS NULL
+    )),
+    CHECK(status != 4 OR (
+        lease_token IS NULL AND lease_expires_at IS NULL
+        AND attempt IS NULL AND error IS NULL AND next_retry_at IS NULL
+        AND provider_message_id IS NULL AND succeeded_at IS NULL
+        AND reason IS NOT NULL AND skipped_at IS NOT NULL AND failed_at IS NULL
+    )),
+    CHECK(status != 5 OR (
+        lease_token IS NULL AND lease_expires_at IS NULL
+        AND attempt IS NOT NULL AND error IS NOT NULL AND next_retry_at IS NULL
+        AND provider_message_id IS NULL AND succeeded_at IS NULL
+        AND reason IS NULL AND skipped_at IS NULL AND failed_at IS NOT NULL
+    )),
+    FOREIGN KEY(intent_id) REFERENCES outbox_intents(id)
+);
+
+CREATE TABLE delivery_checkpoints (
+    worker TEXT PRIMARY KEY NOT NULL
+        CHECK(length(CAST(worker AS BLOB)) <= 65536),
+    cursor BLOB NOT NULL CHECK(length(cursor) = 8)
+);
+
+INSERT INTO delivery_states (intent_id, status)
+SELECT id, 0 FROM outbox_intents;
+
+CREATE INDEX delivery_states_by_status_intent
+    ON delivery_states(status, intent_id);
+CREATE INDEX delivery_states_by_lease_expiry
+    ON delivery_states(status, lease_expires_at, intent_id) WHERE status = 1;
+CREATE INDEX delivery_states_by_retry_due
+    ON delivery_states(status, next_retry_at, intent_id) WHERE status = 2;
+CREATE INDEX outbox_intents_by_created_at
+    ON outbox_intents(created_at, id);
+CREATE UNIQUE INDEX reminder_fires_one_current_per_reminder
+    ON reminder_fires(reminder_id) WHERE state IN (0, 1);

--- a/crates/attention/turso/src/database.rs
+++ b/crates/attention/turso/src/database.rs
@@ -3,6 +3,8 @@ use crate::Error;
 use crate::LifecycleState;
 use crate::backup;
 use crate::backup::BackupManifest;
+use crate::delivery_reader;
+use crate::delivery_writer;
 use crate::lifecycle::Lifecycle;
 use crate::migration;
 use crate::migration::MigrationReport;
@@ -21,25 +23,40 @@ use attention_kernel::AcknowledgeReminderFireResult;
 use attention_kernel::AttentionSignal;
 use attention_kernel::AttentionSignalId;
 use attention_kernel::AttentionSnapshot;
+use attention_kernel::BoundedDeliveryText;
 use attention_kernel::CancelWorkItemBundle;
 use attention_kernel::CancelWorkItemResult;
 use attention_kernel::ChangesAfterQuery;
 use attention_kernel::ChangesResult;
+use attention_kernel::CheckpointAdvance;
+use attention_kernel::CheckpointAdvanceOutcome;
+use attention_kernel::CheckpointQuery;
 use attention_kernel::CompleteWorkItemBundle;
 use attention_kernel::CompleteWorkItemResult;
 use attention_kernel::CreateReminderBundle;
 use attention_kernel::CreateReminderResult;
 use attention_kernel::CreateWorkItemBundle;
 use attention_kernel::CreateWorkItemResult;
+use attention_kernel::DeliveryAuthority;
+use attention_kernel::DeliveryCheckpoint;
+use attention_kernel::DeliveryClaim;
+use attention_kernel::DeliveryClaimQuery;
+use attention_kernel::DeliveryCompletionOutcome;
+use attention_kernel::DeliveryLeaseToken;
+use attention_kernel::DueReminderFire;
+use attention_kernel::DueReminderFiresQuery;
 use attention_kernel::FireReminderBundle;
 use attention_kernel::FireReminderResult;
 use attention_kernel::IngestSourceOccurrenceBundle;
 use attention_kernel::IngestSourceOccurrenceResult;
 use attention_kernel::MutationIdempotencyKey;
+use attention_kernel::OutboxIntentId;
 use attention_kernel::PortError;
 use attention_kernel::PriorMutationOutcome;
+use attention_kernel::ProviderMessageId;
 use attention_kernel::Reminder;
 use attention_kernel::ReminderId;
+use attention_kernel::RenewOutcome;
 use attention_kernel::SnoozeReminderFireBundle;
 use attention_kernel::SnoozeReminderFireResult;
 use attention_kernel::SourceAuthorityQuery;
@@ -48,6 +65,8 @@ use attention_kernel::SourceReceipt;
 use attention_kernel::SourceReceiptId;
 use attention_kernel::WorkItem;
 use attention_kernel::WorkItemId;
+use chrono::DateTime;
+use chrono::Utc;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use turso_db::Builder;
@@ -153,6 +172,175 @@ impl AttentionDatabase {
         let _lifecycle = self.inner.lifecycle.acquire()?;
         let readers = self.semantic_readers().await?;
         semantic_reader::changes(&readers, &self.inner.engine, query).await
+    }
+
+    pub(crate) async fn semantic_due_reminder_fires(
+        &self,
+        query: DueReminderFiresQuery,
+    ) -> Result<Vec<DueReminderFire>, Error> {
+        let _lifecycle = self.inner.lifecycle.acquire()?;
+        let readers = self.semantic_readers().await?;
+        semantic_reader::due_reminder_fires(&readers, &self.inner.engine, query).await
+    }
+
+    pub(crate) async fn delivery_inspect(
+        &self,
+        intent_id: OutboxIntentId,
+    ) -> Result<Option<DeliveryAuthority>, Error> {
+        let _lifecycle = self.inner.lifecycle.acquire()?;
+        let readers = self.semantic_readers().await?;
+        delivery_reader::inspect(&readers, &self.inner.engine, intent_id).await
+    }
+
+    pub(crate) async fn delivery_claim(
+        &self,
+        query: DeliveryClaimQuery,
+    ) -> Result<Vec<DeliveryClaim>, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, _readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::claim(&writer, &self.inner.engine, query).await
+    }
+
+    pub(crate) async fn delivery_renew(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        expires_at: DateTime<Utc>,
+    ) -> Result<RenewOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::renew(
+            &writer,
+            &readers,
+            &self.inner.engine,
+            intent_id,
+            token,
+            expires_at,
+        )
+        .await
+    }
+
+    pub(crate) async fn delivery_succeed(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        provider_message_id: ProviderMessageId,
+        succeeded_at: DateTime<Utc>,
+    ) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::succeed(
+            &writer,
+            &readers,
+            &self.inner.engine,
+            intent_id,
+            token,
+            provider_message_id,
+            succeeded_at,
+        )
+        .await
+    }
+
+    pub(crate) async fn delivery_fail_retryable(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        attempt: u32,
+        error: BoundedDeliveryText,
+        next_retry_at: DateTime<Utc>,
+    ) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::fail_retryable(
+            &writer,
+            &readers,
+            &self.inner.engine,
+            intent_id,
+            token,
+            (attempt, error, next_retry_at),
+        )
+        .await
+    }
+
+    pub(crate) async fn delivery_fail_terminal(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        attempt: u32,
+        error: BoundedDeliveryText,
+        failed_at: DateTime<Utc>,
+    ) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::fail_terminal(
+            &writer,
+            &readers,
+            &self.inner.engine,
+            intent_id,
+            token,
+            (attempt, error, failed_at),
+        )
+        .await
+    }
+
+    pub(crate) async fn delivery_skip(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        reason: BoundedDeliveryText,
+        skipped_at: DateTime<Utc>,
+    ) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::skip(
+            &writer,
+            &readers,
+            &self.inner.engine,
+            intent_id,
+            token,
+            reason,
+            skipped_at,
+        )
+        .await
+    }
+
+    pub(crate) async fn delivery_checkpoint(
+        &self,
+        query: CheckpointQuery,
+    ) -> Result<Option<DeliveryCheckpoint>, Error> {
+        let _lifecycle = self.inner.lifecycle.acquire()?;
+        let readers = self.semantic_readers().await?;
+        delivery_reader::checkpoint(&readers, &self.inner.engine, query).await
+    }
+
+    pub(crate) async fn delivery_advance_checkpoint(
+        &self,
+        advance: CheckpointAdvance,
+    ) -> Result<CheckpointAdvanceOutcome, PortError<Error>> {
+        let _lifecycle = self.inner.lifecycle.acquire().map_err(PortError::Adapter)?;
+        let (writer, readers) = self
+            .semantic_writer_parts()
+            .await
+            .map_err(PortError::Adapter)?;
+        delivery_writer::advance_checkpoint(&writer, &readers, &self.inner.engine, advance).await
     }
 
     async fn semantic_writer_parts(&self) -> Result<(Arc<Writer>, Arc<ReaderPool>), Error> {
@@ -480,13 +668,31 @@ mod tests {
     use crate::writer::SemanticFailpoint;
     use attention_kernel::AttentionCommitPort;
     use attention_kernel::AttentionReadPort;
+    use attention_kernel::BoundedDeliveryText;
     use attention_kernel::ChangeEventId;
+    use attention_kernel::CheckpointAdvance;
+    use attention_kernel::CheckpointAdvanceOutcome;
+    use attention_kernel::ClaimLimit;
     use attention_kernel::CommitCursor;
+    use attention_kernel::CreateReminder;
     use attention_kernel::CreateWorkItem;
+    use attention_kernel::DeliveryClaimQuery;
+    use attention_kernel::DeliveryCompletionOutcome;
+    use attention_kernel::DeliveryStatus;
     use attention_kernel::EvaluationContext;
+    use attention_kernel::FireReminder;
     use attention_kernel::MutationIdempotencyKey;
+    use attention_kernel::OutboxIntentId;
     use attention_kernel::PriorOutcomeQuery;
+    use attention_kernel::ProviderMessageId;
+    use attention_kernel::ReminderFireId;
+    use attention_kernel::ReminderFireState;
+    use attention_kernel::ReminderId;
+    use attention_kernel::ReminderTarget;
+    use attention_kernel::WorkItemId;
+    use attention_kernel::evaluate_create_reminder;
     use attention_kernel::evaluate_create_work_item;
+    use attention_kernel::evaluate_fire_reminder;
     use chrono::Utc;
     use futures::FutureExt;
     use std::time::Duration;
@@ -709,6 +915,165 @@ mod tests {
                 })?;
             database.close().await?;
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_finish_failpoint_rolls_back_outbox_and_pending_authority() -> Result<(), Error> {
+        let (_root, database) = database(1).await?;
+        let reminder_id = ReminderId::new();
+        let fire_id = ReminderFireId::new();
+        database
+            .commit_create_reminder(evaluate_create_reminder(
+                &CreateReminder::new(
+                    reminder_id,
+                    fire_id,
+                    ReminderTarget::WorkItem(WorkItemId::new()),
+                    Utc::now(),
+                    MutationIdempotencyKey::new(),
+                ),
+                EvaluationContext::new(ChangeEventId::new(), None, Utc::now()),
+            ))
+            .await
+            .map_err(|error| match error {
+                PortError::Adapter(error) => error,
+                PortError::Semantic(_) => {
+                    Error::MigrationIntegrity("reminder setup returned semantic error")
+                }
+            })?;
+        let reminder = database
+            .reminder(reminder_id)
+            .await
+            .map_err(|error| match error {
+                PortError::Adapter(error) => error,
+                PortError::Semantic(_) => {
+                    Error::MigrationIntegrity("reminder read returned semantic error")
+                }
+            })?
+            .ok_or(Error::MigrationIntegrity("reminder setup is missing"))?;
+        let intent_id = OutboxIntentId::new();
+        let bundle = evaluate_fire_reminder(
+            &FireReminder::new(reminder_id, fire_id, MutationIdempotencyKey::new()),
+            &reminder,
+            EvaluationContext::new(ChangeEventId::new(), Some(intent_id), Utc::now()),
+        )
+        .map_err(|error| Error::Decode(Box::new(error)))?;
+        let writer = database
+            .inner
+            .writer
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or(Error::Shutdown)?;
+        writer.set_semantic_failpoint(SemanticFailpoint::AfterFinish);
+        assert!(database.commit_fire_reminder(bundle.clone()).await.is_err());
+        writer.set_semantic_failpoint(SemanticFailpoint::Disabled);
+
+        let reminder = database
+            .reminder(reminder_id)
+            .await
+            .map_err(|error| match error {
+                PortError::Adapter(error) => error,
+                PortError::Semantic(_) => {
+                    Error::MigrationIntegrity("reminder read returned semantic error")
+                }
+            })?
+            .ok_or(Error::MigrationIntegrity("reminder disappeared"))?;
+        assert_eq!(reminder.fires()[0].state(), ReminderFireState::Scheduled);
+        let connection = database
+            .inner
+            .engine
+            .lock()
+            .await
+            .as_ref()
+            .ok_or(Error::Shutdown)?
+            .connect()
+            .map_err(Error::from_connect)?;
+        let mut rows = connection
+            .query(
+                "SELECT (SELECT count(*) FROM outbox_intents),
+                        (SELECT count(*) FROM delivery_states)",
+                (),
+            )
+            .await?;
+        let row = rows.next().await?.ok_or(Error::MigrationIntegrity(
+            "delivery inventory count missing",
+        ))?;
+        assert_eq!(row.get::<i64>(0).map_err(Error::from)?, 0);
+        assert_eq!(row.get::<i64>(1).map_err(Error::from)?, 0);
+        drop(rows);
+        drop(connection);
+
+        database
+            .commit_fire_reminder(bundle)
+            .await
+            .map_err(|error| match error {
+                PortError::Adapter(error) => error,
+                PortError::Semantic(_) => {
+                    Error::MigrationIntegrity("fire retry returned semantic error")
+                }
+            })?;
+        writer.set_semantic_failpoint(SemanticFailpoint::AfterCommit);
+        let now = Utc::now();
+        assert!(matches!(
+            database
+                .delivery_claim(DeliveryClaimQuery::new(
+                    now,
+                    now + chrono::Duration::minutes(1),
+                    ClaimLimit::try_from(1).map_err(|error| Error::Decode(Box::new(error)))?,
+                ))
+                .await,
+            Err(PortError::Adapter(Error::CommitOutcomeUnknown))
+        ));
+        let authority = database
+            .delivery_inspect(intent_id)
+            .await?
+            .ok_or(Error::MigrationIntegrity("ambiguous claim did not commit"))?;
+        let DeliveryStatus::Leased { token, .. } = authority.state().status() else {
+            return Err(Error::MigrationIntegrity(
+                "ambiguous claim did not leave a lease",
+            ));
+        };
+        let token = *token;
+        assert_eq!(
+            database
+                .delivery_succeed(
+                    intent_id,
+                    token,
+                    ProviderMessageId::new("ambiguous-provider", 128)
+                        .map_err(|error| Error::Decode(Box::new(error)))?,
+                    now,
+                )
+                .await
+                .map_err(|error| match error {
+                    PortError::Adapter(error) => error,
+                    PortError::Semantic(_) => {
+                        Error::MigrationIntegrity("delivery success returned semantic error")
+                    }
+                })?,
+            DeliveryCompletionOutcome::Applied
+        );
+        assert_eq!(
+            database
+                .delivery_advance_checkpoint(CheckpointAdvance::new(
+                    BoundedDeliveryText::new("ambiguous-worker", 128)
+                        .map_err(|error| Error::Decode(Box::new(error)))?,
+                    None,
+                    CommitCursor::try_from(2).map_err(|error| Error::Decode(Box::new(error)))?,
+                    intent_id,
+                ))
+                .await
+                .map_err(|error| match error {
+                    PortError::Adapter(error) => error,
+                    PortError::Semantic(_) => {
+                        Error::MigrationIntegrity("checkpoint advance returned semantic error")
+                    }
+                })?,
+            CheckpointAdvanceOutcome::Advanced
+        );
+        writer.set_semantic_failpoint(SemanticFailpoint::Disabled);
+        database.close().await?;
         Ok(())
     }
 

--- a/crates/attention/turso/src/delivery_reader.rs
+++ b/crates/attention/turso/src/delivery_reader.rs
@@ -1,0 +1,120 @@
+use crate::Error;
+use crate::domain_sql;
+use crate::mapping;
+use crate::reader::ReaderPool;
+use attention_kernel::CheckpointQuery;
+use attention_kernel::CommitCursor;
+use attention_kernel::DeliveryAuthority;
+use attention_kernel::DeliveryCheckpoint;
+use attention_kernel::DeliveryStatus;
+use attention_kernel::OutboxIntentId;
+use futures::FutureExt;
+use tokio::sync::Mutex;
+use turso_db::Database;
+use turso_db::params;
+
+pub async fn inspect(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+) -> Result<Option<DeliveryAuthority>, Error> {
+    readers
+        .with_snapshot(engine, move |transaction| {
+            async move {
+                let mut rows = transaction
+                    .query(
+                        domain_sql::SELECT_DELIVERY_AUTHORITY,
+                        params![mapping::id(intent_id)],
+                    )
+                    .await?;
+                let authority = rows
+                    .next()
+                    .await?
+                    .map(|row| mapping::delivery_authority(&row))
+                    .transpose()?;
+                drop(rows);
+                Ok(authority)
+            }
+            .boxed()
+        })
+        .await
+}
+
+pub async fn status(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+) -> Result<Option<DeliveryStatus>, Error> {
+    readers
+        .with_snapshot(engine, move |transaction| {
+            async move {
+                let mut rows = transaction
+                    .query(
+                        domain_sql::SELECT_DELIVERY_STATE,
+                        params![mapping::id(intent_id)],
+                    )
+                    .await?;
+                let status = rows
+                    .next()
+                    .await?
+                    .map(|row| mapping::delivery_status(&row, 0))
+                    .transpose()?;
+                drop(rows);
+                Ok(status)
+            }
+            .boxed()
+        })
+        .await
+}
+
+pub async fn checkpoint(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    query: CheckpointQuery,
+) -> Result<Option<DeliveryCheckpoint>, Error> {
+    let worker = mapping::delivery_text(query.worker())?.to_owned();
+    readers
+        .with_snapshot(engine, move |transaction| {
+            let worker = worker.clone();
+            async move {
+                let mut rows = transaction
+                    .query(domain_sql::SELECT_DELIVERY_CHECKPOINT, params![worker])
+                    .await?;
+                let checkpoint = rows
+                    .next()
+                    .await?
+                    .map(|row| mapping::delivery_checkpoint(&row))
+                    .transpose()?;
+                drop(rows);
+                Ok(checkpoint)
+            }
+            .boxed()
+        })
+        .await
+}
+
+pub async fn checkpoint_cursor(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    worker: String,
+) -> Result<Option<CommitCursor>, Error> {
+    readers
+        .with_snapshot(engine, move |transaction| {
+            let worker = worker.clone();
+            async move {
+                let mut rows = transaction
+                    .query(domain_sql::SELECT_DELIVERY_CHECKPOINT, params![worker])
+                    .await?;
+                let cursor = match rows.next().await? {
+                    Some(row) => Some(mapping::parse_checkpoint_cursor(&crate::decode::blob(
+                        &row, 1,
+                    )?)?),
+                    None => None,
+                };
+                drop(rows);
+                Ok(cursor)
+            }
+            .boxed()
+        })
+        .await
+}

--- a/crates/attention/turso/src/delivery_writer.rs
+++ b/crates/attention/turso/src/delivery_writer.rs
@@ -1,0 +1,609 @@
+use crate::Error;
+use crate::decode;
+use crate::delivery_reader;
+use crate::domain_sql;
+use crate::mapping;
+use crate::reader::ReaderPool;
+use crate::writer::TransactionDecision;
+use crate::writer::Writer;
+use attention_kernel::BoundedDeliveryText;
+use attention_kernel::CheckpointAdvance;
+use attention_kernel::CheckpointAdvanceOutcome;
+use attention_kernel::ClaimOutcome;
+use attention_kernel::CommitCursor;
+use attention_kernel::DeliveryClaim;
+use attention_kernel::DeliveryClaimQuery;
+use attention_kernel::DeliveryCompletionOutcome;
+use attention_kernel::DeliveryLeaseToken;
+use attention_kernel::DeliveryState;
+use attention_kernel::DeliveryStatus;
+use attention_kernel::OutboxIntentId;
+use attention_kernel::PortError;
+use attention_kernel::ProviderMessageId;
+use attention_kernel::RenewOutcome;
+use chrono::DateTime;
+use chrono::Utc;
+use futures::FutureExt;
+use std::collections::HashSet;
+use tokio::sync::Mutex;
+use turso_db::Database;
+use turso_db::params;
+use turso_db::transaction::Transaction;
+
+struct Candidate {
+    intent_id: OutboxIntentId,
+    created_at: DateTime<Utc>,
+    status: DeliveryStatus,
+}
+
+fn eligible(status: &DeliveryStatus, eligible_at: &DateTime<Utc>) -> bool {
+    match status {
+        DeliveryStatus::Pending => true,
+        DeliveryStatus::Leased { expires_at, .. } => expires_at <= eligible_at,
+        DeliveryStatus::Retryable { next_retry_at, .. } => next_retry_at <= eligible_at,
+        DeliveryStatus::Succeeded { .. }
+        | DeliveryStatus::Skipped { .. }
+        | DeliveryStatus::TerminalFailure { .. } => false,
+    }
+}
+
+fn fresh_token(
+    issued: &mut HashSet<DeliveryLeaseToken>,
+    previous: Option<DeliveryLeaseToken>,
+) -> Result<DeliveryLeaseToken, PortError<Error>> {
+    loop {
+        let mut bytes = [0_u8; 32];
+        getrandom::fill(&mut bytes)
+            .map_err(|error| PortError::Adapter(Error::Engine(Box::new(error))))?;
+        let token = DeliveryLeaseToken::from_bytes(bytes);
+        if previous == Some(token) || !issued.insert(token) {
+            continue;
+        }
+        return Ok(token);
+    }
+}
+
+async fn state_in(
+    transaction: &Transaction<'_>,
+    intent_id: OutboxIntentId,
+) -> Result<Option<DeliveryStatus>, PortError<Error>> {
+    let mut rows = transaction
+        .query(
+            domain_sql::SELECT_DELIVERY_STATE,
+            params![mapping::id(intent_id)],
+        )
+        .await
+        .map_err(Error::from)
+        .map_err(PortError::Adapter)?;
+    let status = rows
+        .next()
+        .await
+        .map_err(Error::from)
+        .map_err(PortError::Adapter)?
+        .map(|row| mapping::delivery_status(&row, 0))
+        .transpose()
+        .map_err(PortError::Adapter)?;
+    drop(rows);
+    Ok(status)
+}
+
+async fn checkpoint_in(
+    transaction: &Transaction<'_>,
+    worker: &str,
+) -> Result<Option<CommitCursor>, PortError<Error>> {
+    let mut rows = transaction
+        .query(domain_sql::SELECT_DELIVERY_CHECKPOINT, params![worker])
+        .await
+        .map_err(Error::from)
+        .map_err(PortError::Adapter)?;
+    let cursor = match rows
+        .next()
+        .await
+        .map_err(Error::from)
+        .map_err(PortError::Adapter)?
+    {
+        Some(row) => Some(
+            mapping::parse_checkpoint_cursor(&decode::blob(&row, 1).map_err(PortError::Adapter)?)
+                .map_err(PortError::Adapter)?,
+        ),
+        None => None,
+    };
+    drop(rows);
+    Ok(cursor)
+}
+
+async fn prove_status(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    expected: &DeliveryStatus,
+) -> Result<bool, PortError<Error>> {
+    Ok(delivery_reader::status(readers, engine, intent_id)
+        .await
+        .map_err(PortError::Adapter)?
+        .is_some_and(|status| status == *expected))
+}
+
+pub async fn claim(
+    writer: &Writer,
+    engine: &Mutex<Option<Database>>,
+    query: DeliveryClaimQuery,
+) -> Result<Vec<DeliveryClaim>, PortError<Error>> {
+    let eligible_at = *query.eligible_at();
+    let lease_expires_at = *query.lease_expires_at();
+    let limit = query.limit().value();
+    writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let mut rows = transaction
+                    .query(domain_sql::SELECT_DELIVERY_CANDIDATES, ())
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                let mut candidates = Vec::new();
+                while let Some(row) = rows
+                    .next()
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?
+                {
+                    candidates.push(Candidate {
+                        intent_id: mapping::parse_id(
+                            &decode::text(&row, 0).map_err(PortError::Adapter)?,
+                        )
+                        .map_err(PortError::Adapter)?,
+                        created_at: mapping::parse_timestamp(
+                            &decode::text(&row, 1).map_err(PortError::Adapter)?,
+                        )
+                        .map_err(PortError::Adapter)?,
+                        status: mapping::delivery_status(&row, 2).map_err(PortError::Adapter)?,
+                    });
+                }
+                drop(rows);
+                candidates.retain(|candidate| eligible(&candidate.status, &eligible_at));
+                candidates.sort_by_key(|candidate| (candidate.created_at, candidate.intent_id));
+                candidates.truncate(limit);
+                if candidates.is_empty() {
+                    return Ok(TransactionDecision::Rollback(Vec::new()));
+                }
+
+                let mut issued = HashSet::new();
+                let mut claims = Vec::with_capacity(candidates.len());
+                for candidate in candidates {
+                    let previous = match &candidate.status {
+                        DeliveryStatus::Leased { token, .. } => Some(*token),
+                        _ => None,
+                    };
+                    let token = fresh_token(&mut issued, previous)?;
+                    let mut state =
+                        DeliveryState::reconstruct(candidate.intent_id, candidate.status);
+                    let ClaimOutcome::Claimed(claim) = state.claim(token, lease_expires_at) else {
+                        return Err(PortError::Adapter(Error::InvariantViolation(
+                            "eligible delivery became terminal inside claim transaction",
+                        )));
+                    };
+                    let affected = transaction
+                        .execute(
+                            domain_sql::UPDATE_DELIVERY_LEASED,
+                            params![
+                                mapping::id(candidate.intent_id),
+                                mapping::lease_token(token),
+                                mapping::timestamp(&lease_expires_at)
+                            ],
+                        )
+                        .await
+                        .map_err(Error::from)
+                        .map_err(PortError::Adapter)?;
+                    if affected != 1 {
+                        return Err(PortError::Adapter(Error::InvariantViolation(
+                            "delivery claim update lost authority",
+                        )));
+                    }
+                    claims.push(claim);
+                }
+                Ok(TransactionDecision::Commit(claims))
+            }
+            .boxed()
+        })
+        .await
+}
+
+pub async fn renew(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    token: DeliveryLeaseToken,
+    expires_at: DateTime<Utc>,
+) -> Result<RenewOutcome, PortError<Error>> {
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let Some(status) = state_in(transaction, intent_id).await? else {
+                    return Ok(TransactionDecision::Rollback(RenewOutcome::NotLeased));
+                };
+                if matches!(status, DeliveryStatus::Leased { token: current, expires_at: current_at }
+                    if current == token && current_at == expires_at)
+                {
+                    return Ok(TransactionDecision::Rollback(RenewOutcome::Renewed));
+                }
+                let mut state = DeliveryState::reconstruct(intent_id, status);
+                let outcome = state.renew(token, expires_at);
+                if outcome != RenewOutcome::Renewed {
+                    return Ok(TransactionDecision::Rollback(outcome));
+                }
+                let affected = transaction
+                    .execute(
+                        domain_sql::UPDATE_DELIVERY_RENEWED,
+                        params![
+                            mapping::id(intent_id),
+                            mapping::lease_token(token),
+                            mapping::timestamp(&expires_at)
+                        ],
+                    )
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "delivery renewal lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(RenewOutcome::Renewed))
+            }
+            .boxed()
+        })
+        .await;
+    match attempted {
+        Err(PortError::Adapter(Error::CommitOutcomeUnknown)) => {
+            let expected = DeliveryStatus::Leased { token, expires_at };
+            if prove_status(readers, engine, intent_id, &expected).await? {
+                Ok(RenewOutcome::Renewed)
+            } else {
+                Err(PortError::Adapter(Error::CommitOutcomeUnknown))
+            }
+        }
+        result => result,
+    }
+}
+
+pub async fn succeed(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    token: DeliveryLeaseToken,
+    provider_message_id: ProviderMessageId,
+    succeeded_at: DateTime<Utc>,
+) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+    let provider_text = mapping::provider_message_id(&provider_message_id)
+        .map_err(PortError::Adapter)?
+        .to_owned();
+    let expected = DeliveryStatus::Succeeded {
+        provider_message_id: provider_message_id.clone(),
+        succeeded_at,
+    };
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let Some(status) = state_in(transaction, intent_id).await? else {
+                    return Ok(TransactionDecision::Rollback(
+                        DeliveryCompletionOutcome::Fenced,
+                    ));
+                };
+                let mut state = DeliveryState::reconstruct(intent_id, status);
+                let outcome = state.succeed(token, provider_message_id, succeeded_at);
+                if outcome != DeliveryCompletionOutcome::Applied {
+                    return Ok(TransactionDecision::Rollback(outcome));
+                }
+                let affected = transaction
+                    .execute(
+                        domain_sql::UPDATE_DELIVERY_SUCCEEDED,
+                        params![
+                            mapping::id(intent_id),
+                            mapping::lease_token(token),
+                            provider_text,
+                            mapping::timestamp(&succeeded_at)
+                        ],
+                    )
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "delivery success lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(
+                    DeliveryCompletionOutcome::Applied,
+                ))
+            }
+            .boxed()
+        })
+        .await;
+    resolve_completion(attempted, readers, engine, intent_id, &expected).await
+}
+
+pub async fn fail_retryable(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    token: DeliveryLeaseToken,
+    failure: (u32, BoundedDeliveryText, DateTime<Utc>),
+) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+    let (attempt, error, next_retry_at) = failure;
+    let error_text = mapping::delivery_text(&error)
+        .map_err(PortError::Adapter)?
+        .to_owned();
+    let expected = DeliveryStatus::Retryable {
+        attempt,
+        error: error.clone(),
+        next_retry_at,
+    };
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let Some(status) = state_in(transaction, intent_id).await? else {
+                    return Ok(TransactionDecision::Rollback(
+                        DeliveryCompletionOutcome::Fenced,
+                    ));
+                };
+                let mut state = DeliveryState::reconstruct(intent_id, status);
+                let outcome = state.fail_retryable(token, attempt, error, next_retry_at);
+                if outcome != DeliveryCompletionOutcome::Applied {
+                    return Ok(TransactionDecision::Rollback(outcome));
+                }
+                let affected = transaction
+                    .execute(
+                        domain_sql::UPDATE_DELIVERY_RETRYABLE,
+                        params![
+                            mapping::id(intent_id),
+                            mapping::lease_token(token),
+                            i64::from(attempt),
+                            error_text,
+                            mapping::timestamp(&next_retry_at)
+                        ],
+                    )
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "retryable delivery failure lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(
+                    DeliveryCompletionOutcome::Applied,
+                ))
+            }
+            .boxed()
+        })
+        .await;
+    resolve_completion(attempted, readers, engine, intent_id, &expected).await
+}
+
+pub async fn fail_terminal(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    token: DeliveryLeaseToken,
+    failure: (u32, BoundedDeliveryText, DateTime<Utc>),
+) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+    let (attempt, error, failed_at) = failure;
+    let error_text = mapping::delivery_text(&error)
+        .map_err(PortError::Adapter)?
+        .to_owned();
+    let expected = DeliveryStatus::TerminalFailure {
+        attempt,
+        error: error.clone(),
+        failed_at,
+    };
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let Some(status) = state_in(transaction, intent_id).await? else {
+                    return Ok(TransactionDecision::Rollback(
+                        DeliveryCompletionOutcome::Fenced,
+                    ));
+                };
+                let mut state = DeliveryState::reconstruct(intent_id, status);
+                let outcome = state.fail_terminal(token, attempt, error, failed_at);
+                if outcome != DeliveryCompletionOutcome::Applied {
+                    return Ok(TransactionDecision::Rollback(outcome));
+                }
+                let affected = transaction
+                    .execute(
+                        domain_sql::UPDATE_DELIVERY_TERMINAL_FAILURE,
+                        params![
+                            mapping::id(intent_id),
+                            mapping::lease_token(token),
+                            i64::from(attempt),
+                            error_text,
+                            mapping::timestamp(&failed_at)
+                        ],
+                    )
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "terminal delivery failure lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(
+                    DeliveryCompletionOutcome::Applied,
+                ))
+            }
+            .boxed()
+        })
+        .await;
+    resolve_completion(attempted, readers, engine, intent_id, &expected).await
+}
+
+pub async fn skip(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    token: DeliveryLeaseToken,
+    reason: BoundedDeliveryText,
+    skipped_at: DateTime<Utc>,
+) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+    let reason_text = mapping::delivery_text(&reason)
+        .map_err(PortError::Adapter)?
+        .to_owned();
+    let expected = DeliveryStatus::Skipped {
+        reason: reason.clone(),
+        skipped_at,
+    };
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let Some(status) = state_in(transaction, intent_id).await? else {
+                    return Ok(TransactionDecision::Rollback(
+                        DeliveryCompletionOutcome::Fenced,
+                    ));
+                };
+                let mut state = DeliveryState::reconstruct(intent_id, status);
+                let outcome = state.skip(token, reason, skipped_at);
+                if outcome != DeliveryCompletionOutcome::Applied {
+                    return Ok(TransactionDecision::Rollback(outcome));
+                }
+                let affected = transaction
+                    .execute(
+                        domain_sql::UPDATE_DELIVERY_SKIPPED,
+                        params![
+                            mapping::id(intent_id),
+                            mapping::lease_token(token),
+                            reason_text,
+                            mapping::timestamp(&skipped_at)
+                        ],
+                    )
+                    .await
+                    .map_err(Error::from)
+                    .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "delivery skip lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(
+                    DeliveryCompletionOutcome::Applied,
+                ))
+            }
+            .boxed()
+        })
+        .await;
+    resolve_completion(attempted, readers, engine, intent_id, &expected).await
+}
+
+async fn resolve_completion(
+    attempted: Result<DeliveryCompletionOutcome, PortError<Error>>,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    intent_id: OutboxIntentId,
+    expected: &DeliveryStatus,
+) -> Result<DeliveryCompletionOutcome, PortError<Error>> {
+    match attempted {
+        Err(PortError::Adapter(Error::CommitOutcomeUnknown)) => {
+            if prove_status(readers, engine, intent_id, expected).await? {
+                Ok(DeliveryCompletionOutcome::Applied)
+            } else {
+                Err(PortError::Adapter(Error::CommitOutcomeUnknown))
+            }
+        }
+        result => result,
+    }
+}
+
+pub async fn advance_checkpoint(
+    writer: &Writer,
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    advance: CheckpointAdvance,
+) -> Result<CheckpointAdvanceOutcome, PortError<Error>> {
+    let worker = mapping::delivery_text(advance.worker())
+        .map_err(PortError::Adapter)?
+        .to_owned();
+    let terminal_intent_id = advance.terminal_intent_id();
+    let expected = advance.expected();
+    let next = advance.next();
+    let worker_for_write = worker.clone();
+    let attempted = writer
+        .with_immediate(engine, move |transaction| {
+            async move {
+                let terminal = state_in(transaction, terminal_intent_id)
+                    .await?
+                    .is_some_and(|status| status.is_terminal());
+                if !terminal {
+                    return Ok(TransactionDecision::Rollback(
+                        CheckpointAdvanceOutcome::TerminalStateRequired,
+                    ));
+                }
+                let current = checkpoint_in(transaction, &worker_for_write).await?;
+                if current == Some(next) {
+                    return Ok(TransactionDecision::Rollback(
+                        CheckpointAdvanceOutcome::Repeated,
+                    ));
+                }
+                if current != expected {
+                    return Ok(TransactionDecision::Rollback(
+                        CheckpointAdvanceOutcome::Conflict,
+                    ));
+                }
+                let affected = match expected {
+                    None => {
+                        transaction
+                            .execute(
+                                domain_sql::INSERT_DELIVERY_CHECKPOINT,
+                                params![worker_for_write, mapping::checkpoint_cursor(next)],
+                            )
+                            .await
+                    }
+                    Some(expected) => {
+                        transaction
+                            .execute(
+                                domain_sql::UPDATE_DELIVERY_CHECKPOINT,
+                                params![
+                                    worker_for_write,
+                                    mapping::checkpoint_cursor(expected),
+                                    mapping::checkpoint_cursor(next)
+                                ],
+                            )
+                            .await
+                    }
+                }
+                .map_err(Error::from)
+                .map_err(PortError::Adapter)?;
+                if affected != 1 {
+                    return Err(PortError::Adapter(Error::InvariantViolation(
+                        "checkpoint compare-and-swap lost authority",
+                    )));
+                }
+                Ok(TransactionDecision::Commit(
+                    CheckpointAdvanceOutcome::Advanced,
+                ))
+            }
+            .boxed()
+        })
+        .await;
+    match attempted {
+        Err(PortError::Adapter(Error::CommitOutcomeUnknown)) => {
+            let cursor = delivery_reader::checkpoint_cursor(readers, engine, worker)
+                .await
+                .map_err(PortError::Adapter)?;
+            let terminal = delivery_reader::status(readers, engine, terminal_intent_id)
+                .await
+                .map_err(PortError::Adapter)?
+                .is_some_and(|status| status.is_terminal());
+            if cursor == Some(next) && terminal {
+                Ok(CheckpointAdvanceOutcome::Advanced)
+            } else {
+                Err(PortError::Adapter(Error::CommitOutcomeUnknown))
+            }
+        }
+        result => result,
+    }
+}

--- a/crates/attention/turso/src/domain_sql.rs
+++ b/crates/attention/turso/src/domain_sql.rs
@@ -67,6 +67,9 @@ pub const UPSERT_FIRE: &str = "INSERT INTO reminder_fires (id, reminder_id, ordi
     state) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(id) DO UPDATE SET \
     ordinal = excluded.ordinal, trigger_at = excluded.trigger_at, state = excluded.state \
     WHERE reminder_fires.reminder_id = excluded.reminder_id";
+pub const SELECT_DUE_REMINDER_FIRE_CANDIDATES: &str = "SELECT f.id, f.reminder_id, r.revision, \
+    f.trigger_at FROM reminder_fires AS f JOIN reminders AS r ON r.id = f.reminder_id \
+    WHERE f.state = 0";
 
 pub const INSERT_OUTCOME: &str = "INSERT INTO mutation_outcomes (mutation_key, operation, \
     fingerprint, outcome_version, outcome_bytes) VALUES (?1, ?2, ?3, ?4, ?5) \
@@ -79,3 +82,47 @@ pub const SELECT_CHANGES: &str = "SELECT cursor, event_id, occurred_at, kind, pa
     payload_bytes FROM change_events WHERE cursor > ?1 AND cursor <= ?2 ORDER BY cursor LIMIT ?3";
 pub const INSERT_OUTBOX: &str = "INSERT INTO outbox_intents (id, deduplication_key, subject_kind, \
     subject_id, originating_event_id, created_at, purpose) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+pub const INSERT_DELIVERY_PENDING: &str =
+    "INSERT INTO delivery_states (intent_id, status) VALUES (?1, 0)";
+
+pub const SELECT_DELIVERY_AUTHORITY: &str = "SELECT o.id, o.deduplication_key, o.subject_kind, \
+    o.subject_id, o.originating_event_id, o.created_at, o.purpose, d.status, d.lease_token, \
+    d.lease_expires_at, d.attempt, d.error, d.next_retry_at, d.provider_message_id, d.succeeded_at, \
+    d.reason, d.skipped_at, d.failed_at FROM outbox_intents AS o JOIN delivery_states AS d \
+    ON d.intent_id = o.id WHERE o.id = ?1";
+pub const SELECT_DELIVERY_CANDIDATES: &str = "SELECT o.id, o.created_at, d.status, d.lease_token, \
+    d.lease_expires_at, d.attempt, d.error, d.next_retry_at, d.provider_message_id, d.succeeded_at, \
+    d.reason, d.skipped_at, d.failed_at FROM outbox_intents AS o JOIN delivery_states AS d \
+    ON d.intent_id = o.id WHERE d.status IN (0, 1, 2)";
+pub const SELECT_DELIVERY_STATE: &str = "SELECT status, lease_token, lease_expires_at, attempt, \
+    error, next_retry_at, provider_message_id, succeeded_at, reason, skipped_at, failed_at \
+    FROM delivery_states WHERE intent_id = ?1";
+pub const UPDATE_DELIVERY_LEASED: &str = "UPDATE delivery_states SET status = 1, lease_token = ?2, \
+    lease_expires_at = ?3, attempt = NULL, error = NULL, next_retry_at = NULL, \
+    provider_message_id = NULL, succeeded_at = NULL, reason = NULL, skipped_at = NULL, \
+    failed_at = NULL WHERE intent_id = ?1 AND status IN (0, 1, 2)";
+pub const UPDATE_DELIVERY_RENEWED: &str = "UPDATE delivery_states SET lease_expires_at = ?3 \
+    WHERE intent_id = ?1 AND status = 1 AND lease_token = ?2";
+pub const UPDATE_DELIVERY_SUCCEEDED: &str = "UPDATE delivery_states SET status = 3, \
+    lease_token = NULL, lease_expires_at = NULL, attempt = NULL, error = NULL, \
+    next_retry_at = NULL, provider_message_id = ?3, succeeded_at = ?4, reason = NULL, \
+    skipped_at = NULL, failed_at = NULL WHERE intent_id = ?1 AND status = 1 AND lease_token = ?2";
+pub const UPDATE_DELIVERY_RETRYABLE: &str = "UPDATE delivery_states SET status = 2, \
+    lease_token = NULL, lease_expires_at = NULL, attempt = ?3, error = ?4, next_retry_at = ?5, \
+    provider_message_id = NULL, succeeded_at = NULL, reason = NULL, skipped_at = NULL, \
+    failed_at = NULL WHERE intent_id = ?1 AND status = 1 AND lease_token = ?2";
+pub const UPDATE_DELIVERY_TERMINAL_FAILURE: &str = "UPDATE delivery_states SET status = 5, \
+    lease_token = NULL, lease_expires_at = NULL, attempt = ?3, error = ?4, next_retry_at = NULL, \
+    provider_message_id = NULL, succeeded_at = NULL, reason = NULL, skipped_at = NULL, \
+    failed_at = ?5 WHERE intent_id = ?1 AND status = 1 AND lease_token = ?2";
+pub const UPDATE_DELIVERY_SKIPPED: &str = "UPDATE delivery_states SET status = 4, \
+    lease_token = NULL, lease_expires_at = NULL, attempt = NULL, error = NULL, \
+    next_retry_at = NULL, provider_message_id = NULL, succeeded_at = NULL, reason = ?3, \
+    skipped_at = ?4, failed_at = NULL WHERE intent_id = ?1 AND status = 1 AND lease_token = ?2";
+
+pub const SELECT_DELIVERY_CHECKPOINT: &str =
+    "SELECT worker, cursor FROM delivery_checkpoints WHERE worker = ?1";
+pub const INSERT_DELIVERY_CHECKPOINT: &str = "INSERT INTO delivery_checkpoints (worker, cursor) \
+    VALUES (?1, ?2) ON CONFLICT(worker) DO NOTHING";
+pub const UPDATE_DELIVERY_CHECKPOINT: &str = "UPDATE delivery_checkpoints SET cursor = ?3 \
+    WHERE worker = ?1 AND cursor = ?2";

--- a/crates/attention/turso/src/lib.rs
+++ b/crates/attention/turso/src/lib.rs
@@ -13,6 +13,8 @@ mod codec;
 mod config;
 mod database;
 mod decode;
+mod delivery_reader;
+mod delivery_writer;
 mod domain_sql;
 mod error;
 mod lifecycle;
@@ -48,3 +50,6 @@ pub const PINNED_TURSO_VERSION: &str = "0.8.0-pre.1";
 
 /// Operational WAL/file-set threshold selected from retained qualification workloads.
 pub const WAL_OPERATIONAL_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Adapter-enforced UTF-8 byte ceiling for persisted delivery diagnostics and identities.
+pub const DELIVERY_TEXT_LIMIT_BYTES: usize = 64 * 1024;

--- a/crates/attention/turso/src/mapping.rs
+++ b/crates/attention/turso/src/mapping.rs
@@ -1,13 +1,27 @@
 use crate::Error;
 use attention_kernel::AttentionSignal;
+use attention_kernel::BoundedDeliveryText;
 use attention_kernel::CanonicalFingerprint;
+use attention_kernel::ChangeEventId;
 use attention_kernel::ChangeKind;
+use attention_kernel::CommitCursor;
+use attention_kernel::DeliveryAuthority;
+use attention_kernel::DeliveryCheckpoint;
+use attention_kernel::DeliveryLeaseToken;
+use attention_kernel::DeliveryPurpose;
+use attention_kernel::DeliveryState;
+use attention_kernel::DeliveryStatus;
+use attention_kernel::DeliverySubject;
 use attention_kernel::ExternalEntityId;
 use attention_kernel::InvariantError;
 use attention_kernel::MutationOperation;
 use attention_kernel::NormalizedSourceOrder;
 use attention_kernel::OccurrenceId;
 use attention_kernel::OccurrenceKey;
+use attention_kernel::OutboxDeduplicationKey;
+use attention_kernel::OutboxIntent;
+use attention_kernel::OutboxIntentId;
+use attention_kernel::ProviderMessageId;
 use attention_kernel::Reminder;
 use attention_kernel::ReminderFire;
 use attention_kernel::ReminderFireId;
@@ -82,6 +96,58 @@ pub fn parse_timestamp(value: &str) -> Result<DateTime<Utc>, Error> {
         return Err(invalid("timestamp is noncanonical"));
     }
     Ok(parsed)
+}
+
+pub fn delivery_text(value: &BoundedDeliveryText) -> Result<&str, Error> {
+    bounded_write_text(value.as_str())
+}
+
+pub fn provider_message_id(value: &ProviderMessageId) -> Result<&str, Error> {
+    bounded_write_text(value.as_str())
+}
+
+fn bounded_write_text(value: &str) -> Result<&str, Error> {
+    if value.len() > crate::DELIVERY_TEXT_LIMIT_BYTES {
+        return Err(Error::InvariantViolation(
+            "delivery text exceeds adapter byte limit",
+        ));
+    }
+    Ok(value)
+}
+
+fn parse_delivery_text(value: String) -> Result<BoundedDeliveryText, Error> {
+    if value.len() > crate::DELIVERY_TEXT_LIMIT_BYTES {
+        return Err(invalid("delivery text exceeds adapter byte limit"));
+    }
+    BoundedDeliveryText::new(value, crate::DELIVERY_TEXT_LIMIT_BYTES)
+        .map_err(|error| Error::Decode(Box::new(error)))
+}
+
+fn parse_provider_message_id(value: String) -> Result<ProviderMessageId, Error> {
+    if value.len() > crate::DELIVERY_TEXT_LIMIT_BYTES {
+        return Err(invalid("provider message ID exceeds adapter byte limit"));
+    }
+    ProviderMessageId::new(value, crate::DELIVERY_TEXT_LIMIT_BYTES)
+        .map_err(|error| Error::Decode(Box::new(error)))
+}
+
+pub fn lease_token(value: DeliveryLeaseToken) -> Vec<u8> {
+    value.as_bytes().to_vec()
+}
+
+pub fn parse_lease_token(value: &[u8]) -> Result<DeliveryLeaseToken, Error> {
+    let bytes = value
+        .try_into()
+        .map_err(|_| invalid("delivery lease token width is not thirty-two"))?;
+    Ok(DeliveryLeaseToken::from_bytes(bytes))
+}
+
+pub fn checkpoint_cursor(value: CommitCursor) -> Vec<u8> {
+    counter(value.value())
+}
+
+pub fn parse_checkpoint_cursor(value: &[u8]) -> Result<CommitCursor, Error> {
+    CommitCursor::try_from(parse_counter(value)?).map_err(|error| Error::Decode(Box::new(error)))
 }
 
 pub fn fingerprint(value: CanonicalFingerprint) -> Vec<u8> {
@@ -216,6 +282,16 @@ pub fn parse_source_order(
 }
 
 fn optional_text(row: &Row, index: usize) -> Result<Option<String>, Error> {
+    row.get(index)
+        .map_err(|error| Error::Decode(Box::new(error)))
+}
+
+fn optional_blob(row: &Row, index: usize) -> Result<Option<Vec<u8>>, Error> {
+    row.get(index)
+        .map_err(|error| Error::Decode(Box::new(error)))
+}
+
+fn optional_integer(row: &Row, index: usize) -> Result<Option<i64>, Error> {
     row.get(index)
         .map_err(|error| Error::Decode(Box::new(error)))
 }
@@ -421,6 +497,133 @@ pub fn reminder(header: &ReminderHeader, fires: Vec<ReminderFire>) -> Result<Rem
     .map_err(|error| Error::Decode(Box::new(error)))
 }
 
+pub fn delivery_status(row: &Row, index: usize) -> Result<DeliveryStatus, Error> {
+    let status = integer(row, index)?;
+    let token = optional_blob(row, index + 1)?;
+    let lease_expires_at = optional_text(row, index + 2)?;
+    let attempt = optional_integer(row, index + 3)?;
+    let error = optional_text(row, index + 4)?;
+    let next_retry_at = optional_text(row, index + 5)?;
+    let provider_id = optional_text(row, index + 6)?;
+    let succeeded_at = optional_text(row, index + 7)?;
+    let reason = optional_text(row, index + 8)?;
+    let skipped_at = optional_text(row, index + 9)?;
+    let failed_at = optional_text(row, index + 10)?;
+    match (
+        status,
+        token,
+        lease_expires_at,
+        attempt,
+        error,
+        next_retry_at,
+        provider_id,
+        succeeded_at,
+        reason,
+        skipped_at,
+        failed_at,
+    ) {
+        (0, None, None, None, None, None, None, None, None, None, None) => {
+            Ok(DeliveryStatus::Pending)
+        }
+        (1, Some(token), Some(expires_at), None, None, None, None, None, None, None, None) => {
+            Ok(DeliveryStatus::Leased {
+                token: parse_lease_token(&token)?,
+                expires_at: parse_timestamp(&expires_at)?,
+            })
+        }
+        (
+            2,
+            None,
+            None,
+            Some(attempt),
+            Some(error),
+            Some(next_retry_at),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ) => Ok(DeliveryStatus::Retryable {
+            attempt: u32::try_from(attempt)
+                .map_err(|_| invalid("delivery attempt is outside the u32 range"))?,
+            error: parse_delivery_text(error)?,
+            next_retry_at: parse_timestamp(&next_retry_at)?,
+        }),
+        (
+            3,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(provider_id),
+            Some(succeeded_at),
+            None,
+            None,
+            None,
+        ) => Ok(DeliveryStatus::Succeeded {
+            provider_message_id: parse_provider_message_id(provider_id)?,
+            succeeded_at: parse_timestamp(&succeeded_at)?,
+        }),
+        (4, None, None, None, None, None, None, None, Some(reason), Some(skipped_at), None) => {
+            Ok(DeliveryStatus::Skipped {
+                reason: parse_delivery_text(reason)?,
+                skipped_at: parse_timestamp(&skipped_at)?,
+            })
+        }
+        (
+            5,
+            None,
+            None,
+            Some(attempt),
+            Some(error),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(failed_at),
+        ) => Ok(DeliveryStatus::TerminalFailure {
+            attempt: u32::try_from(attempt)
+                .map_err(|_| invalid("delivery attempt is outside the u32 range"))?,
+            error: parse_delivery_text(error)?,
+            failed_at: parse_timestamp(&failed_at)?,
+        }),
+        _ => Err(invalid("delivery state columns are inconsistent")),
+    }
+}
+
+pub fn delivery_authority(row: &Row) -> Result<DeliveryAuthority, Error> {
+    let intent_id: OutboxIntentId = parse_id(&text(row, 0)?)?;
+    let subject = match integer(row, 2)? {
+        0 => DeliverySubject::AttentionSignal(parse_id(&text(row, 3)?)?),
+        1 => DeliverySubject::ReminderFire(parse_id(&text(row, 3)?)?),
+        _ => return Err(invalid("delivery subject kind is unknown")),
+    };
+    let purpose = match integer(row, 6)? {
+        0 => DeliveryPurpose::FreshAttention,
+        1 => DeliveryPurpose::ReminderFired,
+        _ => return Err(invalid("delivery purpose is unknown")),
+    };
+    let intent = OutboxIntent::new(
+        intent_id,
+        OutboxDeduplicationKey::new(text(row, 1)?, crate::DELIVERY_TEXT_LIMIT_BYTES)
+            .map_err(|error| Error::Decode(Box::new(error)))?,
+        subject,
+        parse_id::<ChangeEventId>(&text(row, 4)?)?,
+        parse_timestamp(&text(row, 5)?)?,
+        purpose,
+    );
+    let state = DeliveryState::reconstruct(intent_id, delivery_status(row, 7)?);
+    Ok(DeliveryAuthority::new(intent, state))
+}
+
+pub fn delivery_checkpoint(row: &Row) -> Result<DeliveryCheckpoint, Error> {
+    let worker = parse_delivery_text(text(row, 0)?)?;
+    let cursor = parse_checkpoint_cursor(&blob(row, 1)?)?;
+    Ok(DeliveryCheckpoint::new(worker, cursor))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -447,5 +650,34 @@ mod tests {
         assert!(parse_source_order(0, Some("sequence".to_string()), None).is_err());
         assert!(parse_source_order(1, None, None).is_err());
         assert!(parse_source_order(1, Some("sequence".to_string()), Some(Vec::new())).is_err());
+    }
+
+    #[test]
+    fn delivery_token_cursor_and_text_bounds_are_strict_and_non_leaking() {
+        let token = DeliveryLeaseToken::from_bytes([0xA5; 32]);
+        assert_eq!(
+            parse_lease_token(&lease_token(token)).expect("token"),
+            token
+        );
+        let token_error = parse_lease_token(&[0xA5; 31]).expect_err("short token must fail");
+        assert!(!token_error.to_string().contains("A5"));
+
+        let cursor = CommitCursor::try_from(u64::MAX).expect("nonzero cursor");
+        assert_eq!(
+            parse_checkpoint_cursor(&checkpoint_cursor(cursor)).expect("cursor"),
+            cursor
+        );
+        assert!(parse_checkpoint_cursor(&[0; 7]).is_err());
+
+        let oversized_value = "secret".repeat(crate::DELIVERY_TEXT_LIMIT_BYTES / 6 + 1);
+        let oversized = BoundedDeliveryText::new(
+            oversized_value.clone(),
+            crate::DELIVERY_TEXT_LIMIT_BYTES * 2,
+        )
+        .expect("kernel bound permits fixture");
+        let error = delivery_text(&oversized).expect_err("adapter bound must reject fixture");
+        let diagnostic = error.to_string();
+        assert!(!diagnostic.contains(&oversized_value));
+        assert!(!diagnostic.contains("secret"));
     }
 }

--- a/crates/attention/turso/src/migration.rs
+++ b/crates/attention/turso/src/migration.rs
@@ -7,7 +7,7 @@ use turso_db::Connection;
 use turso_db::params;
 use turso_db::transaction::TransactionBehavior;
 
-pub const MIGRATION_HEAD: u64 = 2;
+pub const MIGRATION_HEAD: u64 = 3;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Migration {
@@ -44,6 +44,11 @@ pub const MIGRATIONS: &[Migration] = &[
         2,
         "attention_core",
         include_bytes!("../migrations/0002_attention_core.sql"),
+    ),
+    Migration::new(
+        3,
+        "durable_delivery",
+        include_bytes!("../migrations/0003_durable_delivery.sql"),
     ),
 ];
 
@@ -176,7 +181,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn injected_failures_preserve_head_one_to_head_two_atomicity() -> Result<(), Error> {
+    async fn injected_failures_preserve_head_one_upgrade_atomicity() -> Result<(), Error> {
         for failpoint in [
             Failpoint::AfterBody,
             Failpoint::AfterLedger,
@@ -222,6 +227,57 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn injected_failures_preserve_head_two_to_head_three_atomicity() -> Result<(), Error> {
+        for failpoint in [
+            Failpoint::AfterBody,
+            Failpoint::AfterLedger,
+            Failpoint::BeforeCommit,
+            Failpoint::AfterCommit,
+        ] {
+            let root = tempfile::tempdir().map_err(Error::Io)?;
+            let path = root.path().join("migration.db");
+            let path = path
+                .to_str()
+                .ok_or(Error::MigrationIntegrity("test path is not UTF-8"))?;
+            let database = Builder::new_local(path).build().await?;
+            let mut connection = database.connect()?;
+            for migration in &MIGRATIONS[..2] {
+                connection
+                    .execute_batch(
+                        std::str::from_utf8(migration.sql)
+                            .map_err(|_| Error::MigrationIntegrity("migration SQL is not UTF-8"))?,
+                    )
+                    .await?;
+                connection
+                    .execute(
+                        "INSERT INTO __attention_migrations (version, name, checksum) VALUES (?1, ?2, ?3)",
+                        params![
+                            i64::try_from(migration.version).map_err(|_| {
+                                Error::MigrationIntegrity("migration version exceeds SQLite integer")
+                            })?,
+                            migration.name,
+                            migration.checksum().to_vec()
+                        ],
+                    )
+                    .await?;
+            }
+
+            assert!(
+                run_with_failpoint(&mut connection, failpoint)
+                    .await
+                    .is_err()
+            );
+            let applied = preflight(&connection).await?;
+            let expected = 2 + usize::from(failpoint == Failpoint::AfterCommit);
+            assert_eq!(applied.len(), expected);
+            let report = run(&mut connection).await?;
+            assert_eq!(report.applied(), MIGRATIONS.len() - expected);
+            assert_eq!(preflight(&connection).await?.len(), MIGRATIONS.len());
+        }
+        Ok(())
+    }
+
     #[test]
     fn migration_sql_remains_foundation_only() {
         let sql = std::str::from_utf8(MIGRATIONS[0].sql).expect("migration SQL is UTF-8");
@@ -250,6 +306,9 @@ mod tests {
         ] {
             assert!(!core.to_ascii_lowercase().contains(excluded));
         }
+        let delivery = std::str::from_utf8(MIGRATIONS[2].sql).expect("migration SQL is UTF-8");
+        assert!(delivery.contains("CREATE TABLE delivery_states"));
+        assert!(delivery.contains("CREATE TABLE delivery_checkpoints"));
     }
 }
 

--- a/crates/attention/turso/src/semantic_reader.rs
+++ b/crates/attention/turso/src/semantic_reader.rs
@@ -13,6 +13,8 @@ use attention_kernel::ChangePage;
 use attention_kernel::ChangesAfterQuery;
 use attention_kernel::ChangesResult;
 use attention_kernel::CommitCursor;
+use attention_kernel::DueReminderFire;
+use attention_kernel::DueReminderFiresQuery;
 use attention_kernel::MutationIdempotencyKey;
 use attention_kernel::MutationOperation;
 use attention_kernel::OccurrenceKey;
@@ -128,6 +130,42 @@ pub async fn reminder(
     readers
         .with_snapshot(engine, move |transaction| {
             reminder_in(transaction, id).boxed()
+        })
+        .await
+}
+
+pub async fn due_reminder_fires(
+    readers: &ReaderPool,
+    engine: &Mutex<Option<Database>>,
+    query: DueReminderFiresQuery,
+) -> Result<Vec<DueReminderFire>, Error> {
+    readers
+        .with_snapshot(engine, move |transaction| {
+            async move {
+                let mut rows = transaction
+                    .query(domain_sql::SELECT_DUE_REMINDER_FIRE_CANDIDATES, ())
+                    .await?;
+                let mut due = Vec::new();
+                while let Some(row) = rows.next().await? {
+                    let trigger_at = mapping::parse_timestamp(&decode::text(&row, 3)?)?;
+                    if trigger_at <= *query.due_at_or_before() {
+                        due.push(DueReminderFire::new(
+                            mapping::parse_id(&decode::text(&row, 1)?)?,
+                            mapping::parse_id(&decode::text(&row, 0)?)?,
+                            attention_kernel::Revision::try_from(mapping::parse_counter(
+                                &decode::blob(&row, 2)?,
+                            )?)
+                            .map_err(|error| Error::Decode(Box::new(error)))?,
+                            trigger_at,
+                        ));
+                    }
+                }
+                drop(rows);
+                due.sort_by_key(|fire| (*fire.trigger_at(), fire.fire_id(), fire.reminder_id()));
+                due.truncate(query.limit().value());
+                Ok(due)
+            }
+            .boxed()
         })
         .await
 }

--- a/crates/attention/turso/src/semantic_writer.rs
+++ b/crates/attention/turso/src/semantic_writer.rs
@@ -208,6 +208,14 @@ async fn finish(
             .await
             .map_err(Error::from)
             .map_err(PortError::Adapter)?;
+        transaction
+            .execute(
+                domain_sql::INSERT_DELIVERY_PENDING,
+                params![mapping::id(intent.id())],
+            )
+            .await
+            .map_err(Error::from)
+            .map_err(PortError::Adapter)?;
     }
     let affected = transaction
         .execute(

--- a/crates/attention/turso/src/store.rs
+++ b/crates/attention/turso/src/store.rs
@@ -8,25 +8,43 @@ use attention_kernel::AttentionCommitPort;
 use attention_kernel::AttentionReadPort;
 use attention_kernel::AttentionSignal;
 use attention_kernel::AttentionSignalId;
+use attention_kernel::BoundedDeliveryText;
 use attention_kernel::CancelWorkItemBundle;
 use attention_kernel::CancelWorkItemResult;
 use attention_kernel::ChangesAfterQuery;
 use attention_kernel::ChangesAfterResult;
+use attention_kernel::CheckpointAdvance;
+use attention_kernel::CheckpointAdvanceOutcome;
+use attention_kernel::CheckpointQuery;
 use attention_kernel::CompleteWorkItemBundle;
 use attention_kernel::CompleteWorkItemResult;
 use attention_kernel::CreateReminderBundle;
 use attention_kernel::CreateReminderResult;
 use attention_kernel::CreateWorkItemBundle;
 use attention_kernel::CreateWorkItemResult;
+use attention_kernel::DeliveryAuthority;
+use attention_kernel::DeliveryCheckpoint;
+use attention_kernel::DeliveryCheckpointPort;
+use attention_kernel::DeliveryClaim;
+use attention_kernel::DeliveryClaimQuery;
+use attention_kernel::DeliveryCompletionOutcome;
+use attention_kernel::DeliveryLeaseToken;
+use attention_kernel::DeliveryPort;
+use attention_kernel::DueReminderFire;
+use attention_kernel::DueReminderFiresQuery;
 use attention_kernel::FireReminderBundle;
 use attention_kernel::FireReminderResult;
 use attention_kernel::IngestSourceOccurrenceBundle;
 use attention_kernel::IngestSourceOccurrenceResult;
+use attention_kernel::OutboxIntentId;
 use attention_kernel::PortError;
 use attention_kernel::PriorMutationOutcome;
 use attention_kernel::PriorOutcomeQuery;
+use attention_kernel::ProviderMessageId;
 use attention_kernel::Reminder;
 use attention_kernel::ReminderId;
+use attention_kernel::ReminderSchedulePort;
+use attention_kernel::RenewOutcome;
 use attention_kernel::SnapshotResult;
 use attention_kernel::SnoozeReminderFireBundle;
 use attention_kernel::SnoozeReminderFireResult;
@@ -36,6 +54,8 @@ use attention_kernel::SourceReceipt;
 use attention_kernel::SourceReceiptId;
 use attention_kernel::WorkItem;
 use attention_kernel::WorkItemId;
+use chrono::DateTime;
+use chrono::Utc;
 use futures::future::BoxFuture;
 
 impl AttentionReadPort for AttentionDatabase {
@@ -167,5 +187,127 @@ impl AttentionCommitPort for AttentionDatabase {
         bundle: SnoozeReminderFireBundle,
     ) -> BoxFuture<'_, Result<SnoozeReminderFireResult, PortError<Self::Error>>> {
         Box::pin(async move { self.semantic_snooze_reminder(bundle).await })
+    }
+}
+
+impl ReminderSchedulePort for AttentionDatabase {
+    type Error = Error;
+
+    fn due_reminder_fires(
+        &self,
+        query: DueReminderFiresQuery,
+    ) -> BoxFuture<'_, Result<Vec<DueReminderFire>, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.semantic_due_reminder_fires(query)
+                .await
+                .map_err(PortError::Adapter)
+        })
+    }
+}
+
+impl DeliveryPort for AttentionDatabase {
+    type Error = Error;
+
+    fn claim(
+        &self,
+        query: DeliveryClaimQuery,
+    ) -> BoxFuture<'_, Result<Vec<DeliveryClaim>, PortError<Self::Error>>> {
+        Box::pin(async move { self.delivery_claim(query).await })
+    }
+
+    fn inspect(
+        &self,
+        intent_id: OutboxIntentId,
+    ) -> BoxFuture<'_, Result<Option<DeliveryAuthority>, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_inspect(intent_id)
+                .await
+                .map_err(PortError::Adapter)
+        })
+    }
+
+    fn renew(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        expires_at: DateTime<Utc>,
+    ) -> BoxFuture<'_, Result<RenewOutcome, PortError<Self::Error>>> {
+        Box::pin(async move { self.delivery_renew(intent_id, token, expires_at).await })
+    }
+
+    fn succeed(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        provider_message_id: ProviderMessageId,
+        succeeded_at: DateTime<Utc>,
+    ) -> BoxFuture<'_, Result<DeliveryCompletionOutcome, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_succeed(intent_id, token, provider_message_id, succeeded_at)
+                .await
+        })
+    }
+
+    fn fail_retryable(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        attempt: u32,
+        error: BoundedDeliveryText,
+        next_retry_at: DateTime<Utc>,
+    ) -> BoxFuture<'_, Result<DeliveryCompletionOutcome, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_fail_retryable(intent_id, token, attempt, error, next_retry_at)
+                .await
+        })
+    }
+
+    fn fail_terminal(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        attempt: u32,
+        error: BoundedDeliveryText,
+        failed_at: DateTime<Utc>,
+    ) -> BoxFuture<'_, Result<DeliveryCompletionOutcome, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_fail_terminal(intent_id, token, attempt, error, failed_at)
+                .await
+        })
+    }
+
+    fn skip(
+        &self,
+        intent_id: OutboxIntentId,
+        token: DeliveryLeaseToken,
+        reason: BoundedDeliveryText,
+        skipped_at: DateTime<Utc>,
+    ) -> BoxFuture<'_, Result<DeliveryCompletionOutcome, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_skip(intent_id, token, reason, skipped_at)
+                .await
+        })
+    }
+}
+
+impl DeliveryCheckpointPort for AttentionDatabase {
+    type Error = Error;
+
+    fn checkpoint(
+        &self,
+        query: CheckpointQuery,
+    ) -> BoxFuture<'_, Result<Option<DeliveryCheckpoint>, PortError<Self::Error>>> {
+        Box::pin(async move {
+            self.delivery_checkpoint(query)
+                .await
+                .map_err(PortError::Adapter)
+        })
+    }
+
+    fn advance_checkpoint(
+        &self,
+        advance: CheckpointAdvance,
+    ) -> BoxFuture<'_, Result<CheckpointAdvanceOutcome, PortError<Self::Error>>> {
+        Box::pin(async move { self.delivery_advance_checkpoint(advance).await })
     }
 }

--- a/crates/attention/turso/tests/commit_conformance.rs
+++ b/crates/attention/turso/tests/commit_conformance.rs
@@ -4,6 +4,7 @@ use attention_turso::Config;
 use chrono::DateTime;
 use chrono::Utc;
 use std::error::Error;
+use turso_db::Builder;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 
@@ -26,6 +27,10 @@ async fn database() -> TestResult<(tempfile::TempDir, AttentionDatabase)> {
 }
 
 fn source_command() -> IngestSourceOccurrence {
+    source_command_with_fresh_attention(false)
+}
+
+fn source_command_with_fresh_attention(fresh_attention: bool) -> IngestSourceOccurrence {
     let kind = SourceKind::new("linear")
         .unwrap_or_else(|error| panic!("fixed source kind must be valid: {error}"));
     let instance = SourceInstance::new("workspace")
@@ -59,7 +64,7 @@ fn source_command() -> IngestSourceOccurrence {
             ),
         },
         SignalSourceLifecycle::Active,
-        false,
+        fresh_attention,
         MutationIdempotencyKey::new(),
     )
 }
@@ -471,6 +476,121 @@ async fn duplicate_occurrence_uses_original_outcome_without_storing_new_key() ->
         ))
     ));
     database.close().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn semantic_replay_does_not_duplicate_event_intent_or_pending_authority() -> TestResult {
+    let (root, database) = database().await?;
+    let command = source_command_with_fresh_attention(true);
+    let event_id = ChangeEventId::new();
+    let intent_id = OutboxIntentId::new();
+    let bundle = evaluate_ingest_source_occurrence(
+        &command,
+        None,
+        None,
+        EvaluationContext::new(event_id, Some(intent_id), at(12)),
+    )?;
+    let applied = database
+        .commit_ingest_source_occurrence(bundle.clone())
+        .await?;
+    assert_eq!(applied.outbox_intent_id(), Some(intent_id));
+    assert_eq!(
+        database.commit_ingest_source_occurrence(bundle).await?,
+        applied.replayed()
+    );
+    database.close().await?;
+
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let raw = Builder::new_local(
+        config
+            .database_directory()
+            .database_file()
+            .to_str()
+            .ok_or("database path is not UTF-8")?,
+    )
+    .build()
+    .await?;
+    let connection = raw.connect()?;
+    for (table, expected) in [
+        ("change_events", 1_i64),
+        ("outbox_intents", 1),
+        ("delivery_states", 1),
+    ] {
+        let mut rows = connection
+            .query(&format!("SELECT count(*) FROM {table}"), ())
+            .await?;
+        assert_eq!(
+            rows.next()
+                .await?
+                .ok_or("table count missing")?
+                .get::<i64>(0)?,
+            expected,
+            "table {table}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn reminder_fired_some_and_none_outbox_paths_create_authority_conditionally() -> TestResult {
+    let (root, database) = database().await?;
+    for with_outbox in [true, false] {
+        let reminder_id = ReminderId::new();
+        let fire_id = ReminderFireId::new();
+        database
+            .commit_create_reminder(evaluate_create_reminder(
+                &CreateReminder::new(
+                    reminder_id,
+                    fire_id,
+                    ReminderTarget::WorkItem(WorkItemId::new()),
+                    at(14),
+                    MutationIdempotencyKey::new(),
+                ),
+                context(),
+            ))
+            .await?;
+        let reminder = database
+            .reminder(reminder_id)
+            .await?
+            .ok_or("created reminder missing")?;
+        let expected_intent = with_outbox.then(OutboxIntentId::new);
+        let outcome = database
+            .commit_fire_reminder(evaluate_fire_reminder(
+                &FireReminder::new(reminder_id, fire_id, MutationIdempotencyKey::new()),
+                &reminder,
+                EvaluationContext::new(ChangeEventId::new(), expected_intent, at(14)),
+            )?)
+            .await?;
+        assert_eq!(outcome.outbox_intent_id(), expected_intent);
+    }
+    database.close().await?;
+
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let raw = Builder::new_local(
+        config
+            .database_directory()
+            .database_file()
+            .to_str()
+            .ok_or("database path is not UTF-8")?,
+    )
+    .build()
+    .await?;
+    let connection = raw.connect()?;
+    let mut rows = connection
+        .query(
+            "SELECT
+                 (SELECT count(*) FROM outbox_intents),
+                 (SELECT count(*) FROM delivery_states),
+                 (SELECT count(*) FROM outbox_intents AS o LEFT JOIN delivery_states AS d
+                    ON d.intent_id = o.id WHERE d.intent_id IS NULL)",
+            (),
+        )
+        .await?;
+    let row = rows.next().await?.ok_or("inventory count missing")?;
+    assert_eq!(row.get::<i64>(0)?, 1);
+    assert_eq!(row.get::<i64>(1)?, 1);
+    assert_eq!(row.get::<i64>(2)?, 0);
     Ok(())
 }
 

--- a/crates/attention/turso/tests/delivery_checkpoint_port.rs
+++ b/crates/attention/turso/tests/delivery_checkpoint_port.rs
@@ -1,0 +1,203 @@
+use attention_kernel::*;
+use attention_turso::AttentionDatabase;
+use attention_turso::Config;
+use chrono::DateTime;
+use chrono::Utc;
+use std::error::Error;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+fn at(value: &str) -> TestResult<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
+}
+
+async fn pending(database: &AttentionDatabase, sequence: usize) -> TestResult<OutboxIntentId> {
+    let time = at("2026-08-03T12:00:00Z")?;
+    let intent_id = OutboxIntentId::new();
+    let command = IngestSourceOccurrence::new(
+        SourceReceiptId::new(),
+        None,
+        AttentionSignalId::new(),
+        OccurrenceKey::new(
+            SourceKind::new("checkpoint-test")?,
+            SourceInstance::new(format!("worker-{sequence}"))?,
+            OccurrenceId::new(format!("occurrence-{sequence}"))?,
+        ),
+        time,
+        time,
+        SourceOrderMode::Unordered,
+        SignalSourceLifecycle::Active,
+        true,
+        MutationIdempotencyKey::new(),
+    );
+    database
+        .commit_ingest_source_occurrence(evaluate_ingest_source_occurrence(
+            &command,
+            None,
+            None,
+            EvaluationContext::new(ChangeEventId::new(), Some(intent_id), time),
+        )?)
+        .await?;
+    Ok(intent_id)
+}
+
+#[tokio::test]
+async fn checkpoint_cas_terminal_gate_precedence_lower_cursor_and_restart() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let database = AttentionDatabase::open(config).await?;
+    database.run_startup_migrations().await?;
+    let ids = [
+        pending(&database, 1).await?,
+        pending(&database, 2).await?,
+        pending(&database, 3).await?,
+        pending(&database, 4).await?,
+    ];
+    let before = database.snapshot().await?.cursor();
+    let lease_at = at("2026-08-03T12:01:00Z")?;
+    let claims = database
+        .claim(DeliveryClaimQuery::new(
+            lease_at,
+            at("2026-08-03T12:02:00Z")?,
+            ClaimLimit::try_from(8)?,
+        ))
+        .await?;
+    let token = |id| {
+        claims
+            .iter()
+            .copied()
+            .find(|claim| claim.intent_id() == id)
+            .map(DeliveryClaim::token)
+            .ok_or("claim missing")
+    };
+    database
+        .succeed(
+            ids[0],
+            token(ids[0])?,
+            ProviderMessageId::new("provider-before-checkpoint", 128)?,
+            lease_at,
+        )
+        .await?;
+    database
+        .skip(
+            ids[1],
+            token(ids[1])?,
+            BoundedDeliveryText::new("skip", 128)?,
+            lease_at,
+        )
+        .await?;
+    database
+        .fail_terminal(
+            ids[2],
+            token(ids[2])?,
+            1,
+            BoundedDeliveryText::new("terminal", 128)?,
+            lease_at,
+        )
+        .await?;
+    assert!(matches!(
+        database.inspect(ids[0]).await?.expect("success").state().status(),
+        DeliveryStatus::Succeeded { provider_message_id, .. }
+            if provider_message_id.as_str() == "provider-before-checkpoint"
+    ));
+
+    let worker = BoundedDeliveryText::new("delivery-worker", 128)?;
+    assert!(
+        database
+            .checkpoint(CheckpointQuery::new(worker.clone()))
+            .await?
+            .is_none()
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                None,
+                CommitCursor::try_from(10)?,
+                OutboxIntentId::new(),
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::TerminalStateRequired
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                None,
+                CommitCursor::try_from(10)?,
+                ids[3],
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::TerminalStateRequired
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                None,
+                CommitCursor::try_from(10)?,
+                ids[0],
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::Advanced
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                Some(CommitCursor::try_from(999)?),
+                CommitCursor::try_from(10)?,
+                ids[1],
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::Repeated
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                Some(CommitCursor::try_from(9)?),
+                CommitCursor::try_from(11)?,
+                ids[2],
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::Conflict
+    );
+    assert_eq!(
+        database
+            .advance_checkpoint(CheckpointAdvance::new(
+                worker.clone(),
+                Some(CommitCursor::try_from(10)?),
+                CommitCursor::try_from(5)?,
+                ids[2],
+            ))
+            .await?,
+        CheckpointAdvanceOutcome::Advanced
+    );
+    assert_eq!(database.snapshot().await?.cursor(), before);
+
+    for (index, terminal_id) in ids[..3].iter().copied().enumerate() {
+        let terminal_worker = BoundedDeliveryText::new(format!("terminal-{index}"), 128)?;
+        assert_eq!(
+            database
+                .advance_checkpoint(CheckpointAdvance::new(
+                    terminal_worker,
+                    None,
+                    CommitCursor::try_from(u64::try_from(index)? + 1)?,
+                    terminal_id,
+                ))
+                .await?,
+            CheckpointAdvanceOutcome::Advanced
+        );
+    }
+
+    database.close().await?;
+    database.reopen().await?;
+    let checkpoint = database
+        .checkpoint(CheckpointQuery::new(worker))
+        .await?
+        .ok_or("checkpoint missing after restart")?;
+    assert_eq!(checkpoint.cursor(), CommitCursor::try_from(5)?);
+    database.close().await?;
+    Ok(())
+}

--- a/crates/attention/turso/tests/delivery_port.rs
+++ b/crates/attention/turso/tests/delivery_port.rs
@@ -1,0 +1,307 @@
+use attention_kernel::*;
+use attention_turso::AttentionDatabase;
+use attention_turso::Config;
+use chrono::DateTime;
+use chrono::Utc;
+use std::collections::HashSet;
+use std::error::Error;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+fn at(value: &str) -> TestResult<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
+}
+
+async fn database() -> TestResult<(tempfile::TempDir, AttentionDatabase)> {
+    let root = tempfile::tempdir()?;
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let database = AttentionDatabase::open(config).await?;
+    database.run_startup_migrations().await?;
+    Ok((root, database))
+}
+
+async fn pending(
+    database: &AttentionDatabase,
+    sequence: usize,
+    created_at: DateTime<Utc>,
+) -> TestResult<OutboxIntentId> {
+    let intent_id = OutboxIntentId::new();
+    let command = IngestSourceOccurrence::new(
+        SourceReceiptId::new(),
+        None,
+        AttentionSignalId::new(),
+        OccurrenceKey::new(
+            SourceKind::new("delivery-test")?,
+            SourceInstance::new(format!("worker-{sequence}"))?,
+            OccurrenceId::new(format!("occurrence-{sequence}"))?,
+        ),
+        created_at,
+        created_at,
+        SourceOrderMode::Unordered,
+        SignalSourceLifecycle::Active,
+        true,
+        MutationIdempotencyKey::new(),
+    );
+    let outcome = database
+        .commit_ingest_source_occurrence(evaluate_ingest_source_occurrence(
+            &command,
+            None,
+            None,
+            EvaluationContext::new(ChangeEventId::new(), Some(intent_id), created_at),
+        )?)
+        .await?;
+    assert_eq!(outcome.outbox_intent_id(), Some(intent_id));
+    Ok(intent_id)
+}
+
+fn claim_query(
+    eligible_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    limit: usize,
+) -> TestResult<DeliveryClaimQuery> {
+    Ok(DeliveryClaimQuery::new(
+        eligible_at,
+        expires_at,
+        ClaimLimit::try_from(limit)?,
+    ))
+}
+
+#[tokio::test]
+async fn inspect_claim_order_boundaries_reclaim_renew_and_missing_outcomes() -> TestResult {
+    let (_root, database) = database().await?;
+    let fractional = pending(&database, 1, at("2026-08-03T12:00:00.5Z")?).await?;
+    let whole = pending(&database, 2, at("2026-08-03T12:00:00Z")?).await?;
+    assert!(matches!(
+        database
+            .inspect(whole)
+            .await?
+            .expect("authority")
+            .state()
+            .status(),
+        DeliveryStatus::Pending
+    ));
+    assert!(database.inspect(OutboxIntentId::new()).await?.is_none());
+
+    let first = database
+        .claim(claim_query(
+            at("2026-08-03T12:01:00Z")?,
+            at("2026-08-03T12:02:00Z")?,
+            1,
+        )?)
+        .await?;
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].intent_id(), whole);
+    let original_token = first[0].token();
+    assert_eq!(
+        database
+            .renew(
+                whole,
+                DeliveryLeaseToken::from_bytes([9; 32]),
+                at("2026-08-03T12:03:00Z")?
+            )
+            .await?,
+        RenewOutcome::Fenced
+    );
+    assert_eq!(
+        database
+            .renew(whole, original_token, at("2026-08-03T12:03:00Z")?)
+            .await?,
+        RenewOutcome::Renewed
+    );
+    assert_eq!(
+        database
+            .renew(
+                OutboxIntentId::new(),
+                original_token,
+                at("2026-08-03T12:03:00Z")?
+            )
+            .await?,
+        RenewOutcome::NotLeased
+    );
+
+    let second = database
+        .claim(claim_query(
+            at("2026-08-03T12:03:00Z")?,
+            at("2026-08-03T12:04:00Z")?,
+            2,
+        )?)
+        .await?;
+    assert_eq!(second.len(), 2);
+    assert_eq!(second[0].intent_id(), whole);
+    assert_eq!(second[1].intent_id(), fractional);
+    assert_ne!(second[0].token(), original_token);
+    database.close().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn completion_precedence_retry_eligibility_and_event_independence() -> TestResult {
+    let (_root, database) = database().await?;
+    let created_at = at("2026-08-03T12:00:00Z")?;
+    let ids = [
+        pending(&database, 10, created_at).await?,
+        pending(&database, 11, created_at).await?,
+        pending(&database, 12, created_at).await?,
+        pending(&database, 13, created_at).await?,
+    ];
+    let before = database.snapshot().await?.cursor();
+    let claims = database
+        .claim(claim_query(
+            at("2026-08-03T12:01:00Z")?,
+            at("2026-08-03T12:02:00Z")?,
+            8,
+        )?)
+        .await?;
+    let claim = |id| {
+        claims
+            .iter()
+            .copied()
+            .find(|claim| claim.intent_id() == id)
+            .ok_or("claim missing")
+    };
+
+    let success = claim(ids[0])?;
+    let provider = ProviderMessageId::new("provider-1", 128)?;
+    let succeeded_at = at("2026-08-03T12:01:30Z")?;
+    assert_eq!(
+        database
+            .succeed(ids[0], success.token(), provider.clone(), succeeded_at)
+            .await?,
+        DeliveryCompletionOutcome::Applied
+    );
+    let stale = DeliveryLeaseToken::from_bytes([7; 32]);
+    assert_eq!(
+        database
+            .succeed(ids[0], stale, provider.clone(), succeeded_at)
+            .await?,
+        DeliveryCompletionOutcome::Repeated
+    );
+    assert_eq!(
+        database
+            .succeed(
+                ids[0],
+                stale,
+                ProviderMessageId::new("provider-2", 128)?,
+                succeeded_at
+            )
+            .await?,
+        DeliveryCompletionOutcome::Conflict
+    );
+
+    let skipped = claim(ids[1])?;
+    let reason = BoundedDeliveryText::new("not applicable", 128)?;
+    let skipped_at = at("2026-08-03T12:01:31Z")?;
+    assert_eq!(
+        database
+            .skip(ids[1], skipped.token(), reason.clone(), skipped_at)
+            .await?,
+        DeliveryCompletionOutcome::Applied
+    );
+    assert_eq!(
+        database.skip(ids[1], stale, reason, skipped_at).await?,
+        DeliveryCompletionOutcome::Repeated
+    );
+
+    let terminal = claim(ids[2])?;
+    let terminal_error = BoundedDeliveryText::new("terminal", 128)?;
+    let failed_at = at("2026-08-03T12:01:32Z")?;
+    assert_eq!(
+        database
+            .fail_terminal(
+                ids[2],
+                terminal.token(),
+                u32::MAX,
+                terminal_error.clone(),
+                failed_at
+            )
+            .await?,
+        DeliveryCompletionOutcome::Applied
+    );
+    assert_eq!(
+        database
+            .fail_terminal(ids[2], stale, u32::MAX, terminal_error, failed_at)
+            .await?,
+        DeliveryCompletionOutcome::Repeated
+    );
+
+    let retry = claim(ids[3])?;
+    let retry_error = BoundedDeliveryText::new("retry", 128)?;
+    let retry_at = at("2026-08-03T12:05:00Z")?;
+    assert_eq!(
+        database
+            .fail_retryable(ids[3], retry.token(), 2, retry_error, retry_at)
+            .await?,
+        DeliveryCompletionOutcome::Applied
+    );
+    assert_eq!(
+        database
+            .fail_retryable(
+                ids[3],
+                retry.token(),
+                2,
+                BoundedDeliveryText::new("retry", 128)?,
+                retry_at
+            )
+            .await?,
+        DeliveryCompletionOutcome::Fenced
+    );
+    assert!(
+        database
+            .claim(claim_query(
+                at("2026-08-03T12:04:59Z")?,
+                at("2026-08-03T12:06:00Z")?,
+                8
+            )?)
+            .await?
+            .is_empty()
+    );
+    let due_retry = database
+        .claim(claim_query(retry_at, at("2026-08-03T12:06:00Z")?, 8)?)
+        .await?;
+    assert_eq!(due_retry.len(), 1);
+    assert_eq!(due_retry[0].intent_id(), ids[3]);
+
+    assert_eq!(database.snapshot().await?.cursor(), before);
+    assert_eq!(
+        database
+            .succeed(
+                OutboxIntentId::new(),
+                stale,
+                ProviderMessageId::new("missing", 128)?,
+                succeeded_at
+            )
+            .await?,
+        DeliveryCompletionOutcome::Fenced
+    );
+    database.close().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_claims_are_disjoint() -> TestResult {
+    let (_root, database) = database().await?;
+    let time = at("2026-08-03T12:00:00Z")?;
+    for index in 20..24 {
+        pending(&database, index, time).await?;
+    }
+    let query = claim_query(at("2026-08-03T12:01:00Z")?, at("2026-08-03T12:02:00Z")?, 2)?;
+    let first_database = database.clone();
+    let first = tokio::spawn(async move { first_database.claim(query).await });
+    let second_database = database.clone();
+    let second = tokio::spawn(async move { second_database.claim(query).await });
+    let first = first.await??;
+    let second = second.await??;
+    assert_eq!(first.len(), 2);
+    assert_eq!(second.len(), 2);
+    let first_ids = first
+        .iter()
+        .map(|claim| claim.intent_id())
+        .collect::<HashSet<_>>();
+    assert!(
+        second
+            .iter()
+            .all(|claim| !first_ids.contains(&claim.intent_id()))
+    );
+    database.close().await?;
+    Ok(())
+}

--- a/crates/attention/turso/tests/exact_pin_gate.rs
+++ b/crates/attention/turso/tests/exact_pin_gate.rs
@@ -7,6 +7,9 @@ use turso_db::Value;
 use turso_db::params;
 use turso_db::transaction::TransactionBehavior;
 
+const CORE_MIGRATION_SQL: &str = include_str!("../migrations/0002_attention_core.sql");
+const DELIVERY_MIGRATION_SQL: &str = include_str!("../migrations/0003_durable_delivery.sql");
+
 fn counter(value: u64) -> Vec<u8> {
     value.to_be_bytes().to_vec()
 }
@@ -124,6 +127,189 @@ async fn partial_unique_indexes_are_enforced_without_becoming_a_design_dependenc
             .execute(
                 "INSERT INTO fires (id, reminder_id, current) VALUES (?1, ?2, ?3)",
                 params![4_i64, 7_i64, 1_i64],
+            )
+            .await
+            .is_err()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn durable_delivery_schema_enforces_shape_width_bounds_and_foreign_keys() -> TestResult {
+    let fixture = FileDatabase::open().await?;
+    let connection = fixture.database.connect()?;
+    connection.execute("PRAGMA foreign_keys = ON", ()).await?;
+    connection.execute_batch(CORE_MIGRATION_SQL).await?;
+    connection.execute_batch(DELIVERY_MIGRATION_SQL).await?;
+    connection
+        .execute(
+            "INSERT INTO change_events
+             (cursor, event_id, occurred_at, kind, payload_version, payload_bytes)
+             VALUES (?1, 'event-1', '2026-08-04T00:00:00Z', 0, 1, x'01')",
+            params![2_u64.to_be_bytes().to_vec()],
+        )
+        .await?;
+    connection
+        .execute(
+            "INSERT INTO outbox_intents
+             (id, deduplication_key, subject_kind, subject_id, originating_event_id, created_at, purpose)
+             VALUES ('intent-1', 'dedupe-1', 0, 'signal-1', 'event-1', '2026-08-04T00:00:00Z', 0)",
+            (),
+        )
+        .await?;
+    connection
+        .execute(
+            "INSERT INTO delivery_states (intent_id, status) VALUES ('intent-1', 0)",
+            (),
+        )
+        .await?;
+
+    assert!(
+        connection
+            .execute(
+                "UPDATE delivery_states SET status = 1, lease_token = ?1 WHERE intent_id = 'intent-1'",
+                params![vec![7_u8; 32]],
+            )
+            .await
+            .is_err()
+    );
+    connection
+        .execute(
+            "UPDATE delivery_states
+             SET status = 1, lease_token = ?1, lease_expires_at = '2026-08-04T00:01:00Z'
+             WHERE intent_id = 'intent-1'",
+            params![vec![7_u8; 32]],
+        )
+        .await?;
+    assert!(
+        connection
+            .execute(
+                "UPDATE delivery_states SET lease_token = ?1 WHERE intent_id = 'intent-1'",
+                params![vec![7_u8; 31]],
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "UPDATE delivery_states
+                 SET status = 2, lease_token = NULL, lease_expires_at = NULL,
+                     attempt = ?1, error = 'retry', next_retry_at = '2026-08-04T00:02:00Z'
+                 WHERE intent_id = 'intent-1'",
+                params![4_294_967_296_i64],
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "UPDATE delivery_states
+                 SET status = 2, lease_token = NULL, lease_expires_at = NULL,
+                     attempt = 1, error = ?1, next_retry_at = '2026-08-04T00:02:00Z'
+                 WHERE intent_id = 'intent-1'",
+                params!["x".repeat(65_537)],
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "INSERT INTO delivery_states (intent_id, status) VALUES ('missing-intent', 0)",
+                (),
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "INSERT INTO delivery_checkpoints (worker, cursor) VALUES ('worker', ?1)",
+                params![vec![0_u8; 7]],
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "INSERT INTO delivery_checkpoints (worker, cursor) VALUES (?1, ?2)",
+                params!["w".repeat(65_537), vec![0_u8; 8]],
+            )
+            .await
+            .is_err()
+    );
+    connection
+        .execute(
+            "INSERT INTO delivery_checkpoints (worker, cursor) VALUES ('worker', ?1)",
+            params![vec![0_u8; 8]],
+        )
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn current_fire_partial_index_allows_history_and_arbitrates_connections() -> TestResult {
+    let fixture = FileDatabase::open().await?;
+    let first = fixture.database.connect()?;
+    first.execute_batch(CORE_MIGRATION_SQL).await?;
+    first.execute_batch(DELIVERY_MIGRATION_SQL).await?;
+    first
+        .execute(
+            "INSERT INTO reminders
+             (id, revision, target_kind, target_id, trigger_at, current_fire_id)
+             VALUES ('reminder-1', ?1, 0, 'target-1', '2026-08-04T00:00:00Z', NULL)",
+            params![1_u64.to_be_bytes().to_vec()],
+        )
+        .await?;
+    for (id, ordinal, state) in [
+        ("history-ack", 0_i64, 2_i64),
+        ("history-snooze", 1, 3),
+        ("current", 2, 0),
+    ] {
+        first
+            .execute(
+                "INSERT INTO reminder_fires
+                 (id, reminder_id, ordinal, trigger_at, state)
+                 VALUES (?1, 'reminder-1', ?2, '2026-08-04T00:00:00Z', ?3)",
+                params![id, ordinal, state],
+            )
+            .await?;
+    }
+
+    let second = fixture.database.connect()?;
+    assert!(
+        second
+            .execute(
+                "INSERT INTO reminder_fires
+                 (id, reminder_id, ordinal, trigger_at, state)
+                 VALUES ('second-current', 'reminder-1', 3, '2026-08-04T00:00:00Z', 1)",
+                (),
+            )
+            .await
+            .is_err()
+    );
+    first
+        .execute(
+            "UPDATE reminder_fires SET state = 2 WHERE id = 'current'",
+            (),
+        )
+        .await?;
+    second
+        .execute(
+            "INSERT INTO reminder_fires
+             (id, reminder_id, ordinal, trigger_at, state)
+             VALUES ('replacement', 'reminder-1', 3, '2026-08-04T00:00:00Z', 1)",
+            (),
+        )
+        .await?;
+    assert!(
+        first
+            .execute(
+                "UPDATE reminder_fires SET state = 0 WHERE id = 'history-ack'",
+                (),
             )
             .await
             .is_err()

--- a/crates/attention/turso/tests/migrations.rs
+++ b/crates/attention/turso/tests/migrations.rs
@@ -21,6 +21,7 @@ type TestResult<T = ()> = Result<T, Box<dyn StdError + Send + Sync>>;
 
 const MIGRATION_SQL: &str = include_str!("../migrations/0001_foundation.sql");
 const CORE_MIGRATION_SQL: &str = include_str!("../migrations/0002_attention_core.sql");
+const DELIVERY_MIGRATION_SQL: &str = include_str!("../migrations/0003_durable_delivery.sql");
 
 fn config(root: &Path) -> Result<Config, attention_turso::PathError> {
     Config::new(root.join("database"), root.join("backups"))
@@ -30,14 +31,38 @@ fn checksum() -> Vec<u8> {
     Sha256::digest(MIGRATION_SQL.as_bytes()).to_vec()
 }
 
+fn core_checksum() -> Vec<u8> {
+    Sha256::digest(CORE_MIGRATION_SQL.as_bytes()).to_vec()
+}
+
+async fn install_head_two(connection: &turso_db::Connection) -> TestResult {
+    connection.execute_batch(MIGRATION_SQL).await?;
+    connection.execute_batch(CORE_MIGRATION_SQL).await?;
+    connection
+        .execute(
+            "INSERT INTO __attention_migrations (version, name, checksum) VALUES
+             (?1, ?2, ?3), (?4, ?5, ?6)",
+            params![
+                1_i64,
+                "foundation",
+                checksum(),
+                2_i64,
+                "attention_core",
+                core_checksum()
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn empty_to_head_rerun_reopen_and_checksum_drift_refusal() -> TestResult {
     let root = tempfile::tempdir()?;
     let config = config(root.path())?;
     let database = AttentionDatabase::open(config.clone()).await?;
     let first = database.run_startup_migrations().await?;
-    assert_eq!(first.applied(), 2);
-    assert_eq!(first.head(), 2);
+    assert_eq!(first.applied(), 3);
+    assert_eq!(first.head(), 3);
     assert_eq!(database.run_startup_migrations().await?.applied(), 0);
     database
         .write_qualification_probe("migration", b"fingerprint", b"value")
@@ -67,7 +92,7 @@ async fn empty_to_head_rerun_reopen_and_checksum_drift_refusal() -> TestResult {
             "SELECT count(*) FROM sqlite_schema WHERE type = 'table' AND name IN (\
              'attention_stream_state', 'work_items', 'source_receipts', 'source_entities', \
              'attention_signals', 'reminders', 'reminder_fires', 'mutation_outcomes', \
-             'change_events', 'outbox_intents')",
+              'change_events', 'outbox_intents', 'delivery_states', 'delivery_checkpoints')",
             (),
         )
         .await?;
@@ -76,7 +101,7 @@ async fn empty_to_head_rerun_reopen_and_checksum_drift_refusal() -> TestResult {
             .await?
             .ok_or("schema count missing")?
             .get::<i64>(0)?,
-        10
+        12
     );
     drop(rows);
     drop(connection);
@@ -107,7 +132,7 @@ async fn malformed_duplicate_unknown_and_too_new_ledgers_are_refused() -> TestRe
         vec![(1_i64, "foundation"), (1_i64, "foundation")],
         vec![(1_i64, "unknown")],
         vec![(2_i64, "future")],
-        vec![(3_i64, "future")],
+        vec![(4_i64, "future")],
     ] {
         let root = tempfile::tempdir()?;
         let config = config(root.path())?;
@@ -140,7 +165,7 @@ async fn malformed_duplicate_unknown_and_too_new_ledgers_are_refused() -> TestRe
 }
 
 #[tokio::test]
-async fn released_head_one_fixture_upgrades_to_head_two() -> TestResult {
+async fn released_head_one_fixture_upgrades_to_head_three() -> TestResult {
     let root = tempfile::tempdir()?;
     let config = config(root.path())?;
     let path = config.database_directory().database_file();
@@ -159,10 +184,153 @@ async fn released_head_one_fixture_upgrades_to_head_two() -> TestResult {
 
     let database = AttentionDatabase::open(config).await?;
     let report = database.run_startup_migrations().await?;
-    assert_eq!(report.applied(), 1);
-    assert_eq!(report.head(), 2);
+    assert_eq!(report.applied(), 2);
+    assert_eq!(report.head(), 3);
     assert_eq!(database.run_startup_migrations().await?.applied(), 0);
     database.close().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn released_head_two_fixture_backfills_pending_exactly_once() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = config(root.path())?;
+    let path = config.database_directory().database_file();
+    let path = path.to_str().ok_or("database path is not UTF-8")?;
+    let raw = Builder::new_local(path).build().await?;
+    let connection = raw.connect()?;
+    install_head_two(&connection).await?;
+    for index in 1_u64..=2 {
+        connection
+            .execute(
+                "INSERT INTO change_events
+                 (cursor, event_id, occurred_at, kind, payload_version, payload_bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    (index + 1).to_be_bytes().to_vec(),
+                    format!("event-{index}"),
+                    "2026-08-04T00:00:00Z",
+                    0_i64,
+                    1_i64,
+                    vec![u8::try_from(index)?]
+                ],
+            )
+            .await?;
+    }
+    for index in 1..=2 {
+        connection
+            .execute(
+                "INSERT INTO outbox_intents
+                 (id, deduplication_key, subject_kind, subject_id, originating_event_id, created_at, purpose)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    format!("intent-{index}"),
+                    format!("dedupe-{index}"),
+                    0_i64,
+                    format!("signal-{index}"),
+                    if index == 1 { "event-1" } else { "event-2" },
+                    "2026-08-04T00:00:00Z",
+                    0_i64
+                ],
+            )
+            .await?;
+    }
+    drop(connection);
+    drop(raw);
+
+    let database = AttentionDatabase::open(config.clone()).await?;
+    let report = database.run_startup_migrations().await?;
+    assert_eq!(report.applied(), 1);
+    assert_eq!(report.head(), 3);
+    assert_eq!(database.run_startup_migrations().await?.applied(), 0);
+    database.close().await?;
+
+    let raw = Builder::new_local(path).build().await?;
+    let connection = raw.connect()?;
+    let mut rows = connection
+        .query(
+            "SELECT intent_id, status FROM delivery_states ORDER BY intent_id",
+            (),
+        )
+        .await?;
+    let mut observed = Vec::new();
+    while let Some(row) = rows.next().await? {
+        observed.push((row.get::<String>(0)?, row.get::<i64>(1)?));
+    }
+    assert_eq!(
+        observed,
+        [("intent-1".to_string(), 0), ("intent-2".to_string(), 0)]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_head_two_current_fire_state_rolls_back_delivery_migration() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = config(root.path())?;
+    let path = config.database_directory().database_file();
+    let path = path.to_str().ok_or("database path is not UTF-8")?;
+    let raw = Builder::new_local(path).build().await?;
+    let connection = raw.connect()?;
+    install_head_two(&connection).await?;
+    connection
+        .execute(
+            "INSERT INTO reminders
+             (id, revision, target_kind, target_id, trigger_at, current_fire_id)
+             VALUES (?1, ?2, 0, ?3, ?4, NULL)",
+            params![
+                "reminder-1",
+                1_u64.to_be_bytes().to_vec(),
+                "target-1",
+                "2026-08-04T00:00:00Z"
+            ],
+        )
+        .await?;
+    for (id, ordinal, state) in [("fire-1", 0_i64, 0_i64), ("fire-2", 1, 1)] {
+        connection
+            .execute(
+                "INSERT INTO reminder_fires
+                 (id, reminder_id, ordinal, trigger_at, state)
+                 VALUES (?1, 'reminder-1', ?2, ?3, ?4)",
+                params![id, ordinal, "2026-08-04T00:00:00Z", state],
+            )
+            .await?;
+    }
+    drop(connection);
+    drop(raw);
+
+    let database = AttentionDatabase::open(config).await?;
+    assert!(database.run_startup_migrations().await.is_err());
+    database.close().await?;
+
+    let raw = Builder::new_local(path).build().await?;
+    let connection = raw.connect()?;
+    let mut rows = connection
+        .query(
+            "SELECT count(*) FROM sqlite_schema WHERE type = 'table' AND name = 'delivery_states'",
+            (),
+        )
+        .await?;
+    assert_eq!(
+        rows.next()
+            .await?
+            .ok_or("schema count missing")?
+            .get::<i64>(0)?,
+        0
+    );
+    let mut rows = connection
+        .query(
+            "SELECT count(*) FROM __attention_migrations WHERE version = 3",
+            (),
+        )
+        .await?;
+    assert_eq!(
+        rows.next()
+            .await?
+            .ok_or("ledger count missing")?
+            .get::<i64>(0)?,
+        0
+    );
     Ok(())
 }
 
@@ -197,7 +365,7 @@ async fn child_process_interruption_never_splits_ddl_and_ledger() -> TestResult 
 
         let database = AttentionDatabase::open(config).await?;
         let report = database.run_startup_migrations().await?;
-        let expected = if boundary == "after-commit" { 1 } else { 2 };
+        let expected = if boundary == "after-commit" { 2 } else { 3 };
         assert_eq!(report.applied(), expected, "boundary {boundary}");
         assert_eq!(database.run_startup_migrations().await?.applied(), 0);
         database.close().await?;
@@ -245,5 +413,7 @@ async fn child_migration_worker() -> TestResult {
 #[test]
 fn core_migration_is_nonempty_and_foundation_bytes_remain_separate() {
     assert!(!CORE_MIGRATION_SQL.is_empty());
+    assert!(!DELIVERY_MIGRATION_SQL.is_empty());
     assert!(!MIGRATION_SQL.contains("attention_stream_state"));
+    assert!(!CORE_MIGRATION_SQL.contains("delivery_states"));
 }

--- a/crates/attention/turso/tests/migrations.rs
+++ b/crates/attention/turso/tests/migrations.rs
@@ -1,5 +1,10 @@
 mod support;
 
+use attention_kernel::AttentionReadPort;
+use attention_kernel::ReminderFireId;
+use attention_kernel::ReminderFireState;
+use attention_kernel::ReminderId;
+use attention_kernel::WorkItemId;
 use attention_turso::AttentionDatabase;
 use attention_turso::Config;
 use attention_turso::Error;
@@ -22,6 +27,26 @@ type TestResult<T = ()> = Result<T, Box<dyn StdError + Send + Sync>>;
 const MIGRATION_SQL: &str = include_str!("../migrations/0001_foundation.sql");
 const CORE_MIGRATION_SQL: &str = include_str!("../migrations/0002_attention_core.sql");
 const DELIVERY_MIGRATION_SQL: &str = include_str!("../migrations/0003_durable_delivery.sql");
+const DUPLICATE_CURRENT_FIRE_REPAIR_SETUP_SQL: &str =
+    include_str!("../maintenance/repair_duplicate_current_reminder_fires_setup.sql");
+const DUPLICATE_CURRENT_FIRE_REPAIR_APPLY_SQL: &str =
+    include_str!("../maintenance/repair_duplicate_current_reminder_fires_apply.sql");
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReminderFixtureSnapshot {
+    revision: Vec<u8>,
+    current_fire_id: Option<String>,
+    fires: Vec<FireFixtureSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FireFixtureSnapshot {
+    id: String,
+    reminder_id: String,
+    ordinal: i64,
+    trigger_at: String,
+    state: i64,
+}
 
 fn config(root: &Path) -> Result<Config, attention_turso::PathError> {
     Config::new(root.join("database"), root.join("backups"))
@@ -53,6 +78,48 @@ async fn install_head_two(connection: &turso_db::Connection) -> TestResult {
         )
         .await?;
     Ok(())
+}
+
+async fn reminder_fixture_snapshot(
+    connection: &turso_db::Connection,
+    reminder_id: &str,
+) -> TestResult<ReminderFixtureSnapshot> {
+    let mut reminder_rows = connection
+        .query(
+            "SELECT revision, current_fire_id FROM reminders WHERE id = ?1",
+            params![reminder_id],
+        )
+        .await?;
+    let reminder = reminder_rows
+        .next()
+        .await?
+        .ok_or("reminder fixture is missing")?;
+    let revision = reminder.get::<Vec<u8>>(0)?;
+    let current_fire_id = reminder.get::<Option<String>>(1)?;
+    drop(reminder_rows);
+
+    let mut fire_rows = connection
+        .query(
+            "SELECT id, reminder_id, ordinal, trigger_at, state
+             FROM reminder_fires WHERE reminder_id = ?1 ORDER BY ordinal, id",
+            params![reminder_id],
+        )
+        .await?;
+    let mut fires = Vec::new();
+    while let Some(row) = fire_rows.next().await? {
+        fires.push(FireFixtureSnapshot {
+            id: row.get(0)?,
+            reminder_id: row.get(1)?,
+            ordinal: row.get(2)?,
+            trigger_at: row.get(3)?,
+            state: row.get(4)?,
+        });
+    }
+    Ok(ReminderFixtureSnapshot {
+        revision,
+        current_fire_id,
+        fires,
+    })
 }
 
 #[tokio::test]
@@ -300,7 +367,9 @@ async fn invalid_head_two_current_fire_state_rolls_back_delivery_migration() -> 
     drop(raw);
 
     let database = AttentionDatabase::open(config).await?;
-    assert!(database.run_startup_migrations().await.is_err());
+    for _ in 0..2 {
+        assert!(database.run_startup_migrations().await.is_err());
+    }
     database.close().await?;
 
     let raw = Builder::new_local(path).build().await?;
@@ -331,6 +400,267 @@ async fn invalid_head_two_current_fire_state_rolls_back_delivery_migration() -> 
             .get::<i64>(0)?,
         0
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_current_reminder_fire_repair_is_atomic_and_unblocks_migration_0003() -> TestResult
+{
+    let root = tempfile::tempdir()?;
+    let config = config(root.path())?;
+    let database_path = config.database_directory().database_file();
+    let path = database_path.to_str().ok_or("database path is not UTF-8")?;
+    let raw = Builder::new_local(path).build().await?;
+    let mut connection = raw.connect()?;
+    install_head_two(&connection).await?;
+
+    let reminder_id = ReminderId::new();
+    let reminder_id_text = reminder_id.to_string();
+    let target_id = WorkItemId::new().to_string();
+    let historical_fire_id = ReminderFireId::new();
+    let historical_fire_id_text = historical_fire_id.to_string();
+    let authoritative_fire_id = ReminderFireId::new();
+    let authoritative_fire_id_text = authoritative_fire_id.to_string();
+    let retired_fire_id = ReminderFireId::new();
+    let retired_fire_id_text = retired_fire_id.to_string();
+    let acknowledged_retired_fire_id = ReminderFireId::new();
+    let acknowledged_retired_fire_id_text = acknowledged_retired_fire_id.to_string();
+    let revision = 7_u64;
+
+    connection
+        .execute(
+            "INSERT INTO reminders
+             (id, revision, target_kind, target_id, trigger_at, current_fire_id)
+             VALUES (?1, ?2, 0, ?3, ?4, NULL)",
+            params![
+                reminder_id_text.as_str(),
+                revision.to_be_bytes().to_vec(),
+                target_id.as_str(),
+                "2026-08-04T00:00:00Z"
+            ],
+        )
+        .await?;
+    for (id, ordinal, trigger_at, state) in [
+        (
+            historical_fire_id_text.as_str(),
+            0_i64,
+            "2026-08-03T00:00:00Z",
+            2_i64,
+        ),
+        (
+            authoritative_fire_id_text.as_str(),
+            1_i64,
+            "2026-08-04T00:00:00Z",
+            1_i64,
+        ),
+        (
+            retired_fire_id_text.as_str(),
+            2_i64,
+            "2026-08-05T00:00:00Z",
+            0_i64,
+        ),
+        (
+            acknowledged_retired_fire_id_text.as_str(),
+            3_i64,
+            "2026-08-06T00:00:00Z",
+            1_i64,
+        ),
+    ] {
+        connection
+            .execute(
+                "INSERT INTO reminder_fires
+                 (id, reminder_id, ordinal, trigger_at, state)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![id, reminder_id_text.as_str(), ordinal, trigger_at, state],
+            )
+            .await?;
+    }
+    connection
+        .execute(
+            "UPDATE reminders SET current_fire_id = ?1 WHERE id = ?2",
+            params![
+                authoritative_fire_id_text.as_str(),
+                reminder_id_text.as_str()
+            ],
+        )
+        .await?;
+    let before = reminder_fixture_snapshot(&connection, &reminder_id_text).await?;
+
+    let invalid_repair = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .await?;
+    invalid_repair
+        .execute_batch(DUPLICATE_CURRENT_FIRE_REPAIR_SETUP_SQL)
+        .await?;
+    let mut inspection = invalid_repair
+        .query(
+            "SELECT
+                 (SELECT count(*) FROM temp.__attention_repair_duplicate_reminders),
+                 (SELECT count(*) FROM temp.__attention_repair_affected_fire_history)",
+            (),
+        )
+        .await?;
+    let inspection_row = inspection
+        .next()
+        .await?
+        .ok_or("repair inspection counts are missing")?;
+    assert_eq!(inspection_row.get::<i64>(0)?, 1);
+    assert_eq!(inspection_row.get::<i64>(1)?, 4);
+    drop(inspection);
+    invalid_repair
+        .execute(
+            "INSERT INTO temp.__attention_repair_authoritative
+             (reminder_id, authoritative_fire_id) VALUES (?1, ?2)",
+            params![
+                reminder_id_text.as_str(),
+                authoritative_fire_id_text.as_str()
+            ],
+        )
+        .await?;
+    let apply_error = invalid_repair
+        .execute_batch(DUPLICATE_CURRENT_FIRE_REPAIR_APPLY_SQL)
+        .await
+        .expect_err("incomplete retirement decisions must fail");
+    let diagnostic = apply_error.to_string();
+    for stored_id in [
+        &reminder_id_text,
+        &historical_fire_id_text,
+        &authoritative_fire_id_text,
+        &retired_fire_id_text,
+        &acknowledged_retired_fire_id_text,
+    ] {
+        assert!(!diagnostic.contains(stored_id));
+    }
+    invalid_repair.rollback().await?;
+    assert_eq!(
+        reminder_fixture_snapshot(&connection, &reminder_id_text).await?,
+        before
+    );
+    drop(connection);
+    drop(raw);
+
+    let database = AttentionDatabase::open(config.clone()).await?;
+    assert!(database.run_startup_migrations().await.is_err());
+    database.close().await?;
+
+    let raw = Builder::new_local(path).build().await?;
+    let mut connection = raw.connect()?;
+    let mut migration_state = connection
+        .query(
+            "SELECT
+                 (SELECT count(*) FROM sqlite_schema
+                  WHERE type = 'table' AND name = 'delivery_states'),
+                 (SELECT count(*) FROM __attention_migrations WHERE version = 3)",
+            (),
+        )
+        .await?;
+    let migration_state_row = migration_state
+        .next()
+        .await?
+        .ok_or("migration rollback state is missing")?;
+    assert_eq!(migration_state_row.get::<i64>(0)?, 0);
+    assert_eq!(migration_state_row.get::<i64>(1)?, 0);
+    drop(migration_state);
+
+    let valid_repair = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .await?;
+    valid_repair
+        .execute_batch(DUPLICATE_CURRENT_FIRE_REPAIR_SETUP_SQL)
+        .await?;
+    valid_repair
+        .execute(
+            "INSERT INTO temp.__attention_repair_authoritative
+             (reminder_id, authoritative_fire_id) VALUES (?1, ?2)",
+            params![
+                reminder_id_text.as_str(),
+                authoritative_fire_id_text.as_str()
+            ],
+        )
+        .await?;
+    valid_repair
+        .execute(
+            "INSERT INTO temp.__attention_repair_retire
+             (reminder_id, retired_fire_id, terminal_state) VALUES (?1, ?2, ?3)",
+            params![
+                reminder_id_text.as_str(),
+                acknowledged_retired_fire_id_text.as_str(),
+                2_i64
+            ],
+        )
+        .await?;
+    valid_repair
+        .execute(
+            "INSERT INTO temp.__attention_repair_retire
+             (reminder_id, retired_fire_id, terminal_state) VALUES (?1, ?2, ?3)",
+            params![
+                reminder_id_text.as_str(),
+                retired_fire_id_text.as_str(),
+                3_i64
+            ],
+        )
+        .await?;
+    valid_repair
+        .execute_batch(DUPLICATE_CURRENT_FIRE_REPAIR_APPLY_SQL)
+        .await?;
+    valid_repair.commit().await?;
+
+    let after = reminder_fixture_snapshot(&connection, &reminder_id_text).await?;
+    assert_eq!(after.revision, before.revision);
+    assert_eq!(
+        after.current_fire_id,
+        Some(authoritative_fire_id_text.clone())
+    );
+    assert_eq!(after.fires.len(), before.fires.len());
+    for (before_fire, after_fire) in before.fires.iter().zip(&after.fires) {
+        assert_eq!(after_fire.id, before_fire.id);
+        assert_eq!(after_fire.reminder_id, before_fire.reminder_id);
+        assert_eq!(after_fire.ordinal, before_fire.ordinal);
+        assert_eq!(after_fire.trigger_at, before_fire.trigger_at);
+    }
+    assert_eq!(after.fires[0].state, 2);
+    assert_eq!(after.fires[1].state, 1);
+    assert_eq!(after.fires[2].state, 3);
+    assert_eq!(after.fires[3].state, 2);
+    assert_eq!(
+        after
+            .fires
+            .iter()
+            .filter(|fire| matches!(fire.state, 0 | 1))
+            .count(),
+        1
+    );
+    drop(connection);
+    drop(raw);
+
+    let database = AttentionDatabase::open(config).await?;
+    let report = database.run_startup_migrations().await?;
+    assert_eq!(report.applied(), 1);
+    assert_eq!(report.head(), 3);
+    assert_eq!(database.run_startup_migrations().await?.applied(), 0);
+    let reminder = database
+        .reminder(reminder_id)
+        .await?
+        .ok_or("repaired reminder is missing")?;
+    assert_eq!(reminder.revision().value(), revision);
+    assert_eq!(reminder.fires().len(), 4);
+    for (fire_id, expected_state) in [
+        (historical_fire_id, ReminderFireState::Acknowledged),
+        (authoritative_fire_id, ReminderFireState::Fired),
+        (retired_fire_id, ReminderFireState::Snoozed),
+        (
+            acknowledged_retired_fire_id,
+            ReminderFireState::Acknowledged,
+        ),
+    ] {
+        let fire = reminder
+            .fires()
+            .iter()
+            .find(|fire| fire.id() == fire_id)
+            .ok_or("retained repaired fire is missing")?;
+        assert_eq!(fire.state(), expected_state);
+    }
+    database.close().await?;
     Ok(())
 }
 

--- a/crates/attention/turso/tests/reminder_schedule_port.rs
+++ b/crates/attention/turso/tests/reminder_schedule_port.rs
@@ -1,0 +1,98 @@
+use attention_kernel::*;
+use attention_turso::AttentionDatabase;
+use attention_turso::Config;
+use chrono::DateTime;
+use chrono::Utc;
+use std::error::Error;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+fn at(value: &str) -> TestResult<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
+}
+
+async fn create_scheduled(
+    database: &AttentionDatabase,
+    trigger_at: DateTime<Utc>,
+) -> TestResult<(ReminderId, ReminderFireId, Revision)> {
+    let reminder_id = ReminderId::new();
+    let fire_id = ReminderFireId::new();
+    database
+        .commit_create_reminder(evaluate_create_reminder(
+            &CreateReminder::new(
+                reminder_id,
+                fire_id,
+                ReminderTarget::WorkItem(WorkItemId::new()),
+                trigger_at,
+                MutationIdempotencyKey::new(),
+            ),
+            EvaluationContext::new(ChangeEventId::new(), None, trigger_at),
+        ))
+        .await?;
+    let revision = database
+        .reminder(reminder_id)
+        .await?
+        .ok_or("created reminder missing")?
+        .revision();
+    Ok((reminder_id, fire_id, revision))
+}
+
+#[tokio::test]
+async fn due_fires_decode_filter_globally_order_limit_and_survive_restart() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let database = AttentionDatabase::open(config).await?;
+    database.run_startup_migrations().await?;
+
+    let whole = create_scheduled(&database, at("2026-08-03T12:00:00Z")?).await?;
+    let fractional = create_scheduled(&database, at("2026-08-03T12:00:00.5Z")?).await?;
+    let tie_time = at("2026-08-03T12:00:01Z")?;
+    let tie_a = create_scheduled(&database, tie_time).await?;
+    let tie_b = create_scheduled(&database, tie_time).await?;
+    let boundary = create_scheduled(&database, at("2026-08-03T12:00:02Z")?).await?;
+    let _future = create_scheduled(&database, at("2026-08-03T12:00:03Z")?).await?;
+    let fired = create_scheduled(&database, at("2026-08-03T11:59:59Z")?).await?;
+    let reminder = database
+        .reminder(fired.0)
+        .await?
+        .ok_or("fire fixture reminder missing")?;
+    database
+        .commit_fire_reminder(evaluate_fire_reminder(
+            &FireReminder::new(fired.0, fired.1, MutationIdempotencyKey::new()),
+            &reminder,
+            EvaluationContext::new(ChangeEventId::new(), None, tie_time),
+        )?)
+        .await?;
+
+    let query = DueReminderFiresQuery::new(at("2026-08-03T12:00:02Z")?, QueryLimit::try_from(16)?);
+    let observed = database.due_reminder_fires(query).await?;
+    let mut ties = [tie_a, tie_b];
+    ties.sort_by_key(|value| (value.1, value.0));
+    let expected = [whole, fractional, ties[0], ties[1], boundary];
+    assert_eq!(observed.len(), expected.len());
+    for (actual, expected) in observed.iter().zip(expected) {
+        assert_eq!(actual.reminder_id(), expected.0);
+        assert_eq!(actual.fire_id(), expected.1);
+        assert_eq!(actual.reminder_revision(), expected.2);
+    }
+
+    let limited = database
+        .due_reminder_fires(DueReminderFiresQuery::new(
+            at("2026-08-03T12:00:02Z")?,
+            QueryLimit::try_from(2)?,
+        ))
+        .await?;
+    assert_eq!(
+        limited
+            .iter()
+            .map(|fire| fire.fire_id())
+            .collect::<Vec<_>>(),
+        [whole.1, fractional.1]
+    );
+
+    database.close().await?;
+    database.reopen().await?;
+    assert_eq!(database.due_reminder_fires(query).await?, observed);
+    database.close().await?;
+    Ok(())
+}

--- a/crates/attention/turso/tests/restart_and_replay.rs
+++ b/crates/attention/turso/tests/restart_and_replay.rs
@@ -3,8 +3,42 @@ use attention_turso::AttentionDatabase;
 use attention_turso::Config;
 use chrono::Utc;
 use std::error::Error;
+use turso_db::Builder;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+async fn pending_delivery(
+    database: &AttentionDatabase,
+    sequence: usize,
+    time: chrono::DateTime<Utc>,
+) -> TestResult<OutboxIntentId> {
+    let intent_id = OutboxIntentId::new();
+    let command = IngestSourceOccurrence::new(
+        SourceReceiptId::new(),
+        None,
+        AttentionSignalId::new(),
+        OccurrenceKey::new(
+            SourceKind::new("restart-delivery")?,
+            SourceInstance::new(format!("instance-{sequence}"))?,
+            OccurrenceId::new(format!("occurrence-{sequence}"))?,
+        ),
+        time,
+        time,
+        SourceOrderMode::Unordered,
+        SignalSourceLifecycle::Active,
+        true,
+        MutationIdempotencyKey::new(),
+    );
+    database
+        .commit_ingest_source_occurrence(evaluate_ingest_source_occurrence(
+            &command,
+            None,
+            None,
+            EvaluationContext::new(ChangeEventId::new(), Some(intent_id), time),
+        )?)
+        .await?;
+    Ok(intent_id)
+}
 
 #[tokio::test]
 async fn roots_outcomes_events_and_original_views_survive_restart() -> TestResult {
@@ -77,7 +111,7 @@ async fn source_authority_outbox_identity_and_complete_fire_history_survive_rest
 {
     let root = tempfile::tempdir()?;
     let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
-    let database = AttentionDatabase::open(config).await?;
+    let database = AttentionDatabase::open(config.clone()).await?;
     database.run_startup_migrations().await?;
     let time = chrono::DateTime::parse_from_rfc3339("2026-08-03T12:00:00Z")?.with_timezone(&Utc);
     let kind = SourceKind::new("linear")?;
@@ -134,11 +168,12 @@ async fn source_authority_outbox_identity_and_complete_fire_history_survive_rest
         ))
         .await?;
     let reminder = database.reminder(reminder_id).await?.expect("reminder");
+    let reminder_outbox_id = OutboxIntentId::new();
     database
         .commit_fire_reminder(evaluate_fire_reminder(
             &FireReminder::new(reminder_id, fire_id, MutationIdempotencyKey::new()),
             &reminder,
-            EvaluationContext::new(ChangeEventId::new(), None, time),
+            EvaluationContext::new(ChangeEventId::new(), Some(reminder_outbox_id), time),
         )?)
         .await?;
     let reminder = database
@@ -157,6 +192,53 @@ async fn source_authority_outbox_identity_and_complete_fire_history_survive_rest
                 MutationIdempotencyKey::new(),
             ),
             &reminder,
+            EvaluationContext::new(ChangeEventId::new(), None, time),
+        )?)
+        .await?;
+
+    let acknowledged_reminder_id = ReminderId::new();
+    let acknowledged_fire_id = ReminderFireId::new();
+    database
+        .commit_create_reminder(evaluate_create_reminder(
+            &CreateReminder::new(
+                acknowledged_reminder_id,
+                acknowledged_fire_id,
+                ReminderTarget::WorkItem(WorkItemId::new()),
+                time,
+                MutationIdempotencyKey::new(),
+            ),
+            EvaluationContext::new(ChangeEventId::new(), None, time),
+        ))
+        .await?;
+    let acknowledged_reminder = database
+        .reminder(acknowledged_reminder_id)
+        .await?
+        .expect("acknowledgement reminder");
+    let acknowledged_outbox_id = OutboxIntentId::new();
+    database
+        .commit_fire_reminder(evaluate_fire_reminder(
+            &FireReminder::new(
+                acknowledged_reminder_id,
+                acknowledged_fire_id,
+                MutationIdempotencyKey::new(),
+            ),
+            &acknowledged_reminder,
+            EvaluationContext::new(ChangeEventId::new(), Some(acknowledged_outbox_id), time),
+        )?)
+        .await?;
+    let acknowledged_reminder = database
+        .reminder(acknowledged_reminder_id)
+        .await?
+        .expect("fired acknowledgement reminder");
+    database
+        .commit_acknowledge_reminder_fire(evaluate_acknowledge_reminder_fire(
+            &AcknowledgeReminderFire::new(
+                acknowledged_reminder_id,
+                acknowledged_fire_id,
+                acknowledged_reminder.revision(),
+                MutationIdempotencyKey::new(),
+            ),
+            &acknowledged_reminder,
             EvaluationContext::new(ChangeEventId::new(), None, time),
         )?)
         .await?;
@@ -184,6 +266,228 @@ async fn source_authority_outbox_identity_and_complete_fire_history_survive_rest
     assert_eq!(reminder.fires()[0].id(), fire_id);
     assert_eq!(reminder.fires()[1].id(), replacement);
     assert_eq!(database.snapshot().await?.cursor(), before_restart);
+    database.close().await?;
+
+    let raw = Builder::new_local(
+        config
+            .database_directory()
+            .database_file()
+            .to_str()
+            .ok_or("database path is not UTF-8")?,
+    )
+    .build()
+    .await?;
+    let connection = raw.connect()?;
+    for intent_id in [outbox_id, reminder_outbox_id, acknowledged_outbox_id] {
+        let mut rows = connection
+            .query(
+                "SELECT status FROM delivery_states WHERE intent_id = ?1",
+                turso_db::params![intent_id.to_string()],
+            )
+            .await?;
+        assert_eq!(
+            rows.next()
+                .await?
+                .ok_or("delivery authority missing after lifecycle transition")?
+                .get::<i64>(0)?,
+            0
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn every_delivery_state_and_checkpoint_survives_without_repair_rewrite() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let database = AttentionDatabase::open(config).await?;
+    database.run_startup_migrations().await?;
+    let base = chrono::DateTime::parse_from_rfc3339("2026-08-03T12:00:00Z")?.with_timezone(&Utc);
+    let active = pending_delivery(&database, 20, base).await?;
+    let expired = pending_delivery(&database, 21, base).await?;
+    let future_retry = pending_delivery(&database, 22, base).await?;
+    let due_retry = pending_delivery(&database, 23, base).await?;
+    let succeeded = pending_delivery(&database, 24, base).await?;
+    let skipped = pending_delivery(&database, 25, base).await?;
+    let terminal = pending_delivery(&database, 26, base).await?;
+    let claims = database
+        .claim(DeliveryClaimQuery::new(
+            base,
+            base + chrono::Duration::minutes(10),
+            ClaimLimit::try_from(16)?,
+        ))
+        .await?;
+    let token = |id| {
+        claims
+            .iter()
+            .copied()
+            .find(|claim| claim.intent_id() == id)
+            .map(DeliveryClaim::token)
+            .ok_or("claim missing")
+    };
+    database
+        .renew(
+            expired,
+            token(expired)?,
+            base + chrono::Duration::minutes(5),
+        )
+        .await?;
+    database
+        .fail_retryable(
+            future_retry,
+            token(future_retry)?,
+            1,
+            BoundedDeliveryText::new("future", 128)?,
+            base + chrono::Duration::minutes(6),
+        )
+        .await?;
+    database
+        .fail_retryable(
+            due_retry,
+            token(due_retry)?,
+            1,
+            BoundedDeliveryText::new("due", 128)?,
+            base + chrono::Duration::minutes(5),
+        )
+        .await?;
+    database
+        .succeed(
+            succeeded,
+            token(succeeded)?,
+            ProviderMessageId::new("restart-provider", 128)?,
+            base,
+        )
+        .await?;
+    database
+        .skip(
+            skipped,
+            token(skipped)?,
+            BoundedDeliveryText::new("restart-skip", 128)?,
+            base,
+        )
+        .await?;
+    database
+        .fail_terminal(
+            terminal,
+            token(terminal)?,
+            3,
+            BoundedDeliveryText::new("restart-terminal", 128)?,
+            base,
+        )
+        .await?;
+    let pending = pending_delivery(&database, 27, base).await?;
+    let worker = BoundedDeliveryText::new("restart-worker", 128)?;
+    database
+        .advance_checkpoint(CheckpointAdvance::new(
+            worker.clone(),
+            None,
+            CommitCursor::try_from(42)?,
+            succeeded,
+        ))
+        .await?;
+    let before_restart = database.snapshot().await?.cursor();
+    let active_token = token(active)?;
+    let expired_token = token(expired)?;
+    database.close().await?;
+    database.reopen().await?;
+
+    assert_eq!(database.snapshot().await?.cursor(), before_restart);
+    assert!(matches!(
+        database.inspect(active).await?.expect("active").state().status(),
+        DeliveryStatus::Leased { token, .. } if *token == active_token
+    ));
+    assert!(matches!(
+        database.inspect(expired).await?.expect("expired").state().status(),
+        DeliveryStatus::Leased { token, .. } if *token == expired_token
+    ));
+    assert!(matches!(
+        database
+            .inspect(future_retry)
+            .await?
+            .expect("future")
+            .state()
+            .status(),
+        DeliveryStatus::Retryable { .. }
+    ));
+    assert!(matches!(
+        database
+            .inspect(due_retry)
+            .await?
+            .expect("due")
+            .state()
+            .status(),
+        DeliveryStatus::Retryable { .. }
+    ));
+    assert!(matches!(
+        database
+            .inspect(succeeded)
+            .await?
+            .expect("success")
+            .state()
+            .status(),
+        DeliveryStatus::Succeeded { .. }
+    ));
+    assert!(matches!(
+        database
+            .inspect(skipped)
+            .await?
+            .expect("skip")
+            .state()
+            .status(),
+        DeliveryStatus::Skipped { .. }
+    ));
+    assert!(matches!(
+        database
+            .inspect(terminal)
+            .await?
+            .expect("terminal")
+            .state()
+            .status(),
+        DeliveryStatus::TerminalFailure { .. }
+    ));
+    assert!(matches!(
+        database
+            .inspect(pending)
+            .await?
+            .expect("pending")
+            .state()
+            .status(),
+        DeliveryStatus::Pending
+    ));
+    assert_eq!(
+        database
+            .checkpoint(CheckpointQuery::new(worker))
+            .await?
+            .ok_or("checkpoint missing")?
+            .cursor(),
+        CommitCursor::try_from(42)?
+    );
+
+    let reclaimed = database
+        .claim(DeliveryClaimQuery::new(
+            base + chrono::Duration::minutes(5),
+            base + chrono::Duration::minutes(15),
+            ClaimLimit::try_from(16)?,
+        ))
+        .await?;
+    let reclaimed_ids = reclaimed
+        .iter()
+        .map(|claim| claim.intent_id())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(reclaimed_ids.len(), 3);
+    assert!(reclaimed_ids.contains(&expired));
+    assert!(reclaimed_ids.contains(&due_retry));
+    assert!(reclaimed_ids.contains(&pending));
+    assert!(!reclaimed_ids.contains(&active));
+    assert!(!reclaimed_ids.contains(&future_retry));
+    assert_ne!(
+        reclaimed
+            .iter()
+            .find(|claim| claim.intent_id() == expired)
+            .ok_or("expired lease not reclaimed")?
+            .token(),
+        expired_token
+    );
     database.close().await?;
     Ok(())
 }

--- a/crates/attention/turso/tests/security_and_diagnostics.rs
+++ b/crates/attention/turso/tests/security_and_diagnostics.rs
@@ -4,14 +4,48 @@ use attention_turso::Config;
 use chrono::DateTime;
 use chrono::Utc;
 use std::error::Error;
+use turso_db::Builder;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+async fn pending_delivery(
+    database: &AttentionDatabase,
+    sequence: usize,
+    time: DateTime<Utc>,
+) -> TestResult<OutboxIntentId> {
+    let intent_id = OutboxIntentId::new();
+    let command = IngestSourceOccurrence::new(
+        SourceReceiptId::new(),
+        None,
+        AttentionSignalId::new(),
+        OccurrenceKey::new(
+            SourceKind::new("security-delivery")?,
+            SourceInstance::new(format!("instance-{sequence}"))?,
+            OccurrenceId::new(format!("occurrence-{sequence}"))?,
+        ),
+        time,
+        time,
+        SourceOrderMode::Unordered,
+        SignalSourceLifecycle::Active,
+        true,
+        MutationIdempotencyKey::new(),
+    );
+    database
+        .commit_ingest_source_occurrence(evaluate_ingest_source_occurrence(
+            &command,
+            None,
+            None,
+            EvaluationContext::new(ChangeEventId::new(), Some(intent_id), time),
+        )?)
+        .await?;
+    Ok(intent_id)
+}
 
 #[tokio::test]
 async fn sql_shaped_source_values_remain_data_and_optional_outbox_is_atomic() -> TestResult {
     let root = tempfile::tempdir()?;
     let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
-    let database = AttentionDatabase::open(config).await?;
+    let database = AttentionDatabase::open(config.clone()).await?;
     database.run_startup_migrations().await?;
     let time = DateTime::parse_from_rfc3339("2026-08-03T12:00:00Z")
         .expect("time")
@@ -63,6 +97,170 @@ async fn sql_shaped_source_values_remain_data_and_optional_outbox_is_atomic() ->
         ))
         .await?;
     assert!(matches!(changes, ChangesResult::Page(ref page) if page.events().len() == 1));
+    database.close().await?;
+
+    let raw = Builder::new_local(
+        config
+            .database_directory()
+            .database_file()
+            .to_str()
+            .ok_or("database path is not UTF-8")?,
+    )
+    .build()
+    .await?;
+    let connection = raw.connect()?;
+    let mut rows = connection
+        .query(
+            "SELECT d.intent_id, d.status FROM outbox_intents AS o
+             JOIN delivery_states AS d ON d.intent_id = o.id WHERE o.id = ?1",
+            turso_db::params![outbox_id.to_string()],
+        )
+        .await?;
+    let row = rows.next().await?.ok_or("delivery authority missing")?;
+    assert_eq!(row.get::<String>(0)?, outbox_id.to_string());
+    assert_eq!(row.get::<i64>(1)?, 0);
+    assert!(rows.next().await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn delivery_values_are_bound_bounded_raw_and_malformed_rows_fail_closed() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let config = Config::new(root.path().join("database"), root.path().join("backups"))?;
+    let database = AttentionDatabase::open(config.clone()).await?;
+    database.run_startup_migrations().await?;
+    let time = DateTime::parse_from_rfc3339("2026-08-03T12:00:00Z")?.with_timezone(&Utc);
+    let succeeded = pending_delivery(&database, 10, time).await?;
+    let failed = pending_delivery(&database, 11, time).await?;
+    let skipped = pending_delivery(&database, 12, time).await?;
+    let oversized = pending_delivery(&database, 13, time).await?;
+    let claims = database
+        .claim(DeliveryClaimQuery::new(
+            time,
+            time + chrono::Duration::minutes(1),
+            ClaimLimit::try_from(8)?,
+        ))
+        .await?;
+    let token = |id| {
+        claims
+            .iter()
+            .copied()
+            .find(|claim| claim.intent_id() == id)
+            .map(DeliveryClaim::token)
+            .ok_or("claim missing")
+    };
+    let provider_value = "provider'); DROP TABLE delivery_states;--";
+    let error_value = "failure'); DELETE FROM outbox_intents;--";
+    let reason_value = "reason\" OR 1=1 --";
+    database
+        .succeed(
+            succeeded,
+            token(succeeded)?,
+            ProviderMessageId::new(provider_value, 256)?,
+            time,
+        )
+        .await?;
+    database
+        .fail_terminal(
+            failed,
+            token(failed)?,
+            u32::MAX,
+            BoundedDeliveryText::new(error_value, 256)?,
+            time,
+        )
+        .await?;
+    database
+        .skip(
+            skipped,
+            token(skipped)?,
+            BoundedDeliveryText::new(reason_value, 256)?,
+            time,
+        )
+        .await?;
+    let oversized_value = "secret".repeat(attention_turso::DELIVERY_TEXT_LIMIT_BYTES / 6 + 1);
+    let oversized_text = BoundedDeliveryText::new(
+        oversized_value.clone(),
+        attention_turso::DELIVERY_TEXT_LIMIT_BYTES * 2,
+    )?;
+    let error = database
+        .fail_retryable(oversized, token(oversized)?, 1, oversized_text, time)
+        .await
+        .expect_err("adapter ceiling must reject caller value");
+    assert!(!error.to_string().contains("secret"));
+    database.close().await?;
+
+    let raw = Builder::new_local(
+        config
+            .database_directory()
+            .database_file()
+            .to_str()
+            .ok_or("database path is not UTF-8")?,
+    )
+    .build()
+    .await?;
+    let connection = raw.connect()?;
+    let mut rows = connection
+        .query(
+            "SELECT length(lease_token) FROM delivery_states WHERE intent_id = ?1",
+            turso_db::params![oversized.to_string()],
+        )
+        .await?;
+    assert_eq!(
+        rows.next()
+            .await?
+            .ok_or("raw token row missing")?
+            .get::<i64>(0)?,
+        32
+    );
+    drop(rows);
+    let mut rows = connection
+        .query(
+            "SELECT
+                 (SELECT provider_message_id FROM delivery_states WHERE intent_id = ?1),
+                 (SELECT error FROM delivery_states WHERE intent_id = ?2),
+                 (SELECT reason FROM delivery_states WHERE intent_id = ?3)",
+            turso_db::params![
+                succeeded.to_string(),
+                failed.to_string(),
+                skipped.to_string()
+            ],
+        )
+        .await?;
+    let row = rows.next().await?.ok_or("bound values missing")?;
+    assert_eq!(row.get::<String>(0)?, provider_value);
+    assert_eq!(row.get::<String>(1)?, error_value);
+    assert_eq!(row.get::<String>(2)?, reason_value);
+    drop(rows);
+    connection
+        .execute("PRAGMA ignore_check_constraints = ON", ())
+        .await?;
+    connection
+        .execute(
+            "UPDATE delivery_states SET succeeded_at = ?2 WHERE intent_id = ?1",
+            turso_db::params![succeeded.to_string(), "stored-secret-timestamp"],
+        )
+        .await?;
+    connection
+        .execute(
+            "INSERT INTO delivery_checkpoints (worker, cursor) VALUES (?1, ?2)",
+            turso_db::params!["malformed-worker", vec![0_u8; 7]],
+        )
+        .await?;
+    drop(connection);
+    drop(raw);
+
+    database.reopen().await?;
+    let error = database
+        .inspect(succeeded)
+        .await
+        .expect_err("malformed timestamp must fail closed");
+    assert!(!error.to_string().contains("stored-secret-timestamp"));
+    let worker = BoundedDeliveryText::new("malformed-worker", 128)?;
+    let error = database
+        .checkpoint(CheckpointQuery::new(worker))
+        .await
+        .expect_err("malformed cursor must fail closed");
+    assert!(!error.to_string().contains("malformed-worker"));
     database.close().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- implement ENG-1121 durable ReminderFire scheduling and outbox delivery authority
- add fenced leases, durable completion state, and worker checkpoints
- add migration, restart, contention, ambiguity, and security conformance coverage

## Verification
- `just crate-check attention-turso`
- `just crate-test attention-kernel`
- `just crate-test attention-turso`
- `just crate-build attention-turso`
- `just check`
- `just test`

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-1121 makes ReminderFire scheduling and outbox delivery durable before scheduler/provider loops depend on them. Previously, Turso persisted outbox intents but had no durable authority for claim, lease, retry, terminal completion, or worker progress, and there was no adapter implementation for discovering due scheduled fires.

This change establishes restart-safe, at-least-once delivery semantics while preserving the existing boundaries: provider sends remain outside database transactions, delivery bookkeeping emits no ChangeEvents, and acknowledgement/snooze do not cancel or rewrite delivery authority.

## What user-facing changes did I ship?

There is no direct UI or provider integration in this PR. The user-visible impact is storage correctness for future reminder delivery:

- due scheduled ReminderFires can be discovered deterministically and inclusively at their trigger boundary;
- reminder notifications are not silently lost when the process restarts;
- expired leases and due retries can be reclaimed with fresh fencing tokens;
- stale workers cannot renew or complete a newer lease;
- terminal delivery results and provider message IDs remain durable before checkpoint progress advances.

This unblocks the scheduler/provider work that consumes these ports.

## How I implemented it

- Added additive migration `0003_durable_delivery.sql` and advanced the migration head to 3.
  - Creates state-shaped `delivery_states` rows for Pending, Leased, Retryable, Succeeded, Skipped, and TerminalFailure.
  - Creates per-worker `delivery_checkpoints` with 8-byte big-endian cursors.
  - Atomically backfills every existing outbox intent as Pending.
  - Adds claim/retry indexes and a partial unique index enforcing at most one Scheduled/Fired fire per reminder.
  - Upgrade failure remains transactional: invalid pre-existing current-fire state leaves both schema and migration ledger unchanged.
- Inserts a Pending delivery authority immediately after every OutboxIntent insert in the same serialized IMMEDIATE semantic transaction.
- Implemented `ReminderSchedulePort` with snapshot reads, canonical timestamp decoding, inclusive due filtering, global `(trigger_at, fire_id, reminder_id)` ordering, and limit-after-ordering.
- Implemented `DeliveryPort` using the existing single serialized writer.
  - Claims Pending, expired Leased, and due Retryable intents in decoded `(created_at, intent_id)` order.
  - Generates raw 32-byte OS-CSPRNG lease tokens and uses fresh tokens on reclaim.
  - Implements renew, succeed, retryable failure, terminal failure, and skip with token fencing and kernel-defined terminal-before-token replay/conflict precedence.
  - Ambiguous claims return `CommitOutcomeUnknown`; other ambiguous applied writes return success only when an authoritative reread proves the durable result.
- Implemented `DeliveryCheckpointPort` with terminal-state gating, first-write/CAS updates, Repeated-before-Conflict precedence, and proof-read handling for ambiguous commits. Cursor monotonicity is intentionally not added because it is not part of the kernel contract.
- Added strict status/token/timestamp/cursor reconstruction and a 64-KiB adapter ceiling for persisted delivery text. SQL uses bound parameters, and diagnostics do not echo lease tokens or untrusted stored values.
- Added exact-engine migration, contention, lifecycle, ambiguity, restart, replay, and security conformance tests. Restart coverage preserves all delivery states and checkpoints without repair rewrites; ChangeEvents remain wakeup/history data rather than send authority.

Migration note: this is an additive automatic migration. Databases containing multiple `reminder_fires` rows in Scheduled/Fired state for one reminder will reject migration 0003 atomically; normal kernel writes already prevent that invalid state.

## How to verify it

- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_cli_just_execute`) and they passed
- [x] `just crate-check attention-turso`
- [x] `just crate-test attention-kernel` — 52 passed
- [x] `just crate-test attention-turso` — 101 passed
- [x] `just crate-build attention-turso`
- [x] `just check`
- [x] `just test` — MCP schema validation passed; 2572 passed, 100 profile-skipped

No manual verification is required; this PR adds no UI, provider call, network handler, or process loop.

## Description for the changelog

Add durable ReminderFire discovery, outbox delivery leases and transitions, worker checkpoints, and restart-safe Turso persistence.
<!-- END:describe_pr:autogen -->
