### PR TITLE
ENG-1181: make OpenCode automation execution reliable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "linear-tools",
  "opencode_rs",
  "pr_comments",
+ "rustix 1.1.4",
  "rustls",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "getrandom 0.3.4",
  "git2",
  "gwt-worktree",
  "linear-tools",

--- a/apps/agentic-outer-dag/CLAUDE.md
+++ b/apps/agentic-outer-dag/CLAUDE.md
@@ -39,6 +39,14 @@ Add any human-authored notes below. Content outside autogen blocks is preserved 
 - OpenCode v1.17.x `POST /session/{id}/command` is completion-coupled rather than enqueue-and-return. Treat that HTTP call as
   dispatch initiation only: once session start is confirmed via SSE, `/session/status`, or bounded transcript evidence, outer-DAG
   must keep supervising via SSE + `/session/status` and treat later `/command` transport failures as non-terminal warnings.
+- Non-dry-run `start` and `resume` are foreground owners. They hold one private per-worktree execution lock through terminal state
+  persistence and through permission/question waits; a concurrent owner or other state-mutating command is rejected.
+- `respond-permission` and `respond-question` are thin clients of the live foreground owner. They send one authenticated,
+  correlation-checked response over a private Unix socket and never start OpenCode, mutate persisted state, or issue `/command`.
+- If the foreground owner exits with an invocation in `prepared`, `post_attempted`, `running_assistant_started`,
+  `paused_permission`, or `paused_question`, `resume` records a conservative manual handoff and never automatically redispatches.
+- During an authorized responder wait, both the inactivity timeout and absolute session deadline are suspended. The original
+  process, server, SSE subscription, session, and completion-coupled command task remain live and resume after the response.
 
 ## Phase 1 live-test ladder (conservative)
 

--- a/apps/agentic-outer-dag/Cargo.toml
+++ b/apps/agentic-outer-dag/Cargo.toml
@@ -57,6 +57,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
 ] }
+rustix = { version = "1", features = ["process"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/agentic-outer-dag/Cargo.toml
+++ b/apps/agentic-outer-dag/Cargo.toml
@@ -31,13 +31,21 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 git2 = { workspace = true, features = ["vendored-openssl", "ssh", "https"] }
+getrandom = "0.3"
 gwt-worktree = { workspace = true }
 linear-tools = { workspace = true }
 opencode_rs = { workspace = true, features = ["server"] }
 pr_comments = { workspace = true }
 sha2 = "0.10"
 thoughts-tool = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = [
+  "io-util",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -8,8 +8,12 @@ use crate::github::coderabbit::skip_reason_indicates_draft;
 use crate::github::pr::DetectedPrLookup;
 use crate::github::pr::GitHubPrClient;
 use crate::linear;
+use crate::opencode::supervisor::InvocationOwnerContext;
 use crate::opencode::supervisor::OpenCodeSupervisor;
+use crate::opencode::supervisor::PreparedCommandOutcome;
+use crate::opencode::supervisor::SessionSelection;
 use crate::opencode::supervisor::SupervisedOutcome;
+use crate::opencode::supervisor::SupervisionEvent;
 use crate::state;
 use crate::state::RunState;
 use crate::state::StageKind;
@@ -19,6 +23,7 @@ use anyhow::Result;
 use pr_comments::github::GitHubRestError;
 use std::fmt::Write as _;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 const DETECTING_PR_BACKOFFS: [Duration; 4] = [
@@ -32,6 +37,7 @@ const SYNC_WITH_MAIN_COMMAND: &str = "sync_with_main_and_resolve_conflicts";
 const RESOLVE_PR_CI_COMMAND: &str = "resolve_pr_ci_failures";
 const REPRESENTATIVE_BOT_THREAD_LIMIT: usize = 5;
 const CI_FAILURE_GRACE_POLLS: u32 = 3;
+const MAX_RESOLVE_START_RETRIES: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReviewThreadRef {
@@ -49,39 +55,6 @@ struct UnresolvedReviewThreadsSnapshot {
 impl UnresolvedReviewThreadsSnapshot {
     fn human_unresolved_threads(&self) -> usize {
         self.total_unresolved.saturating_sub(self.bot_unresolved)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ResolveProgressEvidence {
-    None,
-    AssistantEvidence,
-    UnresolvedThreadsImproved,
-    AssistantAndImproved,
-}
-
-impl ResolveProgressEvidence {
-    fn is_progress(self) -> bool {
-        !matches!(self, Self::None)
-    }
-}
-
-fn classify_resolve_progress(
-    before: &UnresolvedReviewThreadsSnapshot,
-    after: &UnresolvedReviewThreadsSnapshot,
-    diagnostics: Option<&crate::state::OpenCodeDiagnostics>,
-) -> ResolveProgressEvidence {
-    let assistant_evidence = diagnostics
-        .and_then(|diagnostics| diagnostics.final_assistant_message_id.as_deref())
-        .is_some();
-
-    let improved = after.bot_unresolved < before.bot_unresolved || after.bot_unresolved == 0;
-
-    match (assistant_evidence, improved) {
-        (true, true) => ResolveProgressEvidence::AssistantAndImproved,
-        (true, false) => ResolveProgressEvidence::AssistantEvidence,
-        (false, true) => ResolveProgressEvidence::UnresolvedThreadsImproved,
-        (false, false) => ResolveProgressEvidence::None,
     }
 }
 
@@ -133,11 +106,94 @@ fn decide_resolve_pre_dispatch(
     ResolvePreDispatchAction::DispatchResolve
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ResolvePostDispatchAction {
-    ManualHandoff { details: String },
-    ReadyForHumanReview { details: String },
-    LoopAgain { details: String },
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResolveInvocationClass {
+    Completed,
+    AcceptedButNotStarted,
+    FailedOrCancelled,
+    CleanupUncertain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResolveAttemptAction {
+    AdvanceExternalComplete,
+    LoopExternalProgress,
+    RetryStart,
+    ExhaustedStartRetries,
+    ExecutedNoProgress,
+    ManualHandoff,
+}
+
+fn decide_resolve_attempt(
+    before: &UnresolvedReviewThreadsSnapshot,
+    after: &UnresolvedReviewThreadsSnapshot,
+    lifecycle: ResolveInvocationClass,
+    start_retries: u32,
+) -> ResolveAttemptAction {
+    if after.bot_unresolved == 0 {
+        return ResolveAttemptAction::AdvanceExternalComplete;
+    }
+    if after.bot_unresolved < before.bot_unresolved {
+        return ResolveAttemptAction::LoopExternalProgress;
+    }
+
+    match lifecycle {
+        ResolveInvocationClass::AcceptedButNotStarted
+            if start_retries < MAX_RESOLVE_START_RETRIES =>
+        {
+            ResolveAttemptAction::RetryStart
+        }
+        ResolveInvocationClass::AcceptedButNotStarted => {
+            ResolveAttemptAction::ExhaustedStartRetries
+        }
+        ResolveInvocationClass::Completed => ResolveAttemptAction::ExecutedNoProgress,
+        ResolveInvocationClass::FailedOrCancelled | ResolveInvocationClass::CleanupUncertain => {
+            ResolveAttemptAction::ManualHandoff
+        }
+    }
+}
+
+fn current_resolve_invocation_class(state: &RunState) -> ResolveInvocationClass {
+    let Some(invocation) = state.opencode.current_invocation.as_ref() else {
+        return ResolveInvocationClass::CleanupUncertain;
+    };
+    let cleanup_uncertain = invocation
+        .task_disposition
+        .as_ref()
+        .is_none_or(|disposition| !task_disposition_is_certain(disposition));
+    if cleanup_uncertain {
+        return ResolveInvocationClass::CleanupUncertain;
+    }
+
+    match invocation.lifecycle_result.as_ref() {
+        Some(state::InvocationLifecycleResult::Completed) => ResolveInvocationClass::Completed,
+        Some(state::InvocationLifecycleResult::AcceptedButNotStarted) => {
+            ResolveInvocationClass::AcceptedButNotStarted
+        }
+        Some(
+            state::InvocationLifecycleResult::Failed { .. }
+            | state::InvocationLifecycleResult::Cancelled { .. },
+        ) => ResolveInvocationClass::FailedOrCancelled,
+        None => ResolveInvocationClass::CleanupUncertain,
+    }
+}
+
+fn session_selection(active_session_id: Option<&str>) -> SessionSelection {
+    active_session_id.map_or(SessionSelection::Fresh, |session_id| {
+        SessionSelection::Reuse(session_id.to_string())
+    })
+}
+
+fn schedule_resolve_start_retry(state: &mut RunState) {
+    state.opencode.resolve_start_retries = state.opencode.resolve_start_retries.saturating_add(1);
+    state.opencode.active_session_id = None;
+    state.opencode.last_resolve_workflow_outcome =
+        Some(state::ResolveWorkflowOutcome::RetryScheduled);
+    state.stage.kind = StageKind::DispatchingResolvePrComments;
+    state.stage.details = Some(format!(
+        "resolve_pr_comments was accepted but not started; scheduling fresh-session start retry {} of {}",
+        state.opencode.resolve_start_retries, MAX_RESOLVE_START_RETRIES
+    ));
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -145,59 +201,6 @@ enum CiFailureFlow {
     ContinueWaiting,
     DispatchResolve,
     StopManualHandoff,
-}
-
-fn decide_resolve_post_dispatch(
-    before: &UnresolvedReviewThreadsSnapshot,
-    after: &UnresolvedReviewThreadsSnapshot,
-    progress: ResolveProgressEvidence,
-    resolve_comments_runs: u32,
-    max_cycles: u32,
-) -> ResolvePostDispatchAction {
-    if !progress.is_progress() {
-        return ResolvePostDispatchAction::ManualHandoff {
-            details: format!(
-                "resolve_pr_comments completed without progress evidence (no assistant evidence and no unresolved-thread improvement). bot unresolved {}→{}, total unresolved {}→{}, human unresolved {}→{}. Representative bot thread parents: {}",
-                before.bot_unresolved,
-                after.bot_unresolved,
-                before.total_unresolved,
-                after.total_unresolved,
-                before.human_unresolved_threads(),
-                after.human_unresolved_threads(),
-                format_review_thread_refs(&after.representative_bot_refs),
-            ),
-        };
-    }
-
-    if after.bot_unresolved == 0 {
-        return ResolvePostDispatchAction::ReadyForHumanReview {
-            details: format!(
-                "resolved all bot threads after {resolve_comments_runs} evidence-backed resolve cycle(s); remaining unresolved threads total={}; remaining unresolved human threads={}",
-                after.total_unresolved,
-                after.human_unresolved_threads(),
-            ),
-        };
-    }
-
-    if resolve_comments_runs >= max_cycles {
-        return ResolvePostDispatchAction::ManualHandoff {
-            details: format!(
-                "max_review_cycles exhausted: resolve_comments_runs={resolve_comments_runs}/{max_cycles}; unresolved bot threads remaining={}; unresolved human threads remaining={}; representative bot thread parents: {}",
-                after.bot_unresolved,
-                after.human_unresolved_threads(),
-                format_review_thread_refs(&after.representative_bot_refs),
-            ),
-        };
-    }
-
-    ResolvePostDispatchAction::LoopAgain {
-        details: format!(
-            "unresolved bot threads remain ({}); looping resolve_pr_comments cycle {}/{}",
-            after.bot_unresolved,
-            resolve_comments_runs + 1,
-            max_cycles,
-        ),
-    }
 }
 
 async fn fetch_unresolved_review_threads_snapshot(
@@ -248,15 +251,9 @@ async fn fetch_unresolved_review_threads_snapshot(
     })
 }
 
-const _: fn(
-    &UnresolvedReviewThreadsSnapshot,
-    &UnresolvedReviewThreadsSnapshot,
-    Option<&crate::state::OpenCodeDiagnostics>,
-) -> ResolveProgressEvidence = classify_resolve_progress;
-const _: fn(ResolveProgressEvidence) -> bool = ResolveProgressEvidence::is_progress;
-
 pub struct DagEngine {
     supervisor: Option<OpenCodeSupervisor>,
+    owner: Option<Arc<crate::owner::OwnerRuntime>>,
     github: GitHubPrClient,
     coderabbit: CodeRabbitClient,
     ci: RequiredCiClient,
@@ -831,10 +828,17 @@ impl DagEngine {
     pub fn for_current_dir() -> Result<Self> {
         Ok(Self {
             supervisor: None,
+            owner: None,
             github: GitHubPrClient::new()?,
             coderabbit: CodeRabbitClient::new()?,
             ci: RequiredCiClient::new(),
         })
+    }
+
+    pub fn for_current_dir_with_owner(owner: Arc<crate::owner::OwnerRuntime>) -> Result<Self> {
+        let mut engine = Self::for_current_dir()?;
+        engine.owner = Some(owner);
+        Ok(engine)
     }
 
     pub async fn run_until_stop(&mut self, stop_after: Option<StageKind>) -> Result<()> {
@@ -1111,12 +1115,18 @@ impl DagEngine {
                             max_cycles,
                         ) {
                             ResolvePreDispatchAction::ReadyForHumanReview { details } => {
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::Skipped);
                                 state.stage.kind = StageKind::DispatchingDescribePr;
                                 state.stage.details = Some(details);
                                 ThoughtsStateStore::save(&state)?;
                                 break;
                             }
                             ResolvePreDispatchAction::ManualHandoff { details } => {
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::ManualHandoff);
                                 state.stage.kind = StageKind::StoppedManualHandoff;
                                 state.stage.details = Some(details);
                                 ThoughtsStateStore::save(&state)?;
@@ -1155,39 +1165,79 @@ impl DagEngine {
                             }
                         };
 
-                        let progress = classify_resolve_progress(
+                        let lifecycle = current_resolve_invocation_class(&state);
+                        match decide_resolve_attempt(
                             &before,
                             &after,
-                            state.opencode.last_diagnostics.as_ref(),
-                        );
-
-                        if progress.is_progress() {
-                            state.counters.resolve_comments += 1;
-                        }
-
-                        match decide_resolve_post_dispatch(
-                            &before,
-                            &after,
-                            progress,
-                            state.counters.resolve_comments,
-                            max_cycles,
+                            lifecycle,
+                            state.opencode.resolve_start_retries,
                         ) {
-                            ResolvePostDispatchAction::ManualHandoff { details } => {
-                                state.stage.kind = StageKind::StoppedManualHandoff;
-                                state.stage.details = Some(details);
-                                ThoughtsStateStore::save(&state)?;
-                                return Ok(());
-                            }
-                            ResolvePostDispatchAction::ReadyForHumanReview { details } => {
+                            ResolveAttemptAction::AdvanceExternalComplete => {
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::ExternalProgress);
                                 state.stage.kind = StageKind::DispatchingDescribePr;
-                                state.stage.details = Some(details);
+                                state.stage.details = Some(format!(
+                                    "CodeRabbit postcondition reached zero unresolved bot threads after resolve_pr_comments (before: {}, after: {}; lifecycle: {lifecycle:?})",
+                                    before.bot_unresolved, after.bot_unresolved
+                                ));
                                 ThoughtsStateStore::save(&state)?;
                                 break;
                             }
-                            ResolvePostDispatchAction::LoopAgain { details } => {
+                            ResolveAttemptAction::LoopExternalProgress => {
+                                state.counters.resolve_comments += 1;
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::ExternalProgress);
                                 state.stage.kind = StageKind::DispatchingResolvePrComments;
-                                state.stage.details = Some(details);
+                                state.stage.details = Some(format!(
+                                    "CodeRabbit unresolved bot threads decreased (before: {}, after: {}; lifecycle: {lifecycle:?}); continuing resolve cycle {} of {}",
+                                    before.bot_unresolved,
+                                    after.bot_unresolved,
+                                    state.counters.resolve_comments,
+                                    max_cycles
+                                ));
                                 ThoughtsStateStore::save(&state)?;
+                            }
+                            ResolveAttemptAction::RetryStart => {
+                                schedule_resolve_start_retry(&mut state);
+                                ThoughtsStateStore::save(&state)?;
+                            }
+                            ResolveAttemptAction::ExhaustedStartRetries => {
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::RetriesExhausted);
+                                state.opencode.resolve_start_retries = 0;
+                                state.stage.kind = StageKind::StoppedManualHandoff;
+                                state.stage.details = Some(format!(
+                                    "resolve_pr_comments exhausted {} fresh-session start retries after the initial attempt; unresolved bot threads unchanged at {}",
+                                    MAX_RESOLVE_START_RETRIES, after.bot_unresolved
+                                ));
+                                ThoughtsStateStore::save(&state)?;
+                                return Ok(());
+                            }
+                            ResolveAttemptAction::ExecutedNoProgress => {
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::ExecutedNoProgress);
+                                state.stage.kind = StageKind::StoppedManualHandoff;
+                                state.stage.details = Some(format!(
+                                    "resolve_pr_comments executed with current-command assistant evidence but unresolved bot threads did not decrease (before: {}, after: {})",
+                                    before.bot_unresolved, after.bot_unresolved
+                                ));
+                                ThoughtsStateStore::save(&state)?;
+                                return Ok(());
+                            }
+                            ResolveAttemptAction::ManualHandoff => {
+                                state.opencode.resolve_start_retries = 0;
+                                state.opencode.last_resolve_workflow_outcome =
+                                    Some(state::ResolveWorkflowOutcome::ManualHandoff);
+                                state.stage.kind = StageKind::StoppedManualHandoff;
+                                state.stage.details = Some(format!(
+                                    "resolve_pr_comments lifecycle failed or cleanup was uncertain; unresolved bot threads unchanged at {}",
+                                    after.bot_unresolved
+                                ));
+                                ThoughtsStateStore::save(&state)?;
+                                return Ok(());
                             }
                         }
                     }
@@ -1507,65 +1557,113 @@ impl DagEngine {
             ])
             .await?;
         state.opencode.resume_stage = Some(resume_stage.clone());
-        state.opencode.dispatch_attempt += 1;
         state.opencode.last_command = Some(command_name.to_string());
-        ThoughtsStateStore::save(state)?;
-
-        let outcome = self
+        let session_selection = session_selection(state.opencode.active_session_id.as_deref());
+        let prepared = match self
             .supervisor(&state.settings)
             .await?
-            .run_command_supervised(
-                state.opencode.active_session_id.as_deref(),
-                command_name,
-                message,
+            .prepare_command(session_selection, command_name, message)
+            .await?
+        {
+            PreparedCommandOutcome::Prepared(prepared) => prepared,
+            PreparedCommandOutcome::Interrupted(outcome) => {
+                apply_supervised_outcome(state, resume_stage, command_name, outcome);
+                return ThoughtsStateStore::save(state);
+            }
+        };
+
+        state.opencode.active_session_id = Some(prepared.session_id().to_string());
+        state.opencode.current_invocation = Some(state::OpenCodeInvocationState {
+            invocation_id: format!("invocation-{}", prepared.command_message_id()),
+            command: prepared.command_name().to_string(),
+            session_id: prepared.session_id().to_string(),
+            command_message_id: prepared.command_message_id().to_string(),
+            phase: state::OpenCodeInvocationPhase::Prepared,
+            literal_post_attempts: 0,
+            lifecycle_result: None,
+            task_disposition: None,
+            pending_interruption: None,
+        });
+        ThoughtsStateStore::save(state)?;
+        if let Some(invocation) = state.opencode.current_invocation.as_mut() {
+            invocation.phase = state::OpenCodeInvocationPhase::PostAttempted;
+        }
+        ThoughtsStateStore::save(state)?;
+
+        let settings = state.settings.clone();
+        let owner = self.owner.clone();
+        let owner_context = state
+            .opencode
+            .current_invocation
+            .as_ref()
+            .map(|invocation| InvocationOwnerContext {
+                run_id: state.run_id.clone(),
+                invocation_id: invocation.invocation_id.clone(),
+            });
+        let event_resume_stage = resume_stage.clone();
+        let outcome = self
+            .supervisor(&settings)
+            .await?
+            .run_prepared_command(
+                prepared,
+                owner.as_deref(),
+                owner_context.as_ref(),
+                |event| {
+                let invocation = state.opencode.current_invocation.as_mut().ok_or_else(|| {
+                    anyhow::anyhow!("current invocation disappeared during supervision")
+                })?;
+                match event {
+                    SupervisionEvent::LiteralPostAttempt { total } => {
+                        let new_attempts = total.saturating_sub(invocation.literal_post_attempts);
+                        state.opencode.dispatch_attempt =
+                            state.opencode.dispatch_attempt.saturating_add(new_attempts);
+                        invocation.literal_post_attempts = total;
+                    }
+                    SupervisionEvent::AssistantStarted { .. } => {
+                        invocation.phase = state::OpenCodeInvocationPhase::RunningAssistantStarted;
+                    }
+                    SupervisionEvent::Paused { kind, request_id } => {
+                        state.opencode.pending_permission = None;
+                        state.opencode.pending_question = None;
+                        invocation.phase = match kind {
+                            state::InterruptionKind::Permission => {
+                                state.stage.kind = StageKind::StoppedPermissionRequired;
+                                state.stage.details = Some(
+                                    "foreground OpenCode invocation is awaiting an authenticated permission response"
+                                        .to_string(),
+                                );
+                                state::OpenCodeInvocationPhase::PausedPermission
+                            }
+                            state::InterruptionKind::Question => {
+                                state.stage.kind = StageKind::StoppedQuestionRequired;
+                                state.stage.details = Some(
+                                    "foreground OpenCode invocation is awaiting an authenticated question response"
+                                        .to_string(),
+                                );
+                                state::OpenCodeInvocationPhase::PausedQuestion
+                            }
+                        };
+                        invocation.pending_interruption =
+                            Some(state::PendingInterruptionIdentity { kind, request_id });
+                    }
+                    SupervisionEvent::Resumed { assistant_started } => {
+                        state.stage.kind = event_resume_stage.clone();
+                        state.stage.details = None;
+                        state.opencode.pending_permission = None;
+                        state.opencode.pending_question = None;
+                        invocation.phase = if assistant_started {
+                            state::OpenCodeInvocationPhase::RunningAssistantStarted
+                        } else {
+                            state::OpenCodeInvocationPhase::PostAttempted
+                        };
+                        invocation.pending_interruption = None;
+                    }
+                }
+                ThoughtsStateStore::save(state)
+            },
             )
             .await?;
-        match outcome {
-            SupervisedOutcome::Completed {
-                session_id,
-                diagnostics,
-            } => {
-                state.opencode.active_session_id = Some(session_id);
-                state.opencode.last_diagnostics = Some(diagnostics);
-                state.opencode.pending_permission = None;
-                state.opencode.pending_question = None;
-                state.stage.kind = resume_stage;
-                state.stage.details = None;
-            }
-            SupervisedOutcome::PermissionRequired {
-                session_id,
-                request_id,
-                permission_type,
-            } => {
-                state.opencode.active_session_id = Some(session_id);
-                state.opencode.pending_permission = Some(state::PendingPermission {
-                    request_id,
-                    permission_type,
-                });
-                state.stage.kind = StageKind::StoppedPermissionRequired;
-                state.stage.details = Some("OpenCode permission response required".to_string());
-            }
-            SupervisedOutcome::QuestionRequired {
-                session_id,
-                request_id,
-                prompt,
-            } => {
-                state.opencode.active_session_id = Some(session_id);
-                state.opencode.pending_question =
-                    Some(state::PendingQuestion { request_id, prompt });
-                state.stage.kind = StageKind::StoppedQuestionRequired;
-                state.stage.details = Some("OpenCode question response required".to_string());
-            }
-            SupervisedOutcome::Failed {
-                session_id,
-                error,
-                diagnostics,
-            } => {
-                state.opencode.active_session_id = session_id;
-                state.opencode.last_diagnostics = diagnostics;
-                transition_to_stopped_failed(state, error);
-            }
-        }
+        apply_supervised_outcome(state, resume_stage, command_name, outcome);
         ThoughtsStateStore::save(state)
     }
 
@@ -1586,6 +1684,189 @@ impl DagEngine {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("supervisor should be initialized before use"))
     }
+}
+
+fn apply_supervised_outcome(
+    state: &mut RunState,
+    resume_stage: StageKind,
+    command_name: &str,
+    outcome: SupervisedOutcome,
+) {
+    match outcome {
+        SupervisedOutcome::Completed {
+            session_id,
+            diagnostics,
+            literal_post_attempts,
+            task_disposition,
+        } => {
+            state.opencode.active_session_id = Some(session_id);
+            state.opencode.last_diagnostics = Some(diagnostics);
+            terminalize_persisted_invocation(
+                state,
+                literal_post_attempts,
+                state::InvocationLifecycleResult::Completed,
+                task_disposition,
+            );
+            state.opencode.pending_permission = None;
+            state.opencode.pending_question = None;
+            state.stage.kind = resume_stage;
+            state.stage.details = None;
+        }
+        SupervisedOutcome::AcceptedButNotStarted {
+            session_id: _,
+            diagnostics,
+            literal_post_attempts,
+            task_disposition,
+        } => {
+            let invocation_id = state
+                .opencode
+                .current_invocation
+                .as_ref()
+                .map(|invocation| invocation.invocation_id.clone())
+                .unwrap_or_default();
+            state.opencode.active_session_id = None;
+            state.opencode.last_diagnostics = Some(diagnostics);
+            terminalize_persisted_invocation(
+                state,
+                literal_post_attempts,
+                state::InvocationLifecycleResult::AcceptedButNotStarted,
+                task_disposition,
+            );
+            state.opencode.last_lifecycle_anomaly = Some(state::InvocationLifecycleAnomaly {
+                invocation_id,
+                observed_at: chrono::Utc::now().to_rfc3339(),
+                kind: state::InvocationLifecycleAnomalyKind::AcceptedButNotStarted,
+            });
+            if command_name == "resolve_pr_comments" {
+                state.stage.kind = resume_stage;
+                state.stage.details = Some(
+                        "OpenCode accepted resolve_pr_comments but no current-command assistant execution started"
+                            .to_string(),
+                    );
+            } else {
+                transition_to_stopped_failed(
+                    state,
+                    format!(
+                        "OpenCode accepted command '{command_name}' but no current-command assistant execution started"
+                    ),
+                );
+            }
+        }
+        SupervisedOutcome::PermissionRequired {
+            session_id,
+            request_id,
+            permission_type,
+            literal_post_attempts,
+        } => {
+            state.opencode.active_session_id = Some(session_id);
+            if let Some(invocation) = state.opencode.current_invocation.as_mut() {
+                invocation.phase = state::OpenCodeInvocationPhase::PausedPermission;
+                invocation.literal_post_attempts = literal_post_attempts;
+                invocation.pending_interruption = Some(state::PendingInterruptionIdentity {
+                    kind: state::InterruptionKind::Permission,
+                    request_id: request_id.clone(),
+                });
+            }
+            state.opencode.pending_permission = Some(state::PendingPermission {
+                request_id,
+                permission_type,
+            });
+            state.stage.kind = StageKind::StoppedPermissionRequired;
+            state.stage.details = Some("OpenCode permission response required".to_string());
+        }
+        SupervisedOutcome::QuestionRequired {
+            session_id,
+            request_id,
+            prompt,
+            literal_post_attempts,
+        } => {
+            state.opencode.active_session_id = Some(session_id);
+            if let Some(invocation) = state.opencode.current_invocation.as_mut() {
+                invocation.phase = state::OpenCodeInvocationPhase::PausedQuestion;
+                invocation.literal_post_attempts = literal_post_attempts;
+                invocation.pending_interruption = Some(state::PendingInterruptionIdentity {
+                    kind: state::InterruptionKind::Question,
+                    request_id: request_id.clone(),
+                });
+            }
+            state.opencode.pending_question = Some(state::PendingQuestion { request_id, prompt });
+            state.stage.kind = StageKind::StoppedQuestionRequired;
+            state.stage.details = Some("OpenCode question response required".to_string());
+        }
+        SupervisedOutcome::Failed {
+            session_id,
+            error,
+            diagnostics,
+            literal_post_attempts,
+            failure,
+            task_disposition,
+        } => {
+            let cleanup_proven = task_disposition_is_certain(&task_disposition);
+            let invocation_id = state
+                .opencode
+                .current_invocation
+                .as_ref()
+                .map(|invocation| invocation.invocation_id.clone())
+                .unwrap_or_default();
+            state.opencode.active_session_id = session_id;
+            state.opencode.last_diagnostics = diagnostics;
+            terminalize_persisted_invocation(
+                state,
+                literal_post_attempts,
+                state::InvocationLifecycleResult::Failed {
+                    failure: failure.clone(),
+                },
+                task_disposition,
+            );
+            state.opencode.last_lifecycle_anomaly = Some(state::InvocationLifecycleAnomaly {
+                invocation_id,
+                observed_at: chrono::Utc::now().to_rfc3339(),
+                kind: state::InvocationLifecycleAnomalyKind::Failed { failure },
+            });
+            if command_name == "resolve_pr_comments" && cleanup_proven {
+                state.stage.kind = resume_stage;
+                state.stage.details = Some(format!(
+                    "resolve_pr_comments failed after explicit terminal cleanup; checking CodeRabbit postconditions: {error}"
+                ));
+            } else {
+                transition_to_stopped_failed(state, error);
+            }
+        }
+    }
+}
+
+fn terminalize_persisted_invocation(
+    state: &mut RunState,
+    literal_post_attempts: u32,
+    lifecycle_result: state::InvocationLifecycleResult,
+    task_disposition: state::TaskDisposition,
+) {
+    let persisted_attempts = state
+        .opencode
+        .current_invocation
+        .as_ref()
+        .map_or(0, |invocation| invocation.literal_post_attempts);
+    state.opencode.dispatch_attempt = state
+        .opencode
+        .dispatch_attempt
+        .saturating_add(literal_post_attempts.saturating_sub(persisted_attempts));
+    if let Some(invocation) = state.opencode.current_invocation.as_mut() {
+        invocation.phase = state::OpenCodeInvocationPhase::Terminal;
+        invocation.literal_post_attempts = literal_post_attempts;
+        invocation.lifecycle_result = Some(lifecycle_result);
+        invocation.task_disposition = Some(task_disposition);
+        invocation.pending_interruption = None;
+    }
+}
+
+fn task_disposition_is_certain(disposition: &state::TaskDisposition) -> bool {
+    !matches!(
+        disposition.server_abort,
+        state::ServerAbortDisposition::Failed { .. }
+    ) && !matches!(
+        disposition.local_task,
+        state::LocalTaskDisposition::NotStarted | state::LocalTaskDisposition::Spawned
+    )
 }
 
 async fn detect_pr_with_retry<Lookup, LookupFut, OnRetry, Sleep, SleepFut>(
@@ -1626,14 +1907,14 @@ mod tests {
     use super::DagEngine;
     use super::DescribePrRefreshDecision;
     use super::DraftSkipRecovery;
-    use super::ResolvePostDispatchAction;
+    use super::MAX_RESOLVE_START_RETRIES;
+    use super::ResolveAttemptAction;
+    use super::ResolveInvocationClass;
     use super::ResolvePreDispatchAction;
-    use super::ResolveProgressEvidence;
     use super::UnresolvedReviewThreadsSnapshot;
     use super::baseline_last_described_head_sha_after_pr_create;
-    use super::classify_resolve_progress;
     use super::coderabbit_waiting_details;
-    use super::decide_resolve_post_dispatch;
+    use super::decide_resolve_attempt;
     use super::decide_resolve_pre_dispatch;
     use super::detecting_pr_retry_attempt_number;
     use super::ensure_pr_ready_for_review;
@@ -1648,14 +1929,17 @@ mod tests {
     use super::recover_from_check_suite_no_commit_found_422;
     use super::recover_from_draft_review_skip;
     use super::route_after_ci_remediation;
+    use super::schedule_resolve_start_retry;
+    use super::session_selection;
     use super::should_reset_coderabbit_timeout_baseline;
     use super::stage_kind_label;
+    use super::terminalize_persisted_invocation;
     use super::transition_to_dispatch_disabled;
     use super::transition_to_stopped_failed;
     use super::transition_to_ticket_to_pr_no_pr_handoff;
     use crate::github::ci::GhCheck;
     use crate::github::pr::DetectedPrLookup;
-    use crate::state::OpenCodeDiagnostics;
+    use crate::opencode::supervisor::SessionSelection;
     use crate::state::RunState;
     use crate::state::StageKind;
     use crate::test_support::process_state_lock;
@@ -1714,25 +1998,6 @@ mod tests {
         }
     }
 
-    fn sample_review_thread_ref(comment_id: u64) -> super::ReviewThreadRef {
-        super::ReviewThreadRef {
-            comment_id,
-            url: format!("https://example.invalid/comments/{comment_id}"),
-        }
-    }
-
-    fn sample_diagnostics(final_assistant_message_id: Option<&str>) -> OpenCodeDiagnostics {
-        OpenCodeDiagnostics {
-            checked_at: "2026-01-01T00:00:00Z".to_string(),
-            command_message_id: Some("msg-command".to_string()),
-            final_assistant_message_id: final_assistant_message_id.map(str::to_string),
-            final_finish_reason: None,
-            guard_detected: false,
-            final_tool_error: None,
-            command_transport_error: None,
-        }
-    }
-
     fn sample_ci_check(name: &str, state: &str) -> GhCheck {
         GhCheck {
             name: name.to_string(),
@@ -1750,47 +2015,170 @@ mod tests {
     }
 
     #[test]
-    fn classify_resolve_progress_requires_assistant_or_improvement() {
-        let before = sample_unresolved_snapshot(7, 5);
-        let after = sample_unresolved_snapshot(7, 5);
+    fn resolve_attempt_routes_external_zero_before_lifecycle_anomaly() {
+        let before = sample_unresolved_snapshot(5, 3);
+        let after = sample_unresolved_snapshot(2, 0);
 
         assert_eq!(
-            classify_resolve_progress(&before, &after, None),
-            ResolveProgressEvidence::None
+            decide_resolve_attempt(
+                &before,
+                &after,
+                ResolveInvocationClass::AcceptedButNotStarted,
+                MAX_RESOLVE_START_RETRIES,
+            ),
+            ResolveAttemptAction::AdvanceExternalComplete
         );
     }
 
     #[test]
-    fn classify_resolve_progress_accepts_assistant_evidence() {
-        let before = sample_unresolved_snapshot(7, 5);
-        let after = sample_unresolved_snapshot(7, 5);
-        let diagnostics = sample_diagnostics(Some("msg-assistant"));
+    fn resolve_attempt_routes_external_decrease_before_failed_lifecycle() {
+        let before = sample_unresolved_snapshot(5, 4);
+        let after = sample_unresolved_snapshot(4, 3);
 
         assert_eq!(
-            classify_resolve_progress(&before, &after, Some(&diagnostics)),
-            ResolveProgressEvidence::AssistantEvidence
+            decide_resolve_attempt(
+                &before,
+                &after,
+                ResolveInvocationClass::FailedOrCancelled,
+                1,
+            ),
+            ResolveAttemptAction::LoopExternalProgress
         );
     }
 
     #[test]
-    fn classify_resolve_progress_accepts_thread_improvement_without_assistant() {
-        let before = sample_unresolved_snapshot(5, 5);
-        let after = sample_unresolved_snapshot(5, 3);
+    fn resolve_attempt_allows_exactly_two_start_retries_then_exhausts() {
+        let before = sample_unresolved_snapshot(4, 3);
+        let after = sample_unresolved_snapshot(4, 3);
 
         assert_eq!(
-            classify_resolve_progress(&before, &after, None),
-            ResolveProgressEvidence::UnresolvedThreadsImproved
+            decide_resolve_attempt(
+                &before,
+                &after,
+                ResolveInvocationClass::AcceptedButNotStarted,
+                0,
+            ),
+            ResolveAttemptAction::RetryStart
+        );
+        assert_eq!(
+            decide_resolve_attempt(
+                &before,
+                &after,
+                ResolveInvocationClass::AcceptedButNotStarted,
+                1,
+            ),
+            ResolveAttemptAction::RetryStart
+        );
+        assert_eq!(
+            decide_resolve_attempt(
+                &before,
+                &after,
+                ResolveInvocationClass::AcceptedButNotStarted,
+                2,
+            ),
+            ResolveAttemptAction::ExhaustedStartRetries
         );
     }
 
     #[test]
-    fn classify_resolve_progress_ignores_human_only_total_unresolved_drop() {
-        let before = sample_unresolved_snapshot(7, 5);
-        let after = sample_unresolved_snapshot(5, 5);
+    fn resolve_attempt_executed_without_external_progress_hands_off() {
+        let before = sample_unresolved_snapshot(4, 3);
+        let after = sample_unresolved_snapshot(4, 3);
 
         assert_eq!(
-            classify_resolve_progress(&before, &after, None),
-            ResolveProgressEvidence::None
+            decide_resolve_attempt(&before, &after, ResolveInvocationClass::Completed, 0),
+            ResolveAttemptAction::ExecutedNoProgress
+        );
+    }
+
+    #[test]
+    fn resolve_attempt_uncertain_cleanup_never_retries() {
+        let before = sample_unresolved_snapshot(4, 3);
+        let after = sample_unresolved_snapshot(4, 3);
+
+        assert_eq!(
+            decide_resolve_attempt(&before, &after, ResolveInvocationClass::CleanupUncertain, 0,),
+            ResolveAttemptAction::ManualHandoff
+        );
+    }
+
+    #[test]
+    fn terminal_persistence_reconciles_unobserved_literal_post_attempts_once() {
+        let mut state = sample_state();
+        state.opencode.dispatch_attempt = 7;
+        state.opencode.current_invocation = Some(crate::state::OpenCodeInvocationState {
+            invocation_id: "inv-1".to_string(),
+            command: "resolve_pr_comments".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            phase: crate::state::OpenCodeInvocationPhase::PostAttempted,
+            literal_post_attempts: 1,
+            lifecycle_result: None,
+            task_disposition: None,
+            pending_interruption: None,
+        });
+        let disposition = crate::state::TaskDisposition {
+            server_abort: crate::state::ServerAbortDisposition::NotRequired,
+            local_task: crate::state::LocalTaskDisposition::Completed,
+        };
+
+        terminalize_persisted_invocation(
+            &mut state,
+            2,
+            crate::state::InvocationLifecycleResult::Completed,
+            disposition.clone(),
+        );
+        assert_eq!(state.opencode.dispatch_attempt, 8);
+        assert_eq!(
+            state
+                .opencode
+                .current_invocation
+                .as_ref()
+                .map(|invocation| invocation.literal_post_attempts),
+            Some(2)
+        );
+
+        terminalize_persisted_invocation(
+            &mut state,
+            2,
+            crate::state::InvocationLifecycleResult::Completed,
+            disposition,
+        );
+        assert_eq!(state.opencode.dispatch_attempt, 8);
+    }
+
+    #[test]
+    fn resolve_start_retry_forces_fresh_session_without_charging_cycle_counters() {
+        let mut state = sample_state();
+        state.opencode.active_session_id = Some("old-session".to_string());
+        state.opencode.resolve_start_retries = 1;
+        state.opencode.dispatch_attempt = 9;
+        state.counters.resolve_comments = 3;
+        state.opencode.last_lifecycle_anomaly = Some(crate::state::InvocationLifecycleAnomaly {
+            invocation_id: "inv-1".to_string(),
+            observed_at: "2026-01-01T00:00:00Z".to_string(),
+            kind: crate::state::InvocationLifecycleAnomalyKind::AcceptedButNotStarted,
+        });
+
+        schedule_resolve_start_retry(&mut state);
+
+        assert_eq!(state.opencode.resolve_start_retries, 2);
+        assert_eq!(state.opencode.active_session_id, None);
+        assert_eq!(state.opencode.dispatch_attempt, 9);
+        assert_eq!(state.counters.resolve_comments, 3);
+        assert!(state.opencode.last_lifecycle_anomaly.is_some());
+        assert_eq!(
+            session_selection(state.opencode.active_session_id.as_deref()),
+            SessionSelection::Fresh
+        );
+    }
+
+    #[test]
+    fn normal_session_selection_reuses_only_explicit_active_session() {
+        assert_eq!(session_selection(None), SessionSelection::Fresh);
+        assert_eq!(
+            session_selection(Some("session-1")),
+            SessionSelection::Reuse("session-1".to_string())
         );
     }
 
@@ -1814,34 +2202,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_loop_stops_manual_handoff_on_no_assistant_and_no_improvement() {
-        let before = UnresolvedReviewThreadsSnapshot {
-            total_unresolved: 4,
-            bot_unresolved: 3,
-            representative_bot_refs: vec![sample_review_thread_ref(101)],
-        };
-        let after = UnresolvedReviewThreadsSnapshot {
-            total_unresolved: 4,
-            bot_unresolved: 3,
-            representative_bot_refs: vec![sample_review_thread_ref(101)],
-        };
-        let progress = classify_resolve_progress(&before, &after, None);
-
-        let action = decide_resolve_post_dispatch(&before, &after, progress, 2, 5);
-
-        let ResolvePostDispatchAction::ManualHandoff { details } = action else {
-            panic!("expected manual handoff");
-        };
-        assert!(details.contains("bot unresolved 3→3"));
-        assert!(details.contains("https://example.invalid/comments/101"));
-    }
-
-    #[test]
     fn resolve_loop_enforces_max_review_cycles_exhaustion() {
         let before = UnresolvedReviewThreadsSnapshot {
             total_unresolved: 4,
             bot_unresolved: 3,
-            representative_bot_refs: vec![sample_review_thread_ref(202)],
+            representative_bot_refs: Vec::new(),
         };
 
         let action = decide_resolve_pre_dispatch(&before, 5, 5);
@@ -1850,25 +2215,6 @@ mod tests {
             panic!("expected manual handoff");
         };
         assert!(details.contains("max_review_cycles exhausted"));
-    }
-
-    #[test]
-    fn resolve_loop_continues_when_progress_and_unresolved_remain_and_cycles_left() {
-        let before = sample_unresolved_snapshot(5, 4);
-        let after = sample_unresolved_snapshot(4, 3);
-
-        let action = decide_resolve_post_dispatch(
-            &before,
-            &after,
-            ResolveProgressEvidence::UnresolvedThreadsImproved,
-            2,
-            5,
-        );
-
-        assert!(matches!(
-            action,
-            ResolvePostDispatchAction::LoopAgain { .. }
-        ));
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/dag/engine.rs
+++ b/apps/agentic-outer-dag/src/dag/engine.rs
@@ -1567,7 +1567,7 @@ impl DagEngine {
         {
             PreparedCommandOutcome::Prepared(prepared) => prepared,
             PreparedCommandOutcome::Interrupted(outcome) => {
-                apply_supervised_outcome(state, resume_stage, command_name, outcome);
+                apply_preflight_interruption(state, resume_stage, command_name, outcome);
                 return ThoughtsStateStore::save(state);
             }
         };
@@ -1684,6 +1684,16 @@ impl DagEngine {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("supervisor should be initialized before use"))
     }
+}
+
+fn apply_preflight_interruption(
+    state: &mut RunState,
+    resume_stage: StageKind,
+    command_name: &str,
+    outcome: SupervisedOutcome,
+) {
+    state.opencode.current_invocation = None;
+    apply_supervised_outcome(state, resume_stage, command_name, outcome);
 }
 
 fn apply_supervised_outcome(
@@ -1912,6 +1922,7 @@ mod tests {
     use super::ResolveInvocationClass;
     use super::ResolvePreDispatchAction;
     use super::UnresolvedReviewThreadsSnapshot;
+    use super::apply_preflight_interruption;
     use super::baseline_last_described_head_sha_after_pr_create;
     use super::coderabbit_waiting_details;
     use super::decide_resolve_attempt;
@@ -1940,6 +1951,7 @@ mod tests {
     use crate::github::ci::GhCheck;
     use crate::github::pr::DetectedPrLookup;
     use crate::opencode::supervisor::SessionSelection;
+    use crate::opencode::supervisor::SupervisedOutcome;
     use crate::state::RunState;
     use crate::state::StageKind;
     use crate::test_support::process_state_lock;
@@ -1974,6 +1986,81 @@ mod tests {
             false,
         )
         .expect("sample state builds")
+    }
+
+    fn set_previous_terminal_invocation(state: &mut RunState) {
+        state.opencode.current_invocation = Some(crate::state::OpenCodeInvocationState {
+            invocation_id: "previous-invocation".to_string(),
+            command: "previous_command".to_string(),
+            session_id: "previous-session".to_string(),
+            command_message_id: "previous-message".to_string(),
+            phase: crate::state::OpenCodeInvocationPhase::Terminal,
+            literal_post_attempts: 1,
+            lifecycle_result: Some(crate::state::InvocationLifecycleResult::Completed),
+            task_disposition: Some(crate::state::TaskDisposition {
+                server_abort: crate::state::ServerAbortDisposition::NotRequired,
+                local_task: crate::state::LocalTaskDisposition::Completed,
+            }),
+            pending_interruption: None,
+        });
+    }
+
+    #[test]
+    fn permission_preflight_does_not_mutate_previous_invocation() {
+        let mut state = sample_state();
+        set_previous_terminal_invocation(&mut state);
+
+        apply_preflight_interruption(
+            &mut state,
+            StageKind::DispatchingTicketToPr,
+            "linear_ticket_2_pr",
+            SupervisedOutcome::PermissionRequired {
+                session_id: "next-session".to_string(),
+                request_id: "permission-1".to_string(),
+                permission_type: "file.write".to_string(),
+                literal_post_attempts: 0,
+            },
+        );
+
+        assert!(state.opencode.current_invocation.is_none());
+        assert_eq!(
+            state
+                .opencode
+                .pending_permission
+                .as_ref()
+                .map(|pending| pending.request_id.as_str()),
+            Some("permission-1")
+        );
+        assert_eq!(state.stage.kind, StageKind::StoppedPermissionRequired);
+    }
+
+    #[test]
+    fn question_preflight_does_not_mutate_previous_invocation() {
+        let mut state = sample_state();
+        set_previous_terminal_invocation(&mut state);
+
+        apply_preflight_interruption(
+            &mut state,
+            StageKind::DispatchingResolvePrComments,
+            "resolve_pr_comments",
+            SupervisedOutcome::QuestionRequired {
+                session_id: "next-session".to_string(),
+                request_id: "question-1".to_string(),
+                prompt: "Continue?".to_string(),
+                literal_post_attempts: 0,
+            },
+        );
+
+        assert!(state.opencode.current_invocation.is_none());
+        assert_eq!(
+            state
+                .opencode
+                .pending_question
+                .as_ref()
+                .map(|pending| pending.request_id.as_str()),
+            Some("question-1")
+        );
+        assert_eq!(state.stage.kind, StageKind::StoppedQuestionRequired);
     }
 
     fn check_suites_422_error(head_sha: &str) -> anyhow::Error {

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -18,6 +18,7 @@ mod dag;
 mod github;
 mod linear;
 mod opencode;
+mod owner;
 mod preview;
 mod progress;
 mod state;
@@ -76,6 +77,7 @@ fn ensure_supported_dry_run_usage(dry_run: bool, command: &cli::Commands) -> Res
     }
 }
 
+#[cfg(test)]
 fn require_actionable_resume_stage(state: &state::RunState) -> Result<state::StageKind> {
     let resume_stage = state.opencode.resume_stage.clone().ok_or_else(|| {
         anyhow::anyhow!(
@@ -89,6 +91,16 @@ fn require_actionable_resume_stage(state: &state::RunState) -> Result<state::Sta
     );
 
     Ok(resume_stage)
+}
+
+fn has_recovered_nonterminal_invocation(state: &state::RunState) -> bool {
+    state
+        .opencode
+        .current_invocation
+        .as_ref()
+        .is_some_and(|invocation| {
+            !matches!(invocation.phase, state::OpenCodeInvocationPhase::Terminal)
+        })
 }
 
 #[tokio::main]
@@ -192,11 +204,9 @@ async fn main() -> Result<()> {
         }
         cli::Commands::Status { json } => handle_status(json),
         cli::Commands::RespondPermission { allow, deny } => {
-            handle_respond_permission(allow, deny, final_only).await
+            handle_respond_permission(allow, deny).await
         }
-        cli::Commands::RespondQuestion { answer } => {
-            handle_respond_question(&answer, final_only).await
-        }
+        cli::Commands::RespondQuestion { answer } => handle_respond_question(&answer).await,
         cli::Commands::Handoff { message } => handle_handoff(message.as_deref()).await,
         cli::Commands::Reset { yes } => handle_reset(yes),
     }
@@ -324,6 +334,7 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
 
     let target = worktree::resolve(effective_branch.as_deref(), options.worktree_path, true)?;
     worktree::chdir_to(&target)?;
+    let owner = Arc::new(owner::OwnerRuntime::acquire(Path::new("."))?);
 
     if state::store::ThoughtsStateStore::load()?.is_some() && !options.force {
         anyhow::bail!(
@@ -346,7 +357,7 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
     )?;
     state::store::ThoughtsStateStore::save(&state)?;
 
-    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    let mut engine = dag::engine::DagEngine::for_current_dir_with_owner(Arc::clone(&owner))?;
     run_engine_until_stop_with_progress(&mut engine, options.stop_after, options.final_only)
         .await?;
     let state = state::store::ThoughtsStateStore::load()?
@@ -357,9 +368,21 @@ async fn handle_start(ticket: &str, options: StartOptions<'_>) -> Result<()> {
 async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
     let target = worktree::resolve(options.branch, options.worktree_path, false)?;
     worktree::chdir_to(&target)?;
+    let owner = Arc::new(owner::OwnerRuntime::acquire(Path::new("."))?);
 
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
+    if has_recovered_nonterminal_invocation(&state) {
+        state.stage.kind = state::StageKind::StoppedManualHandoff;
+        state.stage.details = Some(
+            "recovered a nonterminal OpenCode invocation; automatic redispatch is disabled because prior execution disposition is uncertain"
+                .to_string(),
+        );
+        state.opencode.last_resolve_workflow_outcome =
+            Some(state::ResolveWorkflowOutcome::ManualHandoff);
+        state::store::ThoughtsStateStore::save(&state)?;
+        return print_status(&state, false);
+    }
     let settings_changed = apply_settings_overrides(
         &mut state.settings,
         SettingsOverrides {
@@ -374,7 +397,7 @@ async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
     if settings_changed {
         state::store::ThoughtsStateStore::save(&state)?;
     }
-    let mut engine = dag::engine::DagEngine::for_current_dir()?;
+    let mut engine = dag::engine::DagEngine::for_current_dir_with_owner(Arc::clone(&owner))?;
     run_engine_until_stop_with_progress(&mut engine, options.stop_after, options.final_only)
         .await?;
     let state = state::store::ThoughtsStateStore::load()?
@@ -403,6 +426,7 @@ fn print_status(state: &state::RunState, as_json: bool) -> Result<()> {
 
 fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
     let worktree_exists = Path::new(&state.worktree.path).exists();
+    let invocation = state.opencode.current_invocation.as_ref();
 
     json!({
         "ticket": state.ticket.linear_key,
@@ -420,6 +444,17 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
         "opencode_session_id": state.opencode.active_session_id,
         "opencode_last_command": state.opencode.last_command,
         "opencode_last_diagnostics": state.opencode.last_diagnostics,
+        "opencode_invocation_phase": invocation.map(|invocation| &invocation.phase),
+        "opencode_invocation_command": invocation.map(|invocation| &invocation.command),
+        "opencode_invocation_id": invocation.map(|invocation| &invocation.invocation_id),
+        "opencode_invocation_session_id": invocation.map(|invocation| &invocation.session_id),
+        "opencode_invocation_message_id": invocation.map(|invocation| &invocation.command_message_id),
+        "opencode_invocation_lifecycle_result": invocation.and_then(|invocation| invocation.lifecycle_result.as_ref()),
+        "opencode_invocation_task_disposition": invocation.and_then(|invocation| invocation.task_disposition.as_ref()),
+        "opencode_invocation_post_attempts": invocation.map(|invocation| invocation.literal_post_attempts),
+        "opencode_resolve_start_retries": state.opencode.resolve_start_retries,
+        "opencode_last_lifecycle_anomaly": state.opencode.last_lifecycle_anomaly,
+        "opencode_last_resolve_workflow_outcome": state.opencode.last_resolve_workflow_outcome,
         "ticket_to_pr_runs": state.counters.ticket_to_pr,
         "resolve_comments_runs": state.counters.resolve_comments,
         "resolve_ci_runs": state.counters.resolve_ci,
@@ -436,91 +471,31 @@ fn compact_status_payload(state: &state::RunState) -> serde_json::Value {
     })
 }
 
-async fn handle_respond_permission(allow: bool, deny: bool, final_only: bool) -> Result<()> {
+async fn handle_respond_permission(allow: bool, deny: bool) -> Result<()> {
     anyhow::ensure!(allow ^ deny, "exactly one of --allow or --deny is required");
-    let mut state = state::store::ThoughtsStateStore::load()?
-        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
-    anyhow::ensure!(
-        matches!(
-            state.stage.kind,
-            state::StageKind::StoppedPermissionRequired
-        ),
-        "current state is not waiting on a permission response"
-    );
-    let pending = state
-        .opencode
-        .pending_permission
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("no pending permission payload found in state"))?;
-    let session_id = state
-        .opencode
-        .active_session_id
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
-
-    let supervisor = opencode::supervisor::OpenCodeSupervisor::start(
-        std::path::Path::new("."),
-        opencode::supervisor::OpenCodeSupervisorTimeouts::from_settings(&state.settings),
+    owner::send_response(
+        Path::new("."),
+        owner::InterruptionResponse::Permission { allow },
     )
     .await?;
-    supervisor
-        .respond_permission(&session_id, &pending.request_id, allow)
-        .await?;
-    drop(supervisor);
-
-    state.opencode.pending_permission = None;
-    state.stage.kind = require_actionable_resume_stage(&state)?;
-    state.stage.details = None;
-    state::store::ThoughtsStateStore::save(&state)?;
-
-    let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    run_engine_until_stop_with_progress(&mut engine, None, final_only).await?;
-    let state = state::store::ThoughtsStateStore::load()?
-        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
-    print_status(&state, false)
+    println!("permission response accepted by foreground owner");
+    Ok(())
 }
 
-async fn handle_respond_question(answer: &str, final_only: bool) -> Result<()> {
-    let mut state = state::store::ThoughtsStateStore::load()?
-        .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
-    anyhow::ensure!(
-        matches!(state.stage.kind, state::StageKind::StoppedQuestionRequired),
-        "current state is not waiting on a question response"
-    );
-    let pending = state
-        .opencode
-        .pending_question
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("no pending question payload found in state"))?;
-    let session_id = state
-        .opencode
-        .active_session_id
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("no active OpenCode session found in state"))?;
-
-    let supervisor = opencode::supervisor::OpenCodeSupervisor::start(
-        std::path::Path::new("."),
-        opencode::supervisor::OpenCodeSupervisorTimeouts::from_settings(&state.settings),
+async fn handle_respond_question(answer: &str) -> Result<()> {
+    owner::send_response(
+        Path::new("."),
+        owner::InterruptionResponse::Question {
+            answers: vec![vec![answer.to_string()]],
+        },
     )
     .await?;
-    supervisor
-        .respond_question(&session_id, &pending.request_id, answer)
-        .await?;
-    drop(supervisor);
-
-    state.opencode.pending_question = None;
-    state.stage.kind = require_actionable_resume_stage(&state)?;
-    state.stage.details = None;
-    state::store::ThoughtsStateStore::save(&state)?;
-
-    let mut engine = dag::engine::DagEngine::for_current_dir()?;
-    run_engine_until_stop_with_progress(&mut engine, None, final_only).await?;
-    let state = state::store::ThoughtsStateStore::load()?
-        .ok_or_else(|| anyhow::anyhow!("persisted state disappeared after responding"))?;
-    print_status(&state, false)
+    println!("question response accepted by foreground owner");
+    Ok(())
 }
 
 async fn handle_handoff(message: Option<&str>) -> Result<()> {
+    owner::OwnerRuntime::ensure_unlocked(Path::new("."))?;
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
     let body = message.unwrap_or("manual handoff requested from agentic-outer-dag");
@@ -533,6 +508,7 @@ async fn handle_handoff(message: Option<&str>) -> Result<()> {
 
 fn handle_reset(yes: bool) -> Result<()> {
     anyhow::ensure!(yes, "reset requires --yes");
+    owner::OwnerRuntime::ensure_unlocked(Path::new("."))?;
     state::store::ThoughtsStateStore::delete()?;
     println!("state reset");
     Ok(())
@@ -546,6 +522,7 @@ mod tests {
     use super::compact_status_payload;
     use super::ensure_supported_dry_run_usage;
     use super::handle_start;
+    use super::has_recovered_nonterminal_invocation;
     use super::require_actionable_resume_stage;
     use super::resolve_start_effective_branch;
     use super::state;
@@ -589,6 +566,7 @@ mod tests {
         state.opencode.last_command = Some("linear_ticket_2_pr".to_string());
         state.opencode.last_diagnostics = Some(state::OpenCodeDiagnostics {
             checked_at: "2026-01-01T00:00:00Z".to_string(),
+            literal_post_attempts: 1,
             command_message_id: Some("msg-outer-dag-1".to_string()),
             final_assistant_message_id: Some("msg-assistant-1".to_string()),
             final_finish_reason: Some("stop".to_string()),
@@ -599,6 +577,31 @@ mod tests {
             }),
             command_transport_error: None,
         });
+        state.opencode.current_invocation = Some(state::OpenCodeInvocationState {
+            invocation_id: "invocation-1".to_string(),
+            command: "resolve_pr_comments".to_string(),
+            session_id: "session-123".to_string(),
+            command_message_id: "msg-outer-dag-1".to_string(),
+            phase: state::OpenCodeInvocationPhase::Terminal,
+            literal_post_attempts: 2,
+            lifecycle_result: Some(state::InvocationLifecycleResult::AcceptedButNotStarted),
+            task_disposition: Some(state::TaskDisposition {
+                server_abort: state::ServerAbortDisposition::Succeeded { aborted: true },
+                local_task: state::LocalTaskDisposition::AbortedAndJoined,
+            }),
+            pending_interruption: Some(state::PendingInterruptionIdentity {
+                kind: state::InterruptionKind::Permission,
+                request_id: "secret-runtime-request".to_string(),
+            }),
+        });
+        state.opencode.resolve_start_retries = 2;
+        state.opencode.last_lifecycle_anomaly = Some(state::InvocationLifecycleAnomaly {
+            invocation_id: "invocation-1".to_string(),
+            observed_at: "2026-01-01T00:00:00Z".to_string(),
+            kind: state::InvocationLifecycleAnomalyKind::AcceptedButNotStarted,
+        });
+        state.opencode.last_resolve_workflow_outcome =
+            Some(state::ResolveWorkflowOutcome::RetriesExhausted);
         state.counters.ticket_to_pr = 1;
         state.counters.resolve_comments = 0;
         state.counters.resolve_ci = 2;
@@ -649,6 +652,17 @@ mod tests {
             "opencode_session_id",
             "opencode_last_command",
             "opencode_last_diagnostics",
+            "opencode_invocation_phase",
+            "opencode_invocation_command",
+            "opencode_invocation_id",
+            "opencode_invocation_session_id",
+            "opencode_invocation_message_id",
+            "opencode_invocation_lifecycle_result",
+            "opencode_invocation_task_disposition",
+            "opencode_invocation_post_attempts",
+            "opencode_resolve_start_retries",
+            "opencode_last_lifecycle_anomaly",
+            "opencode_last_resolve_workflow_outcome",
             "ticket_to_pr_runs",
             "resolve_comments_runs",
             "resolve_ci_runs",
@@ -730,6 +744,20 @@ mod tests {
                 .and_then(|diagnostics| diagnostics.get("guard_detected")),
             Some(&Value::Bool(true))
         );
+        assert_eq!(
+            payload.get("opencode_invocation_phase"),
+            Some(&Value::String("terminal".to_string()))
+        );
+        assert_eq!(
+            payload.get("opencode_invocation_post_attempts"),
+            Some(&Value::Number(2_u64.into()))
+        );
+        assert_eq!(
+            payload.get("opencode_resolve_start_retries"),
+            Some(&Value::Number(2_u64.into()))
+        );
+        assert!(payload.get("opencode_current_invocation").is_none());
+        assert!(!payload.to_string().contains("secret-runtime-request"));
     }
 
     #[test]
@@ -886,6 +914,36 @@ mod tests {
             require_actionable_resume_stage(&state).unwrap(),
             state::StageKind::DispatchingResolvePrComments
         );
+    }
+
+    #[test]
+    fn every_nonterminal_invocation_phase_requires_conservative_recovery() {
+        for phase in [
+            state::OpenCodeInvocationPhase::Prepared,
+            state::OpenCodeInvocationPhase::PostAttempted,
+            state::OpenCodeInvocationPhase::RunningAssistantStarted,
+            state::OpenCodeInvocationPhase::PausedPermission,
+            state::OpenCodeInvocationPhase::PausedQuestion,
+        ] {
+            let mut state = sample_state();
+            state.opencode.current_invocation = Some(state::OpenCodeInvocationState {
+                invocation_id: "inv-1".to_string(),
+                command: "resolve_pr_comments".to_string(),
+                session_id: "session-1".to_string(),
+                command_message_id: "msg-1".to_string(),
+                phase,
+                literal_post_attempts: 1,
+                lifecycle_result: None,
+                task_disposition: None,
+                pending_interruption: None,
+            });
+            assert!(has_recovered_nonterminal_invocation(&state));
+        }
+
+        let mut state = sample_state();
+        state.opencode.current_invocation.as_mut().unwrap().phase =
+            state::OpenCodeInvocationPhase::Terminal;
+        assert!(!has_recovered_nonterminal_invocation(&state));
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/main.rs
+++ b/apps/agentic-outer-dag/src/main.rs
@@ -103,6 +103,23 @@ fn has_recovered_nonterminal_invocation(state: &state::RunState) -> bool {
         })
 }
 
+fn apply_recovered_nonterminal_handoff(state: &mut state::RunState) {
+    let recovered_resolve = state
+        .opencode
+        .current_invocation
+        .as_ref()
+        .is_some_and(|invocation| invocation.command == "resolve_pr_comments");
+    state.stage.kind = state::StageKind::StoppedManualHandoff;
+    state.stage.details = Some(
+        "recovered a nonterminal OpenCode invocation; automatic redispatch is disabled because prior execution disposition is uncertain"
+            .to_string(),
+    );
+    if recovered_resolve {
+        state.opencode.last_resolve_workflow_outcome =
+            Some(state::ResolveWorkflowOutcome::ManualHandoff);
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Install the rustls CryptoProvider before any HTTP clients are created.
@@ -373,13 +390,7 @@ async fn handle_resume(options: ResumeOptions<'_>) -> Result<()> {
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found; run start first"))?;
     if has_recovered_nonterminal_invocation(&state) {
-        state.stage.kind = state::StageKind::StoppedManualHandoff;
-        state.stage.details = Some(
-            "recovered a nonterminal OpenCode invocation; automatic redispatch is disabled because prior execution disposition is uncertain"
-                .to_string(),
-        );
-        state.opencode.last_resolve_workflow_outcome =
-            Some(state::ResolveWorkflowOutcome::ManualHandoff);
+        apply_recovered_nonterminal_handoff(&mut state);
         state::store::ThoughtsStateStore::save(&state)?;
         return print_status(&state, false);
     }
@@ -495,7 +506,7 @@ async fn handle_respond_question(answer: &str) -> Result<()> {
 }
 
 async fn handle_handoff(message: Option<&str>) -> Result<()> {
-    owner::OwnerRuntime::ensure_unlocked(Path::new("."))?;
+    let _mutation_lease = owner::OwnerMutationLease::acquire(Path::new("."))?;
     let mut state = state::store::ThoughtsStateStore::load()?
         .ok_or_else(|| anyhow::anyhow!("no persisted state found in the current worktree"))?;
     let body = message.unwrap_or("manual handoff requested from agentic-outer-dag");
@@ -508,7 +519,7 @@ async fn handle_handoff(message: Option<&str>) -> Result<()> {
 
 fn handle_reset(yes: bool) -> Result<()> {
     anyhow::ensure!(yes, "reset requires --yes");
-    owner::OwnerRuntime::ensure_unlocked(Path::new("."))?;
+    let _mutation_lease = owner::OwnerMutationLease::acquire(Path::new("."))?;
     state::store::ThoughtsStateStore::delete()?;
     println!("state reset");
     Ok(())
@@ -518,6 +529,7 @@ fn handle_reset(yes: bool) -> Result<()> {
 mod tests {
     use super::SettingsOverrides;
     use super::StartOptions;
+    use super::apply_recovered_nonterminal_handoff;
     use super::apply_settings_overrides;
     use super::compact_status_payload;
     use super::ensure_supported_dry_run_usage;
@@ -944,6 +956,35 @@ mod tests {
         state.opencode.current_invocation.as_mut().unwrap().phase =
             state::OpenCodeInvocationPhase::Terminal;
         assert!(!has_recovered_nonterminal_invocation(&state));
+    }
+
+    #[test]
+    fn recovered_resolve_invocation_records_resolve_manual_handoff() {
+        let mut state = sample_state();
+        state.opencode.current_invocation.as_mut().unwrap().phase =
+            state::OpenCodeInvocationPhase::PausedPermission;
+
+        apply_recovered_nonterminal_handoff(&mut state);
+
+        assert_eq!(state.stage.kind, state::StageKind::StoppedManualHandoff);
+        assert_eq!(
+            state.opencode.last_resolve_workflow_outcome,
+            Some(state::ResolveWorkflowOutcome::ManualHandoff)
+        );
+    }
+
+    #[test]
+    fn recovered_non_resolve_invocation_preserves_prior_resolve_outcome() {
+        let mut state = sample_state();
+        let invocation = state.opencode.current_invocation.as_mut().unwrap();
+        invocation.command = "linear_ticket_2_pr".to_string();
+        invocation.phase = state::OpenCodeInvocationPhase::PostAttempted;
+        let prior = state.opencode.last_resolve_workflow_outcome.clone();
+
+        apply_recovered_nonterminal_handoff(&mut state);
+
+        assert_eq!(state.stage.kind, state::StageKind::StoppedManualHandoff);
+        assert_eq!(state.opencode.last_resolve_workflow_outcome, prior);
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -1,5 +1,10 @@
+use crate::state::CleanupFailure;
+use crate::state::InvocationFailure;
+use crate::state::LocalTaskDisposition;
 use crate::state::OpenCodeDiagnostics;
 use crate::state::OpenCodeToolErrorDiagnostics;
+use crate::state::ServerAbortDisposition;
+use crate::state::TaskDisposition;
 use anyhow::Context;
 use anyhow::Result;
 use opencode_rs::Client;
@@ -17,8 +22,12 @@ use opencode_rs::types::question::QuestionReply;
 use opencode_rs::types::session::CreateSessionRequest;
 use opencode_rs::types::session::SessionStatusInfo;
 use opencode_rs::version;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -63,22 +72,91 @@ pub enum SupervisedOutcome {
     Completed {
         session_id: String,
         diagnostics: OpenCodeDiagnostics,
+        literal_post_attempts: u32,
+        task_disposition: TaskDisposition,
+    },
+    AcceptedButNotStarted {
+        session_id: String,
+        diagnostics: OpenCodeDiagnostics,
+        literal_post_attempts: u32,
+        task_disposition: TaskDisposition,
     },
     PermissionRequired {
         session_id: String,
         request_id: String,
         permission_type: String,
+        literal_post_attempts: u32,
     },
     QuestionRequired {
         session_id: String,
         request_id: String,
         prompt: String,
+        literal_post_attempts: u32,
     },
     Failed {
         session_id: Option<String>,
         error: String,
         diagnostics: Option<OpenCodeDiagnostics>,
+        literal_post_attempts: u32,
+        failure: InvocationFailure,
+        task_disposition: TaskDisposition,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionSelection {
+    Reuse(String),
+    Fresh,
+}
+
+pub enum PreparedCommandOutcome {
+    Prepared(PreparedCommandInvocation),
+    Interrupted(SupervisedOutcome),
+}
+
+pub struct PreparedCommandInvocation {
+    session_id: String,
+    command_name: String,
+    message: String,
+    transcript_window: TranscriptWindow,
+    subscription: opencode_rs::sse::SseSubscription<Event>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SupervisionEvent {
+    LiteralPostAttempt {
+        total: u32,
+    },
+    AssistantStarted {
+        message_id: String,
+    },
+    Paused {
+        kind: crate::state::InterruptionKind,
+        request_id: String,
+    },
+    Resumed {
+        assistant_started: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct InvocationOwnerContext {
+    pub run_id: String,
+    pub invocation_id: String,
+}
+
+impl PreparedCommandInvocation {
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn command_name(&self) -> &str {
+        &self.command_name
+    }
+
+    pub fn command_message_id(&self) -> &str {
+        &self.transcript_window.command_message_id
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -104,10 +182,39 @@ enum IdleGateDecision {
     IgnoreUntilDispatchConfirmed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionStatusObservation {
+    Absent,
+    Idle,
+    BusyLike,
+}
+
+fn observe_session_status(
+    statuses: &HashMap<String, SessionStatusInfo>,
+    session_id: &str,
+) -> SessionStatusObservation {
+    match statuses.get(session_id) {
+        None => SessionStatusObservation::Absent,
+        Some(SessionStatusInfo::Idle) => SessionStatusObservation::Idle,
+        Some(
+            SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. } | SessionStatusInfo::Unknown,
+        ) => SessionStatusObservation::BusyLike,
+    }
+}
+
+fn event_session_matches(event_session_id: Option<&str>, session_id: &str) -> bool {
+    event_session_id.is_none_or(|event_session_id| event_session_id == session_id)
+}
+
 impl TranscriptAnalysis {
-    fn diagnostics(&self, command_message_id: &str) -> OpenCodeDiagnostics {
+    fn diagnostics(
+        &self,
+        command_message_id: &str,
+        literal_post_attempts: u32,
+    ) -> OpenCodeDiagnostics {
         OpenCodeDiagnostics {
             checked_at: chrono::Utc::now().to_rfc3339(),
+            literal_post_attempts,
             command_message_id: Some(command_message_id.to_string()),
             final_assistant_message_id: self.final_assistant_message_id.clone(),
             final_finish_reason: self.final_finish_reason.clone(),
@@ -134,6 +241,15 @@ fn idle_gate_decision(
     }
 }
 
+fn suspend_supervision_clocks(
+    deadline: &mut tokio::time::Instant,
+    last_activity: &mut tokio::time::Instant,
+    waited: Duration,
+) {
+    *deadline += waited;
+    *last_activity += waited;
+}
+
 fn transcript_indicates_dispatch(
     messages: &[Message],
     transcript_window: &TranscriptWindow,
@@ -158,10 +274,20 @@ fn transcript_indicates_dispatch(
 #[derive(Debug)]
 enum CompletionValidation {
     Passed(OpenCodeDiagnostics),
+    AcceptedButNotStarted(OpenCodeDiagnostics),
     Failed {
         error: String,
         diagnostics: Option<OpenCodeDiagnostics>,
     },
+}
+
+type CommandTask = tokio::task::JoinHandle<Result<(), OpencodeError>>;
+
+struct TerminalFailure {
+    error: String,
+    diagnostics: Option<OpenCodeDiagnostics>,
+    literal_post_attempts: u32,
+    failure: InvocationFailure,
 }
 
 impl OpenCodeSupervisor {
@@ -238,33 +364,36 @@ impl OpenCodeSupervisor {
         Ok(())
     }
 
-    pub async fn run_command_supervised(
+    pub async fn prepare_command(
         &self,
-        existing_session_id: Option<&str>,
+        session_selection: SessionSelection,
         command_name: &str,
         message: Option<&str>,
-    ) -> Result<SupervisedOutcome> {
-        let session_id = if let Some(session_id) = existing_session_id {
-            self.client
-                .sessions()
-                .get(session_id)
-                .await
-                .with_context(|| format!("failed to load session {session_id}"))?;
-            session_id.to_string()
-        } else {
-            self.client
-                .sessions()
-                .create(&CreateSessionRequest::default())
-                .await
-                .context("failed to create OpenCode session")?
-                .id
+    ) -> Result<PreparedCommandOutcome> {
+        let session_id = match session_selection {
+            SessionSelection::Reuse(session_id) => {
+                self.client
+                    .sessions()
+                    .get(&session_id)
+                    .await
+                    .with_context(|| format!("failed to load session {session_id}"))?;
+                session_id
+            }
+            SessionSelection::Fresh => {
+                self.client
+                    .sessions()
+                    .create(&CreateSessionRequest::default())
+                    .await
+                    .context("failed to create OpenCode session")?
+                    .id
+            }
         };
 
-        if let Some(outcome) = self.preflight_pending_interruptions(&session_id).await? {
-            return Ok(outcome);
+        if let Some(outcome) = self.preflight_pending_interruptions(&session_id, 0).await? {
+            return Ok(PreparedCommandOutcome::Interrupted(outcome));
         }
 
-        let mut subscription = self
+        let subscription = self
             .client
             .subscribe_session(&session_id)
             .context("failed to subscribe to session events")?;
@@ -273,11 +402,64 @@ impl OpenCodeSupervisor {
             baseline_tail_message_id: self.fetch_transcript_tail_id(&session_id).await?,
         };
 
+        Ok(PreparedCommandOutcome::Prepared(
+            PreparedCommandInvocation {
+                session_id,
+                command_name: command_name.to_string(),
+                message: message.unwrap_or_default().to_string(),
+                transcript_window,
+                subscription,
+            },
+        ))
+    }
+
+    #[cfg(test)]
+    async fn run_command_supervised(
+        &self,
+        existing_session_id: Option<&str>,
+        command_name: &str,
+        message: Option<&str>,
+    ) -> Result<SupervisedOutcome> {
+        let selection = existing_session_id.map_or(SessionSelection::Fresh, |session_id| {
+            SessionSelection::Reuse(session_id.to_string())
+        });
+        match self
+            .prepare_command(selection, command_name, message)
+            .await?
+        {
+            PreparedCommandOutcome::Prepared(prepared) => {
+                self.run_prepared_command(prepared, None, None, |_| Ok(()))
+                    .await
+            }
+            PreparedCommandOutcome::Interrupted(outcome) => Ok(outcome),
+        }
+    }
+
+    pub async fn run_prepared_command<F>(
+        &self,
+        prepared: PreparedCommandInvocation,
+        owner: Option<&crate::owner::OwnerRuntime>,
+        owner_context: Option<&InvocationOwnerContext>,
+        mut on_event: F,
+    ) -> Result<SupervisedOutcome>
+    where
+        F: FnMut(SupervisionEvent) -> Result<()>,
+    {
+        let PreparedCommandInvocation {
+            session_id,
+            command_name,
+            message: dispatch_message,
+            transcript_window,
+            mut subscription,
+        } = prepared;
+
         let cmd_client = self.client.clone();
         let dispatch_session_id = session_id.clone();
-        let dispatch_command = command_name.to_string();
-        let dispatch_message = message.unwrap_or_default().to_string();
+        let dispatch_command = command_name.clone();
         let dispatch_message_id = transcript_window.command_message_id.clone();
+        let literal_post_attempts = Arc::new(AtomicU32::new(0));
+        let task_literal_post_attempts = Arc::clone(&literal_post_attempts);
+        let (attempt_tx, mut attempt_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut command_task = Some(tokio::spawn(async move {
             let request = CommandRequest {
                 command: dispatch_command,
@@ -286,45 +468,99 @@ impl OpenCodeSupervisor {
             };
             cmd_client
                 .messages()
-                .command(&dispatch_session_id, &request)
+                .command_with_attempt_observer(&dispatch_session_id, &request, move |_| {
+                    let total = task_literal_post_attempts.fetch_add(1, Ordering::Relaxed) + 1;
+                    let _ = attempt_tx.send(total);
+                })
                 .await
                 .map(|_| ())
         }));
+        let mut observed_local = LocalTaskDisposition::Spawned;
 
-        let deadline = tokio::time::Instant::now() + self.timeouts.session_deadline;
+        let mut deadline = tokio::time::Instant::now() + self.timeouts.session_deadline;
         let mut last_activity = tokio::time::Instant::now();
         let mut poll_interval = tokio::time::interval(POLL_INTERVAL);
         poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut observed_busy = false;
+        let mut assistant_started = false;
+        let mut correlated_assistant_ids = HashSet::new();
         let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
         let mut awaiting_idle_grace = false;
         let mut sse_active = true;
         let mut command_transport_error: Option<String> = None;
 
+        macro_rules! terminal_runtime_error {
+            ($failure:expr, $error:expr) => {{
+                let error = $error;
+                return Ok(self
+                    .terminal_failure(
+                        session_id.clone(),
+                        TerminalFailure {
+                            error: error.to_string(),
+                            diagnostics: None,
+                            literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
+                            failure: $failure,
+                        },
+                        &mut command_task,
+                        observed_local,
+                    )
+                    .await);
+            }};
+        }
+
+        macro_rules! emit_event {
+            ($event:expr) => {
+                if let Err(error) = on_event($event) {
+                    terminal_runtime_error!(InvocationFailure::Persistence, error);
+                }
+            };
+        }
+
         loop {
             let now = tokio::time::Instant::now();
             if now.duration_since(last_activity) >= self.timeouts.inactivity_timeout {
-                return Ok(SupervisedOutcome::Failed {
-                    session_id: Some(session_id.clone()),
-                    error: format!(
-                        "session idle timeout after {}",
-                        describe_duration(self.timeouts.inactivity_timeout)
-                    ),
-                    diagnostics: None,
-                });
+                let error = format!(
+                    "session idle timeout after {}",
+                    describe_duration(self.timeouts.inactivity_timeout)
+                );
+                return Ok(self
+                    .terminal_failure(
+                        session_id,
+                        TerminalFailure {
+                            error,
+                            diagnostics: None,
+                            literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
+                            failure: InvocationFailure::InactivityTimeout,
+                        },
+                        &mut command_task,
+                        observed_local,
+                    )
+                    .await);
             }
             if now >= deadline {
-                return Ok(SupervisedOutcome::Failed {
-                    session_id: Some(session_id.clone()),
-                    error: format!(
-                        "session execution timed out after {}",
-                        describe_duration(self.timeouts.session_deadline)
-                    ),
-                    diagnostics: None,
-                });
+                let error = format!(
+                    "session execution timed out after {}",
+                    describe_duration(self.timeouts.session_deadline)
+                );
+                return Ok(self
+                    .terminal_failure(
+                        session_id,
+                        TerminalFailure {
+                            error,
+                            diagnostics: None,
+                            literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
+                            failure: InvocationFailure::SessionDeadline,
+                        },
+                        &mut command_task,
+                        observed_local,
+                    )
+                    .await);
             }
 
             tokio::select! {
+                Some(total) = attempt_rx.recv() => {
+                    emit_event!(SupervisionEvent::LiteralPostAttempt { total });
+                }
                 maybe_event = subscription.recv(), if sse_active => {
                     let Some(event) = maybe_event else {
                         sse_active = false;
@@ -333,13 +569,87 @@ impl OpenCodeSupervisor {
 
                     match event {
                         Event::PermissionAsked { properties } => {
+                            if properties.request.session_id != session_id {
+                                continue;
+                            }
+                            if let (Some(owner), Some(owner_context)) = (owner, owner_context) {
+                                let request_id = properties.request.id;
+                                let correlation = crate::owner::InterruptionCorrelation {
+                                    run_id: owner_context.run_id.clone(),
+                                    invocation_id: owner_context.invocation_id.clone(),
+                                    session_id: session_id.clone(),
+                                    command_message_id: transcript_window.command_message_id.clone(),
+                                    kind: crate::state::InterruptionKind::Permission,
+                                    request_id: request_id.clone(),
+                                };
+                                emit_event!(SupervisionEvent::Paused {
+                                    kind: crate::state::InterruptionKind::Permission,
+                                    request_id: request_id.clone(),
+                                });
+                                let waited = match self
+                                    .continue_permission_with_owner(
+                                        owner,
+                                        &correlation,
+                                        &session_id,
+                                        &request_id,
+                                    )
+                                    .await
+                                {
+                                    Ok(waited) => waited,
+                                    Err(error) => {
+                                        terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
+                                    }
+                                };
+                                suspend_supervision_clocks(
+                                    &mut deadline,
+                                    &mut last_activity,
+                                    waited,
+                                );
+                                emit_event!(SupervisionEvent::Resumed { assistant_started });
+                                continue;
+                            }
                             return Ok(SupervisedOutcome::PermissionRequired {
                                 session_id,
                                 request_id: properties.request.id,
                                 permission_type: properties.request.permission,
+                                literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
                             });
                         }
                         Event::QuestionAsked { properties } => {
+                            if properties.request.session_id != session_id {
+                                continue;
+                            }
+                            if let (Some(owner), Some(owner_context)) = (owner, owner_context) {
+                                let request_id = properties.request.id;
+                                let correlation = crate::owner::InterruptionCorrelation {
+                                    run_id: owner_context.run_id.clone(),
+                                    invocation_id: owner_context.invocation_id.clone(),
+                                    session_id: session_id.clone(),
+                                    command_message_id: transcript_window.command_message_id.clone(),
+                                    kind: crate::state::InterruptionKind::Question,
+                                    request_id: request_id.clone(),
+                                };
+                                emit_event!(SupervisionEvent::Paused {
+                                    kind: crate::state::InterruptionKind::Question,
+                                    request_id: request_id.clone(),
+                                });
+                                let waited = match self
+                                    .continue_question_with_owner(owner, &correlation, &request_id)
+                                    .await
+                                {
+                                    Ok(waited) => waited,
+                                    Err(error) => {
+                                        terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
+                                    }
+                                };
+                                suspend_supervision_clocks(
+                                    &mut deadline,
+                                    &mut last_activity,
+                                    waited,
+                                );
+                                emit_event!(SupervisionEvent::Resumed { assistant_started });
+                                continue;
+                            }
                             let prompt = properties
                                 .request
                                 .questions
@@ -350,18 +660,44 @@ impl OpenCodeSupervisor {
                                 session_id,
                                 request_id: properties.request.id,
                                 prompt,
+                                literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
                             });
                         }
-                        Event::MessagePartDelta { .. }
-                        | Event::MessagePartUpdated { .. }
-                        | Event::MessageUpdated { .. } => {
-                            last_activity = tokio::time::Instant::now();
-                            observed_busy = true;
-                            awaiting_idle_grace = false;
+                        Event::MessageUpdated { properties } => {
+                            let info = &properties.info;
+                            if event_session_matches(info.session_id.as_deref(), &session_id)
+                                && info.role == "assistant"
+                                && info.parent_id.as_deref()
+                                    == Some(transcript_window.command_message_id.as_str())
+                            {
+                                if !assistant_started {
+                                    emit_event!(SupervisionEvent::AssistantStarted {
+                                        message_id: info.id.clone(),
+                                    });
+                                }
+                                correlated_assistant_ids.insert(info.id.clone());
+                                assistant_started = true;
+                                observed_busy = true;
+                                last_activity = tokio::time::Instant::now();
+                                awaiting_idle_grace = false;
+                            }
                         }
-                        Event::SessionIdle { .. } => {
+                        Event::MessagePartDelta { properties }
+                        | Event::MessagePartUpdated { properties } => {
+                            if event_session_matches(properties.session_id.as_deref(), &session_id)
+                                && properties.message_id.as_ref().is_some_and(|message_id| {
+                                correlated_assistant_ids.contains(message_id)
+                            }) {
+                                last_activity = tokio::time::Instant::now();
+                                awaiting_idle_grace = false;
+                            }
+                        }
+                        Event::SessionIdle { properties } => {
+                            if properties.session_id != session_id {
+                                continue;
+                            }
                             match idle_gate_decision(
-                                observed_busy,
+                                assistant_started,
                                 idle_grace_deadline,
                                 tokio::time::Instant::now(),
                             ) {
@@ -371,6 +707,9 @@ impl OpenCodeSupervisor {
                                             session_id,
                                             &transcript_window,
                                             command_transport_error.as_ref(),
+                                            literal_post_attempts.load(Ordering::Relaxed),
+                                            &mut command_task,
+                                            observed_local,
                                         )
                                         .await);
                                 }
@@ -381,29 +720,139 @@ impl OpenCodeSupervisor {
                             }
                         }
                         Event::SessionError { properties } => {
-                            return Ok(SupervisedOutcome::Failed {
-                                session_id: properties.session_id.or(Some(session_id)),
-                                error: format!("session error: {:?}", properties.error),
-                                diagnostics: None,
-                            });
+                            if !event_session_matches(properties.session_id.as_deref(), &session_id) {
+                                continue;
+                            }
+                            let outcome_session_id =
+                                properties.session_id.unwrap_or_else(|| session_id.clone());
+                            return Ok(self
+                                .terminal_failure(
+                                    outcome_session_id,
+                                    TerminalFailure {
+                                        error: format!("session error: {:?}", properties.error),
+                                        diagnostics: None,
+                                        literal_post_attempts: literal_post_attempts
+                                            .load(Ordering::Relaxed),
+                                        failure: InvocationFailure::SessionError,
+                                    },
+                                    &mut command_task,
+                                    observed_local,
+                                )
+                                .await);
                         }
                         _ => {}
                     }
                 }
                 _ = poll_interval.tick() => {
-                    if let Some(outcome) = self.preflight_pending_interruptions(&session_id).await? {
-                        return Ok(outcome);
+                    let pending_interruption = match self
+                        .preflight_pending_interruptions(
+                            &session_id,
+                            literal_post_attempts.load(Ordering::Relaxed),
+                        )
+                        .await
+                    {
+                        Ok(outcome) => outcome,
+                        Err(error) => {
+                            tracing::warn!(error = %error, "failed to poll pending interruptions");
+                            None
+                        }
+                    };
+                    if let Some(outcome) = pending_interruption {
+                        match (owner, owner_context, outcome) {
+                            (
+                                Some(owner),
+                                Some(owner_context),
+                                SupervisedOutcome::PermissionRequired { request_id, .. },
+                            ) => {
+                                let correlation = crate::owner::InterruptionCorrelation {
+                                    run_id: owner_context.run_id.clone(),
+                                    invocation_id: owner_context.invocation_id.clone(),
+                                    session_id: session_id.clone(),
+                                    command_message_id: transcript_window.command_message_id.clone(),
+                                    kind: crate::state::InterruptionKind::Permission,
+                                    request_id: request_id.clone(),
+                                };
+                                emit_event!(SupervisionEvent::Paused {
+                                    kind: crate::state::InterruptionKind::Permission,
+                                    request_id: request_id.clone(),
+                                });
+                                let waited = match self
+                                    .continue_permission_with_owner(
+                                        owner,
+                                        &correlation,
+                                        &session_id,
+                                        &request_id,
+                                    )
+                                    .await
+                                {
+                                    Ok(waited) => waited,
+                                    Err(error) => {
+                                        terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
+                                    }
+                                };
+                                suspend_supervision_clocks(
+                                    &mut deadline,
+                                    &mut last_activity,
+                                    waited,
+                                );
+                                emit_event!(SupervisionEvent::Resumed { assistant_started });
+                                continue;
+                            }
+                            (
+                                Some(owner),
+                                Some(owner_context),
+                                SupervisedOutcome::QuestionRequired { request_id, .. },
+                            ) => {
+                                let correlation = crate::owner::InterruptionCorrelation {
+                                    run_id: owner_context.run_id.clone(),
+                                    invocation_id: owner_context.invocation_id.clone(),
+                                    session_id: session_id.clone(),
+                                    command_message_id: transcript_window.command_message_id.clone(),
+                                    kind: crate::state::InterruptionKind::Question,
+                                    request_id: request_id.clone(),
+                                };
+                                emit_event!(SupervisionEvent::Paused {
+                                    kind: crate::state::InterruptionKind::Question,
+                                    request_id: request_id.clone(),
+                                });
+                                let waited = match self
+                                    .continue_question_with_owner(owner, &correlation, &request_id)
+                                    .await
+                                {
+                                    Ok(waited) => waited,
+                                    Err(error) => {
+                                        terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
+                                    }
+                                };
+                                suspend_supervision_clocks(
+                                    &mut deadline,
+                                    &mut last_activity,
+                                    waited,
+                                );
+                                emit_event!(SupervisionEvent::Resumed { assistant_started });
+                                continue;
+                            }
+                            (_, _, outcome) => return Ok(outcome),
+                        }
                     }
 
-                    match self.client.sessions().status_for(&session_id).await {
-                        Ok(SessionStatusInfo::Busy | SessionStatusInfo::Retry { .. } | SessionStatusInfo::Unknown) => {
+                    match self.client.sessions().status_map().await {
+                        Ok(statuses)
+                            if matches!(
+                                observe_session_status(&statuses, &session_id),
+                                SessionStatusObservation::BusyLike
+                            ) => {
                             last_activity = tokio::time::Instant::now();
                             observed_busy = true;
                             awaiting_idle_grace = false;
                         }
-                        Ok(SessionStatusInfo::Idle) => {
+                        Ok(statuses)
+                            if matches!(
+                                observe_session_status(&statuses, &session_id),
+                                SessionStatusObservation::Absent | SessionStatusObservation::Idle
+                            ) => {
                             match idle_gate_decision(
-                                observed_busy,
+                                assistant_started,
                                 idle_grace_deadline,
                                 tokio::time::Instant::now(),
                             ) {
@@ -413,6 +862,9 @@ impl OpenCodeSupervisor {
                                             session_id,
                                             &transcript_window,
                                             command_transport_error.as_ref(),
+                                            literal_post_attempts.load(Ordering::Relaxed),
+                                            &mut command_task,
+                                            observed_local,
                                         )
                                         .await);
                                 }
@@ -422,6 +874,7 @@ impl OpenCodeSupervisor {
                                 IdleGateDecision::IgnoreUntilDispatchConfirmed => {}
                             }
                         }
+                        Ok(_) => {}
                         Err(error) => {
                             tracing::warn!(error = %error, "failed to poll session status");
                         }
@@ -436,27 +889,41 @@ impl OpenCodeSupervisor {
                     match result {
                         Some(Ok(Ok(()))) => {
                             idle_grace_deadline = Some(tokio::time::Instant::now() + IDLE_GRACE);
+                            awaiting_idle_grace = true;
                             command_task = None;
+                            observed_local = LocalTaskDisposition::Completed;
                         }
                         Some(Ok(Err(error))) => {
+                            command_task = None;
+                            observed_local = LocalTaskDisposition::ReturnedError;
                             if !matches!(error, OpencodeError::Transport(_)) {
-                                return Ok(SupervisedOutcome::Failed {
-                                    session_id: Some(session_id),
-                                    error: error.to_string(),
-                                    diagnostics: None,
-                                });
+                                return Ok(self
+                                    .terminal_failure(
+                                        session_id,
+                                        TerminalFailure {
+                                            error: error.to_string(),
+                                            diagnostics: None,
+                                            literal_post_attempts: literal_post_attempts
+                                                .load(Ordering::Relaxed),
+                                            failure: InvocationFailure::CommandTransport,
+                                        },
+                                        &mut command_task,
+                                        observed_local,
+                                    )
+                                    .await);
                             }
 
                             let mut start_evidence = observed_busy;
 
                             if !start_evidence
-                                && let Ok(status) = self.client.sessions().status_for(&session_id).await
-                                && status.is_busy_like()
+                                && let Ok(statuses) = self.client.sessions().status_map().await
+                                && statuses
+                                    .get(&session_id)
+                                    .is_some_and(SessionStatusInfo::is_busy_like)
                             {
                                 start_evidence = true;
                                 observed_busy = true;
                                 last_activity = tokio::time::Instant::now();
-                                awaiting_idle_grace = false;
                             }
 
                             if !start_evidence {
@@ -475,38 +942,66 @@ impl OpenCodeSupervisor {
                             }
 
                             if start_evidence {
+                                idle_grace_deadline
+                                    .get_or_insert_with(|| tokio::time::Instant::now() + IDLE_GRACE);
+                                awaiting_idle_grace = true;
                                 tracing::warn!(
                                     session_id = %session_id,
                                     error = %error,
                                     "POST /session/{session_id}/command transport error after start evidence; continuing supervision via SSE/status"
                                 );
                                 command_transport_error.get_or_insert_with(|| error.to_string());
-                                command_task = None;
                                 continue;
                             }
 
-                            return Ok(SupervisedOutcome::Failed {
-                                session_id: Some(session_id),
-                                error: format!(
-                                    "transport error dispatching OpenCode command '{command_name}' (no session start evidence observed): {error}"
-                                ),
-                                diagnostics: Some(OpenCodeDiagnostics {
-                                    checked_at: chrono::Utc::now().to_rfc3339(),
-                                    command_message_id: Some(transcript_window.command_message_id.clone()),
-                                    final_assistant_message_id: None,
-                                    final_finish_reason: None,
-                                    guard_detected: false,
-                                    final_tool_error: None,
-                                    command_transport_error: Some(error.to_string()),
-                                }),
-                            });
+                            let diagnostics = OpenCodeDiagnostics {
+                                checked_at: chrono::Utc::now().to_rfc3339(),
+                                literal_post_attempts: literal_post_attempts.load(Ordering::Relaxed),
+                                command_message_id: Some(transcript_window.command_message_id.clone()),
+                                final_assistant_message_id: None,
+                                final_finish_reason: None,
+                                guard_detected: false,
+                                final_tool_error: None,
+                                command_transport_error: Some(error.to_string()),
+                            };
+                            return Ok(self
+                                .terminal_failure(
+                                    session_id,
+                                    TerminalFailure {
+                                        error: format!(
+                                            "transport error dispatching OpenCode command '{command_name}' (no session start evidence observed): {error}"
+                                        ),
+                                        diagnostics: Some(diagnostics),
+                                        literal_post_attempts: literal_post_attempts
+                                            .load(Ordering::Relaxed),
+                                        failure: InvocationFailure::CommandTransport,
+                                    },
+                                    &mut command_task,
+                                    observed_local,
+                                )
+                                .await);
                         }
                         Some(Err(error)) => {
-                            return Ok(SupervisedOutcome::Failed {
-                                session_id: Some(session_id),
-                                error: format!("command task failed: {error}"),
-                                diagnostics: None,
-                            });
+                            command_task = None;
+                            observed_local = if error.is_cancelled() {
+                                LocalTaskDisposition::JoinCancelled
+                            } else {
+                                LocalTaskDisposition::JoinPanicked
+                            };
+                            return Ok(self
+                                .terminal_failure(
+                                    session_id,
+                                    TerminalFailure {
+                                        error: format!("command task failed: {error}"),
+                                        diagnostics: None,
+                                        literal_post_attempts: literal_post_attempts
+                                            .load(Ordering::Relaxed),
+                                        failure: InvocationFailure::LocalTask,
+                                    },
+                                    &mut command_task,
+                                    observed_local,
+                                )
+                                .await);
                         }
                         None => unreachable!("command task guard should prevent None"),
                     }
@@ -517,21 +1012,53 @@ impl OpenCodeSupervisor {
                         None => std::future::pending::<()>().await,
                     }
                 }, if awaiting_idle_grace => {
-                    awaiting_idle_grace = false;
-                    if matches!(self.client.sessions().status_for(&session_id).await, Ok(SessionStatusInfo::Idle)) {
-                        return Ok(self
-                            .completion_outcome(
-                                session_id,
-                                &transcript_window,
-                                command_transport_error.as_ref(),
-                            )
-                            .await);
-                    }
-                    observed_busy = true;
-                    last_activity = tokio::time::Instant::now();
+                    return Ok(self
+                        .completion_outcome(
+                            session_id,
+                            &transcript_window,
+                            command_transport_error.as_ref(),
+                            literal_post_attempts.load(Ordering::Relaxed),
+                            &mut command_task,
+                            observed_local,
+                        )
+                        .await);
                 }
             }
         }
+    }
+
+    async fn continue_permission_with_owner(
+        &self,
+        owner: &crate::owner::OwnerRuntime,
+        correlation: &crate::owner::InterruptionCorrelation,
+        session_id: &str,
+        request_id: &str,
+    ) -> Result<Duration> {
+        owner.publish_pending(correlation)?;
+        let wait_started = tokio::time::Instant::now();
+        let response = owner.await_response(correlation).await?;
+        let crate::owner::InterruptionResponse::Permission { allow } = response else {
+            anyhow::bail!("owner returned mismatched permission response");
+        };
+        self.respond_permission(session_id, request_id, allow)
+            .await?;
+        Ok(tokio::time::Instant::now().duration_since(wait_started))
+    }
+
+    async fn continue_question_with_owner(
+        &self,
+        owner: &crate::owner::OwnerRuntime,
+        correlation: &crate::owner::InterruptionCorrelation,
+        request_id: &str,
+    ) -> Result<Duration> {
+        owner.publish_pending(correlation)?;
+        let wait_started = tokio::time::Instant::now();
+        let response = owner.await_response(correlation).await?;
+        let crate::owner::InterruptionResponse::Question { answers } = response else {
+            anyhow::bail!("owner returned mismatched question response");
+        };
+        self.respond_question_answers(request_id, answers).await?;
+        Ok(tokio::time::Instant::now().duration_since(wait_started))
     }
 
     pub async fn respond_permission(
@@ -560,20 +1087,80 @@ impl OpenCodeSupervisor {
         Ok(())
     }
 
-    pub async fn respond_question(
+    async fn terminalize_command_task(
         &self,
-        _session_id: &str,
+        session_id: &str,
+        command_task: &mut Option<CommandTask>,
+        observed_local: LocalTaskDisposition,
+        abort_server: bool,
+    ) -> TaskDisposition {
+        let server_abort = if abort_server {
+            match self.client.sessions().abort(session_id).await {
+                Ok(aborted) => ServerAbortDisposition::Succeeded { aborted },
+                Err(OpencodeError::Transport(_)) => ServerAbortDisposition::Failed {
+                    failure: CleanupFailure::Transport,
+                },
+                Err(_) => ServerAbortDisposition::Failed {
+                    failure: CleanupFailure::Server,
+                },
+            }
+        } else {
+            ServerAbortDisposition::NotRequired
+        };
+
+        let local_task = match command_task.take() {
+            None => observed_local,
+            Some(task) if task.is_finished() => match task.await {
+                Ok(Ok(())) => LocalTaskDisposition::Completed,
+                Ok(Err(_)) => LocalTaskDisposition::ReturnedError,
+                Err(error) if error.is_cancelled() => LocalTaskDisposition::JoinCancelled,
+                Err(_) => LocalTaskDisposition::JoinPanicked,
+            },
+            Some(task) => {
+                task.abort();
+                match task.await {
+                    Err(error) if error.is_cancelled() => LocalTaskDisposition::AbortedAndJoined,
+                    Err(_) => LocalTaskDisposition::JoinPanicked,
+                    Ok(Ok(())) => LocalTaskDisposition::Completed,
+                    Ok(Err(_)) => LocalTaskDisposition::ReturnedError,
+                }
+            }
+        };
+
+        TaskDisposition {
+            server_abort,
+            local_task,
+        }
+    }
+
+    async fn terminal_failure(
+        &self,
+        session_id: String,
+        terminal: TerminalFailure,
+        command_task: &mut Option<CommandTask>,
+        observed_local: LocalTaskDisposition,
+    ) -> SupervisedOutcome {
+        let task_disposition = self
+            .terminalize_command_task(&session_id, command_task, observed_local, true)
+            .await;
+        SupervisedOutcome::Failed {
+            session_id: Some(session_id),
+            error: terminal.error,
+            diagnostics: terminal.diagnostics,
+            literal_post_attempts: terminal.literal_post_attempts,
+            failure: terminal.failure,
+            task_disposition,
+        }
+    }
+
+    async fn respond_question_answers(
+        &self,
         request_id: &str,
-        answer: &str,
+        answers: Vec<Vec<String>>,
     ) -> Result<()> {
         self.client
             .question()
-            .reply(
-                request_id,
-                &QuestionReply {
-                    answers: vec![vec![answer.to_string()]],
-                },
-            )
+            .reply(request_id, &QuestionReply { answers })
             .await
             .with_context(|| format!("failed to respond to question request {request_id}"))?;
         Ok(())
@@ -582,6 +1169,7 @@ impl OpenCodeSupervisor {
     async fn preflight_pending_interruptions(
         &self,
         session_id: &str,
+        literal_post_attempts: u32,
     ) -> Result<Option<SupervisedOutcome>> {
         let permissions = self
             .client
@@ -597,6 +1185,7 @@ impl OpenCodeSupervisor {
                 session_id: session_id.to_string(),
                 request_id: permission.id,
                 permission_type: permission.permission,
+                literal_post_attempts,
             }));
         }
 
@@ -618,6 +1207,7 @@ impl OpenCodeSupervisor {
                     .first()
                     .map(|entry| entry.question.clone())
                     .unwrap_or_default(),
+                literal_post_attempts,
             }));
         }
 
@@ -629,19 +1219,39 @@ impl OpenCodeSupervisor {
         session_id: String,
         transcript_window: &TranscriptWindow,
         command_transport_error: Option<&String>,
+        literal_post_attempts: u32,
+        command_task: &mut Option<CommandTask>,
+        observed_local: LocalTaskDisposition,
     ) -> SupervisedOutcome {
-        let outcome = match self
-            .validate_completion_with_retries(&session_id, transcript_window)
-            .await
-        {
+        let validation = self
+            .validate_completion_with_retries(&session_id, transcript_window, literal_post_attempts)
+            .await;
+        let abort_server = !matches!(validation, CompletionValidation::Passed(_));
+        let task_disposition = self
+            .terminalize_command_task(&session_id, command_task, observed_local, abort_server)
+            .await;
+        let outcome = match validation {
             CompletionValidation::Passed(diagnostics) => SupervisedOutcome::Completed {
                 session_id,
                 diagnostics,
+                literal_post_attempts,
+                task_disposition,
             },
+            CompletionValidation::AcceptedButNotStarted(diagnostics) => {
+                SupervisedOutcome::AcceptedButNotStarted {
+                    session_id,
+                    diagnostics,
+                    literal_post_attempts,
+                    task_disposition,
+                }
+            }
             CompletionValidation::Failed { error, diagnostics } => SupervisedOutcome::Failed {
                 session_id: Some(session_id),
                 error,
                 diagnostics,
+                literal_post_attempts,
+                failure: InvocationFailure::CompletionValidation,
+                task_disposition,
             },
         };
 
@@ -665,6 +1275,7 @@ impl OpenCodeSupervisor {
         &self,
         session_id: &str,
         transcript_window: &TranscriptWindow,
+        literal_post_attempts: u32,
     ) -> CompletionValidation {
         for attempt in 0..=TRANSCRIPT_SETTLING_RETRY_BACKOFFS.len() {
             if attempt > 0 {
@@ -684,7 +1295,8 @@ impl OpenCodeSupervisor {
             };
 
             let analysis = analyze_transcript_window(&messages, transcript_window);
-            let diagnostics = analysis.diagnostics(&transcript_window.command_message_id);
+            let diagnostics =
+                analysis.diagnostics(&transcript_window.command_message_id, literal_post_attempts);
             if analysis.guard_detected {
                 return CompletionValidation::Failed {
                     error:
@@ -715,7 +1327,7 @@ impl OpenCodeSupervisor {
                 return CompletionValidation::Passed(diagnostics);
             }
             if attempt == TRANSCRIPT_SETTLING_RETRY_BACKOFFS.len() {
-                return CompletionValidation::Passed(diagnostics);
+                return CompletionValidation::AcceptedButNotStarted(diagnostics);
             }
         }
 
@@ -760,13 +1372,19 @@ fn analyze_transcript_window(
                 .as_ref()
                 .and_then(|baseline| messages.iter().position(|message| message.id() == baseline))
                 .map(|index| index + 1)
-        })
-        .unwrap_or(0);
-    let window = &messages[start_index.min(messages.len())..];
-    let final_assistant = window
-        .iter()
-        .rev()
-        .find(|message| message.role() == "assistant");
+        });
+    let window = start_index.map_or(&[][..], |index| &messages[index.min(messages.len())..]);
+    let lineage_assistant = window.iter().rev().find(|message| {
+        message.role() == "assistant"
+            && message.info.parent_id.as_deref()
+                == Some(transcript_window.command_message_id.as_str())
+    });
+    let final_assistant = lineage_assistant.or_else(|| {
+        window
+            .iter()
+            .rev()
+            .find(|message| message.role() == "assistant" && message.info.parent_id.is_none())
+    });
     let mut guard_detected = false;
     let mut unresolved_tool_calls = 0;
 
@@ -844,23 +1462,47 @@ fn attach_transport_warning(
         SupervisedOutcome::Completed {
             session_id,
             mut diagnostics,
+            literal_post_attempts,
+            task_disposition,
         } => {
             diagnostics.command_transport_error.get_or_insert(warning);
             SupervisedOutcome::Completed {
                 session_id,
                 diagnostics,
+                literal_post_attempts,
+                task_disposition,
+            }
+        }
+        SupervisedOutcome::AcceptedButNotStarted {
+            session_id,
+            mut diagnostics,
+            literal_post_attempts,
+            task_disposition,
+        } => {
+            diagnostics.command_transport_error.get_or_insert(warning);
+            SupervisedOutcome::AcceptedButNotStarted {
+                session_id,
+                diagnostics,
+                literal_post_attempts,
+                task_disposition,
             }
         }
         SupervisedOutcome::Failed {
             session_id,
             error,
             diagnostics: Some(mut diagnostics),
+            literal_post_attempts,
+            failure,
+            task_disposition,
         } => {
             diagnostics.command_transport_error.get_or_insert(warning);
             SupervisedOutcome::Failed {
                 session_id,
                 error,
                 diagnostics: Some(diagnostics),
+                literal_post_attempts,
+                failure,
+                task_disposition,
             }
         }
         other => other,
@@ -1020,6 +1662,89 @@ mod tests {
         })
     }
 
+    fn transcript_message_with_parent(
+        role: &str,
+        id: &str,
+        parent_id: Option<&str>,
+    ) -> serde_json::Value {
+        let mut message = transcript_message(role, id, &serde_json::json!([]));
+        if let Some(parent_id) = parent_id {
+            message["info"]["parentID"] = serde_json::json!(parent_id);
+        }
+        message
+    }
+
+    #[test]
+    fn transcript_requires_parent_correlation_when_lineage_is_present() {
+        let messages: Vec<Message> = serde_json::from_value(serde_json::json!([
+            transcript_message("user", "msg-command", &serde_json::json!([])),
+            transcript_message_with_parent("assistant", "msg-wrong", Some("msg-other")),
+            transcript_message_with_parent("assistant", "msg-current", Some("msg-command"))
+        ]))
+        .unwrap();
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-command".to_string(),
+                baseline_tail_message_id: None,
+            },
+        );
+
+        assert!(analysis.has_assistant_message);
+        assert_eq!(
+            analysis.final_assistant_message_id.as_deref(),
+            Some("msg-current")
+        );
+    }
+
+    #[test]
+    fn transcript_fallback_accepts_only_lineage_absent_assistant_in_anchored_window() {
+        let messages: Vec<Message> = serde_json::from_value(serde_json::json!([
+            transcript_message_with_parent("assistant", "msg-before", None),
+            transcript_message("user", "msg-baseline", &serde_json::json!([])),
+            transcript_message("user", "msg-command", &serde_json::json!([])),
+            transcript_message_with_parent("assistant", "msg-wrong", Some("msg-other")),
+            transcript_message_with_parent("assistant", "msg-fallback", None)
+        ]))
+        .unwrap();
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-command".to_string(),
+                baseline_tail_message_id: Some("msg-baseline".to_string()),
+            },
+        );
+
+        assert_eq!(
+            analysis.final_assistant_message_id.as_deref(),
+            Some("msg-fallback")
+        );
+    }
+
+    #[test]
+    fn transcript_without_current_anchor_excludes_unrelated_assistant() {
+        let messages: Vec<Message> =
+            serde_json::from_value(serde_json::json!([transcript_message_with_parent(
+                "assistant",
+                "msg-unrelated",
+                None
+            )]))
+            .unwrap();
+
+        let analysis = analyze_transcript_window(
+            &messages,
+            &TranscriptWindow {
+                command_message_id: "msg-missing".to_string(),
+                baseline_tail_message_id: Some("baseline-missing".to_string()),
+            },
+        );
+
+        assert!(!analysis.has_assistant_message);
+        assert_eq!(analysis.final_assistant_message_id, None);
+    }
+
     fn parse_messages(value: serde_json::Value) -> Vec<Message> {
         serde_json::from_value(value).unwrap()
     }
@@ -1030,6 +1755,57 @@ mod tests {
             idle_gate_decision(false, None, tokio::time::Instant::now()),
             IdleGateDecision::IgnoreUntilDispatchConfirmed
         );
+    }
+
+    #[test]
+    fn status_observation_preserves_absence_and_all_present_variants() {
+        let mut statuses = HashMap::new();
+        assert_eq!(
+            observe_session_status(&statuses, "session-1"),
+            SessionStatusObservation::Absent
+        );
+
+        statuses.insert("session-1".to_string(), SessionStatusInfo::Idle);
+        assert_eq!(
+            observe_session_status(&statuses, "session-1"),
+            SessionStatusObservation::Idle
+        );
+
+        for status in [
+            SessionStatusInfo::Busy,
+            SessionStatusInfo::Retry {
+                attempt: 1,
+                message: "retrying".to_string(),
+                next: 42,
+            },
+            SessionStatusInfo::Unknown,
+        ] {
+            statuses.insert("session-1".to_string(), status);
+            assert_eq!(
+                observe_session_status(&statuses, "session-1"),
+                SessionStatusObservation::BusyLike
+            );
+        }
+    }
+
+    #[test]
+    fn event_session_correlation_rejects_explicit_wrong_session() {
+        assert!(event_session_matches(None, "session-1"));
+        assert!(event_session_matches(Some("session-1"), "session-1"));
+        assert!(!event_session_matches(Some("session-2"), "session-1"));
+    }
+
+    #[test]
+    fn authorized_wait_suspends_both_supervision_clocks() {
+        let original_deadline = tokio::time::Instant::now() + Duration::from_mins(1);
+        let original_activity = tokio::time::Instant::now();
+        let mut deadline = original_deadline;
+        let mut last_activity = original_activity;
+
+        suspend_supervision_clocks(&mut deadline, &mut last_activity, Duration::from_secs(45));
+
+        assert_eq!(deadline, original_deadline + Duration::from_secs(45));
+        assert_eq!(last_activity, original_activity + Duration::from_secs(45));
     }
 
     #[test]
@@ -1082,7 +1858,7 @@ mod tests {
 
         let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
         let outcome = supervisor
-            .preflight_pending_interruptions("session-1")
+            .preflight_pending_interruptions("session-1", 0)
             .await
             .unwrap();
 
@@ -1114,7 +1890,7 @@ mod tests {
 
         let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
         let outcome = supervisor
-            .preflight_pending_interruptions("session-2")
+            .preflight_pending_interruptions("session-2", 0)
             .await
             .unwrap();
 
@@ -1170,21 +1946,24 @@ mod tests {
 
     #[test]
     fn detects_guard_text_as_failure() {
-        let messages = parse_messages(serde_json::json!([transcript_message(
-            "assistant",
-            "msg-assistant",
-            &serde_json::json!([
-                {
-                    "type": "text",
-                    "text": "nested launch blocked by OPENCODE_ORCHESTRATOR_MANAGED"
-                }
-            ])
-        )]));
+        let messages = parse_messages(serde_json::json!([
+            transcript_message("user", "msg-command", &serde_json::json!([])),
+            transcript_message(
+                "assistant",
+                "msg-assistant",
+                &serde_json::json!([
+                    {
+                        "type": "text",
+                        "text": "nested launch blocked by OPENCODE_ORCHESTRATOR_MANAGED"
+                    }
+                ])
+            )
+        ]));
 
         let analysis = analyze_transcript_window(
             &messages,
             &TranscriptWindow {
-                command_message_id: "msg-missing".to_string(),
+                command_message_id: "msg-command".to_string(),
                 baseline_tail_message_id: None,
             },
         );
@@ -1319,6 +2098,7 @@ mod tests {
                     command_message_id: "msg-dispatch".to_string(),
                     baseline_tail_message_id: None,
                 },
+                1,
             )
             .await;
 
@@ -1333,7 +2113,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_assistant_after_settling_still_passes() {
+    async fn missing_assistant_after_settling_is_accepted_but_not_started() {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/session/session-1/message"))
@@ -1351,11 +2131,12 @@ mod tests {
                     command_message_id: "msg-dispatch".to_string(),
                     baseline_tail_message_id: None,
                 },
+                1,
             )
             .await;
 
-        let CompletionValidation::Passed(diagnostics) = validation else {
-            panic!("expected transcript validation success without assistant");
+        let CompletionValidation::AcceptedButNotStarted(diagnostics) = validation else {
+            panic!("expected accepted-but-not-started classification without assistant");
         };
         assert_eq!(diagnostics.final_assistant_message_id, None);
     }
@@ -1396,6 +2177,7 @@ mod tests {
                     command_message_id: "msg-dispatch".to_string(),
                     baseline_tail_message_id: None,
                 },
+                1,
             )
             .await;
 
@@ -1472,6 +2254,7 @@ mod tests {
                     command_message_id: "msg-dispatch".to_string(),
                     baseline_tail_message_id: None,
                 },
+                1,
             )
             .await;
 
@@ -1510,6 +2293,7 @@ mod tests {
                     command_message_id: "msg-dispatch".to_string(),
                     baseline_tail_message_id: None,
                 },
+                1,
             )
             .await;
 
@@ -1572,15 +2356,22 @@ mod tests {
             .await;
 
         let transcript_seq = SequenceResponder::new(vec![
-            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
             ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
-                "assistant",
-                "msg-assistant",
-                &serde_json::json!([
-                    { "type": "text", "text": "done" },
-                    { "type": "step-finish", "reason": "stop", "cost": 0.0 }
-                ]),
+                "user",
+                "msg-baseline",
+                &serde_json::json!([])
             )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-baseline", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        { "type": "text", "text": "done" },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ]),
+                )
+            ])),
         ]);
         let transcript_seq_for_assert = transcript_seq.clone();
         Mock::given(method("GET"))
@@ -1610,7 +2401,16 @@ mod tests {
             .expect("join should succeed")
             .expect("run should succeed");
 
-        assert!(matches!(outcome, SupervisedOutcome::Completed { .. }));
+        let SupervisedOutcome::Completed {
+            diagnostics,
+            literal_post_attempts,
+            ..
+        } = outcome
+        else {
+            panic!("expected completed outcome");
+        };
+        assert_eq!(literal_post_attempts, 1);
+        assert_eq!(diagnostics.literal_post_attempts, 1);
         assert!(
             transcript_seq_for_assert.call_count() >= 2,
             "expected baseline and completion transcript fetches"
@@ -1657,15 +2457,22 @@ mod tests {
             .await;
 
         let transcript_seq = SequenceResponder::new(vec![
-            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
             ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
-                "assistant",
-                "msg-assistant",
-                &serde_json::json!([
-                    { "type": "text", "text": "done" },
-                    { "type": "step-finish", "reason": "stop", "cost": 0.0 }
-                ]),
+                "user",
+                "msg-baseline",
+                &serde_json::json!([])
             )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-baseline", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        { "type": "text", "text": "done" },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ]),
+                )
+            ])),
         ]);
         Mock::given(method("GET"))
             .and(path("/session/session-1/message"))
@@ -1693,12 +2500,18 @@ mod tests {
                 session_id: "session-1".to_string(),
                 diagnostics: OpenCodeDiagnostics {
                     checked_at: "2026-01-01T00:00:00Z".to_string(),
+                    literal_post_attempts: 1,
                     command_message_id: Some("msg-dispatch".to_string()),
                     final_assistant_message_id: Some("msg-assistant".to_string()),
                     final_finish_reason: Some("stop".to_string()),
                     guard_detected: false,
                     final_tool_error: None,
                     command_transport_error: None,
+                },
+                literal_post_attempts: 1,
+                task_disposition: TaskDisposition {
+                    server_abort: ServerAbortDisposition::NotRequired,
+                    local_task: LocalTaskDisposition::Completed,
                 },
             },
             warning.as_ref(),
@@ -1711,6 +2524,337 @@ mod tests {
             diagnostics.command_transport_error.as_deref(),
             Some("Transport error: timeout")
         );
+    }
+
+    #[tokio::test]
+    async fn uncertain_terminalization_aborts_server_then_joins_local_task() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/abort"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(true))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let mut task = Some(tokio::spawn(async {
+            std::future::pending::<()>().await;
+            Ok::<(), OpencodeError>(())
+        }));
+
+        let disposition = supervisor
+            .terminalize_command_task("session-1", &mut task, LocalTaskDisposition::Spawned, true)
+            .await;
+
+        assert_eq!(
+            disposition.server_abort,
+            ServerAbortDisposition::Succeeded { aborted: true }
+        );
+        assert_eq!(
+            disposition.local_task,
+            LocalTaskDisposition::AbortedAndJoined
+        );
+        assert!(task.is_none());
+    }
+
+    #[tokio::test]
+    async fn normal_terminalization_never_aborts_server() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/abort"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(true))
+            .expect(0)
+            .mount(&mock)
+            .await;
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let mut task = Some(tokio::spawn(async {
+            std::future::pending::<()>().await;
+            Ok::<(), OpencodeError>(())
+        }));
+
+        let disposition = supervisor
+            .terminalize_command_task("session-1", &mut task, LocalTaskDisposition::Spawned, false)
+            .await;
+
+        assert_eq!(
+            disposition.server_abort,
+            ServerAbortDisposition::NotRequired
+        );
+        assert_eq!(
+            disposition.local_task,
+            LocalTaskDisposition::AbortedAndJoined
+        );
+    }
+
+    #[tokio::test]
+    async fn persistence_callback_failure_aborts_server_and_joins_command_task() {
+        let mock = MockServer::start().await;
+        mount_existing_session(&mock).await;
+        mount_empty_interruptions(&mock).await;
+        mount_stalled_event_stream(&mock).await;
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(30))
+                    .set_body_json(serde_json::json!({})),
+            )
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/abort"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(true))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let supervisor = test_supervisor(&mock, TempDir::new().unwrap().path());
+        let PreparedCommandOutcome::Prepared(prepared) = supervisor
+            .prepare_command(
+                SessionSelection::Reuse("session-1".to_string()),
+                "implement_plan",
+                Some("do it"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected prepared command");
+        };
+        let outcome = supervisor
+            .run_prepared_command(prepared, None, None, |event| match event {
+                SupervisionEvent::LiteralPostAttempt { .. } => {
+                    anyhow::bail!("state persistence failed")
+                }
+                _ => Ok(()),
+            })
+            .await
+            .unwrap();
+
+        let SupervisedOutcome::Failed {
+            failure,
+            task_disposition,
+            ..
+        } = outcome
+        else {
+            panic!("expected terminal failure");
+        };
+        assert_eq!(failure, InvocationFailure::Persistence);
+        assert_eq!(
+            task_disposition.server_abort,
+            ServerAbortDisposition::Succeeded { aborted: true }
+        );
+        assert_eq!(
+            task_disposition.local_task,
+            LocalTaskDisposition::AbortedAndJoined
+        );
+    }
+
+    async fn run_owner_pause_continuation_case(
+        interruption_event: serde_json::Value,
+        reply_path: &str,
+        response: crate::owner::InterruptionResponse,
+    ) {
+        let mock = MockServer::start().await;
+        mount_existing_session(&mock).await;
+        mount_stalled_event_stream(&mock).await;
+        let properties = interruption_event
+            .get("properties")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let empty = ResponseTemplate::new(200).set_body_json(serde_json::json!([]));
+        let pending =
+            ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(vec![properties]));
+        match interruption_event
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("permission.asked") => {
+                Mock::given(method("GET"))
+                    .and(path("/permission"))
+                    .respond_with(SequenceResponder::new(vec![
+                        empty.clone(),
+                        pending,
+                        empty.clone(),
+                    ]))
+                    .mount(&mock)
+                    .await;
+                Mock::given(method("GET"))
+                    .and(path("/question"))
+                    .respond_with(empty.clone())
+                    .mount(&mock)
+                    .await;
+            }
+            Some("question.asked") => {
+                Mock::given(method("GET"))
+                    .and(path("/permission"))
+                    .respond_with(empty.clone())
+                    .mount(&mock)
+                    .await;
+                Mock::given(method("GET"))
+                    .and(path("/question"))
+                    .respond_with(SequenceResponder::new(vec![
+                        empty.clone(),
+                        pending,
+                        empty.clone(),
+                    ]))
+                    .mount(&mock)
+                    .await;
+            }
+            other => panic!("unsupported interruption event type: {other:?}"),
+        }
+        Mock::given(method("GET"))
+            .and(path("/session/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/command"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(100))
+                    .set_body_json(serde_json::json!({})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(reply_path))
+            .respond_with(ResponseTemplate::new(200).set_body_json(true))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/session/session-1/abort"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(true))
+            .expect(0)
+            .mount(&mock)
+            .await;
+        let transcript_seq = SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([transcript_message(
+                "user",
+                "msg-baseline",
+                &serde_json::json!([])
+            )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                transcript_message("user", "msg-baseline", &serde_json::json!([])),
+                transcript_message(
+                    "assistant",
+                    "msg-assistant",
+                    &serde_json::json!([
+                        { "type": "text", "text": "done" },
+                        { "type": "step-finish", "reason": "stop", "cost": 0.0 }
+                    ])
+                )
+            ])),
+        ]);
+        Mock::given(method("GET"))
+            .and(path("/session/session-1/message"))
+            .respond_with(transcript_seq)
+            .mount(&mock)
+            .await;
+
+        let worktree = TempDir::new().unwrap();
+        let owner = crate::owner::OwnerRuntime::acquire(worktree.path()).unwrap();
+        let supervisor = test_supervisor(&mock, worktree.path());
+        let PreparedCommandOutcome::Prepared(prepared) = supervisor
+            .prepare_command(
+                SessionSelection::Reuse("session-1".to_string()),
+                "implement_plan",
+                Some("do it"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected prepared command");
+        };
+        let owner_context = InvocationOwnerContext {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+        };
+        let observed_events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let callback_events = Arc::clone(&observed_events);
+        let run = tokio::spawn(async move {
+            supervisor
+                .run_prepared_command(prepared, Some(&owner), Some(&owner_context), move |event| {
+                    callback_events.lock().unwrap().push(match event {
+                        SupervisionEvent::Paused { .. } => "paused",
+                        SupervisionEvent::Resumed { .. } => "resumed",
+                        SupervisionEvent::LiteralPostAttempt { .. } => "post",
+                        SupervisionEvent::AssistantStarted { .. } => "assistant",
+                    });
+                    Ok(())
+                })
+                .await
+        });
+
+        let mut sent = false;
+        for _ in 0..100 {
+            if crate::owner::send_response(worktree.path(), response.clone())
+                .await
+                .is_ok()
+            {
+                sent = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(sent, "responder should reach the live foreground owner");
+        let outcome = timeout(Duration::from_secs(5), run)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(matches!(outcome, SupervisedOutcome::Completed { .. }));
+        let events = observed_events.lock().unwrap();
+        assert!(events.contains(&"post"));
+        assert!(events.contains(&"paused"));
+        assert!(events.contains(&"resumed"));
+    }
+
+    #[tokio::test]
+    async fn permission_pause_continues_same_one_post_invocation() {
+        run_owner_pause_continuation_case(
+            serde_json::json!({
+                "type": "permission.asked",
+                "properties": {
+                    "id": "permission-1",
+                    "sessionID": "session-1",
+                    "permission": "file.write",
+                    "patterns": ["**/*.rs"]
+                }
+            }),
+            "/permission/permission-1/reply",
+            crate::owner::InterruptionResponse::Permission { allow: true },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn question_pause_continues_same_one_post_invocation() {
+        run_owner_pause_continuation_case(
+            serde_json::json!({
+                "type": "question.asked",
+                "properties": {
+                    "id": "question-1",
+                    "sessionID": "session-1",
+                    "questions": [{"question": "Continue?"}]
+                }
+            }),
+            "/question/question-1/reply",
+            crate::owner::InterruptionResponse::Question {
+                answers: vec![vec!["Yes".to_string()]],
+            },
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-const IDLE_GRACE: Duration = Duration::from_secs(1);
+const IDLE_GRACE: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const TRANSCRIPT_SETTLING_RETRY_BACKOFFS: [Duration; 4] = [
     Duration::from_millis(50),
@@ -484,6 +484,7 @@ impl OpenCodeSupervisor {
         let mut observed_busy = false;
         let mut assistant_started = false;
         let mut correlated_assistant_ids = HashSet::new();
+        let mut handled_interruptions = HashSet::new();
         let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
         let mut awaiting_idle_grace = false;
         let mut sse_active = true;
@@ -574,6 +575,13 @@ impl OpenCodeSupervisor {
                             }
                             if let (Some(owner), Some(owner_context)) = (owner, owner_context) {
                                 let request_id = properties.request.id;
+                                let interruption_key = (
+                                    crate::state::InterruptionKind::Permission,
+                                    request_id.clone(),
+                                );
+                                if handled_interruptions.contains(&interruption_key) {
+                                    continue;
+                                }
                                 let correlation = crate::owner::InterruptionCorrelation {
                                     run_id: owner_context.run_id.clone(),
                                     invocation_id: owner_context.invocation_id.clone(),
@@ -600,6 +608,7 @@ impl OpenCodeSupervisor {
                                         terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
                                     }
                                 };
+                                handled_interruptions.insert(interruption_key);
                                 suspend_supervision_clocks(
                                     &mut deadline,
                                     &mut last_activity,
@@ -621,6 +630,13 @@ impl OpenCodeSupervisor {
                             }
                             if let (Some(owner), Some(owner_context)) = (owner, owner_context) {
                                 let request_id = properties.request.id;
+                                let interruption_key = (
+                                    crate::state::InterruptionKind::Question,
+                                    request_id.clone(),
+                                );
+                                if handled_interruptions.contains(&interruption_key) {
+                                    continue;
+                                }
                                 let correlation = crate::owner::InterruptionCorrelation {
                                     run_id: owner_context.run_id.clone(),
                                     invocation_id: owner_context.invocation_id.clone(),
@@ -642,6 +658,7 @@ impl OpenCodeSupervisor {
                                         terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
                                     }
                                 };
+                                handled_interruptions.insert(interruption_key);
                                 suspend_supervision_clocks(
                                     &mut deadline,
                                     &mut last_activity,
@@ -763,7 +780,14 @@ impl OpenCodeSupervisor {
                                 Some(owner),
                                 Some(owner_context),
                                 SupervisedOutcome::PermissionRequired { request_id, .. },
-                            ) => {
+                            ) if !handled_interruptions.contains(&(
+                                crate::state::InterruptionKind::Permission,
+                                request_id.clone(),
+                            )) => {
+                                let interruption_key = (
+                                    crate::state::InterruptionKind::Permission,
+                                    request_id.clone(),
+                                );
                                 let correlation = crate::owner::InterruptionCorrelation {
                                     run_id: owner_context.run_id.clone(),
                                     invocation_id: owner_context.invocation_id.clone(),
@@ -790,6 +814,7 @@ impl OpenCodeSupervisor {
                                         terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
                                     }
                                 };
+                                handled_interruptions.insert(interruption_key);
                                 suspend_supervision_clocks(
                                     &mut deadline,
                                     &mut last_activity,
@@ -802,7 +827,14 @@ impl OpenCodeSupervisor {
                                 Some(owner),
                                 Some(owner_context),
                                 SupervisedOutcome::QuestionRequired { request_id, .. },
-                            ) => {
+                            ) if !handled_interruptions.contains(&(
+                                crate::state::InterruptionKind::Question,
+                                request_id.clone(),
+                            )) => {
+                                let interruption_key = (
+                                    crate::state::InterruptionKind::Question,
+                                    request_id.clone(),
+                                );
                                 let correlation = crate::owner::InterruptionCorrelation {
                                     run_id: owner_context.run_id.clone(),
                                     invocation_id: owner_context.invocation_id.clone(),
@@ -824,6 +856,7 @@ impl OpenCodeSupervisor {
                                         terminal_runtime_error!(InvocationFailure::OwnerIpc, error);
                                     }
                                 };
+                                handled_interruptions.insert(interruption_key);
                                 suspend_supervision_clocks(
                                     &mut deadline,
                                     &mut last_activity,
@@ -832,6 +865,12 @@ impl OpenCodeSupervisor {
                                 emit_event!(SupervisionEvent::Resumed { assistant_started });
                                 continue;
                             }
+                            (
+                                Some(_),
+                                Some(_),
+                                SupervisedOutcome::PermissionRequired { .. }
+                                | SupervisedOutcome::QuestionRequired { .. },
+                            ) => {}
                             (_, _, outcome) => return Ok(outcome),
                         }
                     }
@@ -1758,6 +1797,11 @@ mod tests {
     }
 
     #[test]
+    fn idle_grace_is_strictly_longer_than_poll_interval() {
+        assert!(IDLE_GRACE > POLL_INTERVAL);
+    }
+
+    #[test]
     fn status_observation_preserves_absence_and_all_present_variants() {
         let mut statuses = HashMap::new();
         assert_eq!(
@@ -2662,10 +2706,25 @@ mod tests {
         interruption_event: serde_json::Value,
         reply_path: &str,
         response: crate::owner::InterruptionResponse,
+        pending_repetitions: usize,
+        interleave_sse_after_poll: bool,
     ) {
         let mock = MockServer::start().await;
         mount_existing_session(&mock).await;
-        mount_stalled_event_stream(&mock).await;
+        if interleave_sse_after_poll {
+            Mock::given(method("GET"))
+                .and(path("/event"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("content-type", "text/event-stream")
+                        .set_delay(Duration::from_millis(300))
+                        .set_body_string(format!("data: {interruption_event}\n\n")),
+                )
+                .mount(&mock)
+                .await;
+        } else {
+            mount_stalled_event_stream(&mock).await;
+        }
         let properties = interruption_event
             .get("properties")
             .cloned()
@@ -2673,6 +2732,9 @@ mod tests {
         let empty = ResponseTemplate::new(200).set_body_json(serde_json::json!([]));
         let pending =
             ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(vec![properties]));
+        let mut pending_sequence = vec![empty.clone()];
+        pending_sequence.extend(std::iter::repeat_n(pending, pending_repetitions));
+        pending_sequence.push(empty.clone());
         match interruption_event
             .get("type")
             .and_then(serde_json::Value::as_str)
@@ -2680,11 +2742,7 @@ mod tests {
             Some("permission.asked") => {
                 Mock::given(method("GET"))
                     .and(path("/permission"))
-                    .respond_with(SequenceResponder::new(vec![
-                        empty.clone(),
-                        pending,
-                        empty.clone(),
-                    ]))
+                    .respond_with(SequenceResponder::new(pending_sequence))
                     .mount(&mock)
                     .await;
                 Mock::given(method("GET"))
@@ -2701,11 +2759,7 @@ mod tests {
                     .await;
                 Mock::given(method("GET"))
                     .and(path("/question"))
-                    .respond_with(SequenceResponder::new(vec![
-                        empty.clone(),
-                        pending,
-                        empty.clone(),
-                    ]))
+                    .respond_with(SequenceResponder::new(pending_sequence))
                     .mount(&mock)
                     .await;
             }
@@ -2816,8 +2870,11 @@ mod tests {
         assert!(matches!(outcome, SupervisedOutcome::Completed { .. }));
         let events = observed_events.lock().unwrap();
         assert!(events.contains(&"post"));
-        assert!(events.contains(&"paused"));
-        assert!(events.contains(&"resumed"));
+        assert_eq!(events.iter().filter(|event| **event == "paused").count(), 1);
+        assert_eq!(
+            events.iter().filter(|event| **event == "resumed").count(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -2834,6 +2891,8 @@ mod tests {
             }),
             "/permission/permission-1/reply",
             crate::owner::InterruptionResponse::Permission { allow: true },
+            1,
+            false,
         )
         .await;
     }
@@ -2853,8 +2912,65 @@ mod tests {
             crate::owner::InterruptionResponse::Question {
                 answers: vec![vec!["Yes".to_string()]],
             },
+            1,
+            false,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn duplicate_polled_permission_is_handled_once() {
+        run_owner_pause_continuation_case(
+            serde_json::json!({
+                "type": "permission.asked",
+                "properties": {
+                    "id": "permission-1",
+                    "sessionID": "session-1",
+                    "permission": "file.write",
+                    "patterns": ["**/*.rs"]
+                }
+            }),
+            "/permission/permission-1/reply",
+            crate::owner::InterruptionResponse::Permission { allow: true },
+            2,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn polled_question_then_duplicate_sse_event_is_handled_once() {
+        run_owner_pause_continuation_case(
+            serde_json::json!({
+                "type": "question.asked",
+                "properties": {
+                    "id": "question-1",
+                    "sessionID": "session-1",
+                    "questions": [{"question": "Continue?"}]
+                }
+            }),
+            "/question/question-1/reply",
+            crate::owner::InterruptionResponse::Question {
+                answers: vec![vec!["Yes".to_string()]],
+            },
+            1,
+            true,
+        )
+        .await;
+    }
+
+    #[test]
+    fn interruption_deduplication_distinguishes_kinds_for_same_request_id() {
+        let mut handled = HashSet::new();
+        handled.insert((
+            crate::state::InterruptionKind::Permission,
+            "request-1".to_string(),
+        ));
+
+        assert!(!handled.contains(&(
+            crate::state::InterruptionKind::Question,
+            "request-1".to_string(),
+        )));
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/owner.rs
+++ b/apps/agentic-outer-dag/src/owner.rs
@@ -164,8 +164,8 @@ impl OwnerRuntime {
                 reject_reply(&mut stream, error.to_string()).await;
                 continue;
             }
-            write_reply_bounded(&mut stream, true, None).await?;
             self.clear_pending()?;
+            write_reply_bounded(&mut stream, true, None).await?;
             return Ok(request.response);
         }
     }
@@ -610,6 +610,50 @@ mod tests {
             .await
             .is_err()
         );
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "test intentionally serializes process-wide environment mutation"
+    )]
+    async fn cleanup_failure_does_not_emit_an_accepted_reply() {
+        let _guard = process_state_lock().lock().unwrap();
+        let runtime = TempDir::new().unwrap();
+        std::fs::set_permissions(runtime.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let _runtime_dir = EnvVarGuard::set("XDG_RUNTIME_DIR", runtime.path());
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = permission_correlation();
+        owner.publish_pending(&correlation).unwrap();
+
+        let request = IpcRequest {
+            protocol_version: PROTOCOL_VERSION,
+            worktree_hash: owner.worktree_hash.clone(),
+            owner_token: owner.owner_token.clone(),
+            correlation: correlation.clone(),
+            response: InterruptionResponse::Permission { allow: true },
+        };
+        let mut stream = UnixStream::connect(&owner.paths.socket).await.unwrap();
+        write_frame(&mut stream, &request).await.unwrap();
+
+        std::fs::remove_file(&owner.paths.manifest).unwrap();
+        std::fs::create_dir_all(&owner.paths.manifest).unwrap();
+
+        let error = owner
+            .await_response(&correlation)
+            .await
+            .expect_err("manifest cleanup failure must remain fatal");
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to remove unexpected runtime artifact")
+        );
+
+        tokio::time::timeout(IPC_TIMEOUT, read_frame::<IpcReply, _>(&mut stream))
+            .await
+            .expect("owner should close the connection without timing out")
+            .expect_err("cleanup failure must not emit an accepted reply");
     }
 
     #[tokio::test]

--- a/apps/agentic-outer-dag/src/owner.rs
+++ b/apps/agentic-outer-dag/src/owner.rs
@@ -1,0 +1,783 @@
+use crate::state::InterruptionKind;
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+use std::fs::DirBuilder;
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::fs::FileTypeExt;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use thoughts_tool::utils::locks::FileLock;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixListener;
+use tokio::net::UnixStream;
+
+const PROTOCOL_VERSION: u32 = 1;
+const MAX_FRAME_BYTES: usize = 64 * 1024;
+const MAX_RUNTIME_FILE_BYTES: u64 = MAX_FRAME_BYTES as u64;
+const MAX_SOCKET_PATH_BYTES: usize = 100;
+#[cfg(not(test))]
+const IPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(test)]
+const IPC_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+pub struct OwnerRuntime {
+    _lock: FileLock,
+    listener: UnixListener,
+    paths: RuntimePaths,
+    owner_token: String,
+    worktree_hash: String,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimePaths {
+    lock: PathBuf,
+    socket: PathBuf,
+    manifest: PathBuf,
+    manifest_temp: PathBuf,
+    secret: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InterruptionCorrelation {
+    pub run_id: String,
+    pub invocation_id: String,
+    pub session_id: String,
+    pub command_message_id: String,
+    pub kind: InterruptionKind,
+    pub request_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum InterruptionResponse {
+    Permission { allow: bool },
+    Question { answers: Vec<Vec<String>> },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OwnerManifest {
+    protocol_version: u32,
+    worktree_hash: String,
+    socket_path: PathBuf,
+    pending: InterruptionCorrelation,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IpcRequest {
+    protocol_version: u32,
+    worktree_hash: String,
+    owner_token: String,
+    correlation: InterruptionCorrelation,
+    response: InterruptionResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IpcReply {
+    accepted: bool,
+    error: Option<String>,
+}
+
+impl OwnerRuntime {
+    pub fn acquire(worktree: &Path) -> Result<Self> {
+        let canonical = worktree
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize worktree {}", worktree.display()))?;
+        let worktree_hash = worktree_hash(&canonical);
+        let paths = runtime_paths(&worktree_hash)?;
+        let lock = FileLock::try_lock_exclusive(&paths.lock)?.ok_or_else(|| {
+            anyhow::anyhow!("another agentic-outer-dag owner is active for this worktree")
+        })?;
+        std::fs::set_permissions(&paths.lock, std::fs::Permissions::from_mode(0o600))?;
+        validate_private_regular_file(&paths.lock, current_uid()?)?;
+
+        remove_stale_runtime_file(&paths.socket)?;
+        remove_stale_runtime_file(&paths.manifest)?;
+        remove_stale_runtime_file(&paths.manifest_temp)?;
+        remove_stale_runtime_file(&paths.secret)?;
+        let listener = UnixListener::bind(&paths.socket)
+            .with_context(|| format!("failed to bind owner socket {}", paths.socket.display()))?;
+        std::fs::set_permissions(&paths.socket, std::fs::Permissions::from_mode(0o600))?;
+        validate_private_socket(&paths.socket, current_uid()?)?;
+        let owner_token = generate_owner_token()?;
+        write_private_file(&paths.secret, owner_token.as_bytes(), true)?;
+
+        Ok(Self {
+            _lock: lock,
+            listener,
+            paths,
+            owner_token,
+            worktree_hash,
+        })
+    }
+
+    pub fn ensure_unlocked(worktree: &Path) -> Result<()> {
+        let canonical = worktree.canonicalize()?;
+        let paths = runtime_paths(&worktree_hash(&canonical))?;
+        let lock = FileLock::try_lock_exclusive(&paths.lock)?.ok_or_else(|| {
+            anyhow::anyhow!("another agentic-outer-dag owner is active for this worktree")
+        })?;
+        drop(lock);
+        Ok(())
+    }
+
+    pub fn publish_pending(&self, correlation: &InterruptionCorrelation) -> Result<()> {
+        let manifest = OwnerManifest {
+            protocol_version: PROTOCOL_VERSION,
+            worktree_hash: self.worktree_hash.clone(),
+            socket_path: self.paths.socket.clone(),
+            pending: correlation.clone(),
+        };
+        let bytes = serde_json::to_vec(&manifest)?;
+        write_private_file_atomic(&self.paths.manifest_temp, &self.paths.manifest, &bytes)
+    }
+
+    pub fn clear_pending(&self) -> Result<()> {
+        remove_stale_runtime_file(&self.paths.manifest)
+    }
+
+    pub async fn await_response(
+        &self,
+        expected: &InterruptionCorrelation,
+    ) -> Result<InterruptionResponse> {
+        loop {
+            let (mut stream, _) = self.listener.accept().await?;
+            let request: IpcRequest = match read_frame(&mut stream).await {
+                Ok(request) => request,
+                Err(error) => {
+                    let _ = write_reply(&mut stream, false, Some(error.to_string())).await;
+                    continue;
+                }
+            };
+            let validation = self.validate_request(&request, expected);
+            if let Err(error) = validation {
+                write_reply(&mut stream, false, Some(error.to_string())).await?;
+                continue;
+            }
+            write_reply(&mut stream, true, None).await?;
+            self.clear_pending()?;
+            return Ok(request.response);
+        }
+    }
+
+    fn validate_request(
+        &self,
+        request: &IpcRequest,
+        expected: &InterruptionCorrelation,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            request.protocol_version == PROTOCOL_VERSION,
+            "IPC protocol mismatch"
+        );
+        anyhow::ensure!(
+            request.worktree_hash == self.worktree_hash,
+            "worktree mismatch"
+        );
+        anyhow::ensure!(
+            constant_time_eq(request.owner_token.as_bytes(), self.owner_token.as_bytes()),
+            "owner authentication failed"
+        );
+        anyhow::ensure!(
+            &request.correlation == expected,
+            "interruption correlation mismatch"
+        );
+        anyhow::ensure!(
+            response_kind(&request.response) == expected.kind,
+            "response kind mismatch"
+        );
+        Ok(())
+    }
+}
+
+impl Drop for OwnerRuntime {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.paths.socket);
+        let _ = std::fs::remove_file(&self.paths.manifest);
+        let _ = std::fs::remove_file(&self.paths.manifest_temp);
+        let _ = std::fs::remove_file(&self.paths.secret);
+    }
+}
+
+pub async fn send_response(worktree: &Path, response: InterruptionResponse) -> Result<()> {
+    let canonical = worktree.canonicalize()?;
+    let hash = worktree_hash(&canonical);
+    let paths = runtime_paths(&hash)?;
+    let uid = current_uid()?;
+    validate_private_regular_file(&paths.manifest, uid).with_context(|| {
+        "no live foreground owner is awaiting this response; keep persisted pending state and recover conservatively"
+    })?;
+    validate_private_regular_file(&paths.secret, uid)?;
+    validate_private_socket(&paths.socket, uid)?;
+    let manifest_bytes = std::fs::read(&paths.manifest)?;
+    let manifest: OwnerManifest = serde_json::from_slice(&manifest_bytes)?;
+    anyhow::ensure!(
+        manifest.protocol_version == PROTOCOL_VERSION,
+        "IPC protocol mismatch"
+    );
+    anyhow::ensure!(manifest.worktree_hash == hash, "worktree mismatch");
+    anyhow::ensure!(
+        manifest.socket_path == paths.socket,
+        "unsafe owner socket path"
+    );
+    let owner_token = std::fs::read_to_string(&paths.secret)?;
+    let request = IpcRequest {
+        protocol_version: PROTOCOL_VERSION,
+        worktree_hash: hash,
+        owner_token,
+        correlation: manifest.pending,
+        response,
+    };
+    let mut stream = tokio::time::timeout(IPC_TIMEOUT, UnixStream::connect(&paths.socket))
+        .await
+        .context("timed out connecting to foreground owner")?
+        .with_context(
+            || "owner socket is unavailable; keep persisted pending state and recover conservatively",
+        )?;
+    tokio::time::timeout(IPC_TIMEOUT, write_frame(&mut stream, &request))
+        .await
+        .context("timed out sending response to foreground owner")??;
+    let reply: IpcReply = tokio::time::timeout(IPC_TIMEOUT, read_frame(&mut stream))
+        .await
+        .context("timed out awaiting foreground owner acknowledgement")??;
+    anyhow::ensure!(
+        reply.accepted,
+        "owner rejected response: {}",
+        reply.error.unwrap_or_default()
+    );
+    Ok(())
+}
+
+fn response_kind(response: &InterruptionResponse) -> InterruptionKind {
+    match response {
+        InterruptionResponse::Permission { .. } => InterruptionKind::Permission,
+        InterruptionResponse::Question { .. } => InterruptionKind::Question,
+    }
+}
+
+async fn write_reply(stream: &mut UnixStream, accepted: bool, error: Option<String>) -> Result<()> {
+    write_frame(stream, &IpcReply { accepted, error }).await
+}
+
+async fn write_frame<T: Serialize + Sync>(stream: &mut UnixStream, value: &T) -> Result<()> {
+    let bytes = serde_json::to_vec(value)?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_FRAME_BYTES,
+        "IPC frame exceeds maximum size"
+    );
+    stream.write_u32(bytes.len().try_into()?).await?;
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn read_frame<T: for<'de> Deserialize<'de>>(stream: &mut UnixStream) -> Result<T> {
+    let length = stream.read_u32().await? as usize;
+    anyhow::ensure!(length <= MAX_FRAME_BYTES, "IPC frame exceeds maximum size");
+    let mut bytes = vec![0; length];
+    stream.read_exact(&mut bytes).await?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn runtime_paths(worktree_hash: &str) -> Result<RuntimePaths> {
+    let uid = current_uid()?;
+    let preferred_base = match std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from) {
+        Some(path) if validate_private_directory(&path, uid).is_ok() => path,
+        _ => short_runtime_fallback(uid),
+    };
+    let preferred = build_runtime_paths(&preferred_base, worktree_hash);
+    let base = if preferred.socket.as_os_str().as_bytes().len() < MAX_SOCKET_PATH_BYTES {
+        preferred_base
+    } else {
+        short_runtime_fallback(uid)
+    };
+    create_private_directory(&base, uid)?;
+    let app = base.join("agentic-outer-dag");
+    create_private_directory(&app, uid)?;
+    let directory = app.join(worktree_hash);
+    create_private_directory(&directory, uid)?;
+    let paths = RuntimePaths {
+        lock: directory.join("owner.lock"),
+        socket: directory.join("owner.sock"),
+        manifest: directory.join("owner.json"),
+        manifest_temp: directory.join("owner.tmp"),
+        secret: directory.join("owner.secret"),
+    };
+    anyhow::ensure!(
+        paths.socket.as_os_str().as_bytes().len() < MAX_SOCKET_PATH_BYTES,
+        "owner socket path is too long"
+    );
+    Ok(paths)
+}
+
+fn build_runtime_paths(base: &Path, worktree_hash: &str) -> RuntimePaths {
+    let directory = base.join("agentic-outer-dag").join(worktree_hash);
+    RuntimePaths {
+        lock: directory.join("owner.lock"),
+        socket: directory.join("owner.sock"),
+        manifest: directory.join("owner.json"),
+        manifest_temp: directory.join("owner.tmp"),
+        secret: directory.join("owner.secret"),
+    }
+}
+
+fn short_runtime_fallback(uid: u32) -> PathBuf {
+    std::env::temp_dir().join(format!("agentic-outer-dag-{uid}"))
+}
+
+fn current_uid() -> Result<u32> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME is required to determine runtime ownership"))?;
+    Ok(std::fs::metadata(home)?.uid())
+}
+
+fn create_private_directory(path: &Path, uid: u32) -> Result<()> {
+    DirBuilder::new().recursive(true).mode(0o700).create(path)?;
+    validate_private_directory(path, uid)
+}
+
+fn validate_private_directory(path: &Path, uid: u32) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.file_type().is_dir(),
+        "runtime path is not a directory"
+    );
+    anyhow::ensure!(
+        !metadata.file_type().is_symlink(),
+        "runtime directory is a symlink"
+    );
+    anyhow::ensure!(metadata.uid() == uid, "runtime directory owner mismatch");
+    anyhow::ensure!(
+        metadata.permissions().mode().trailing_zeros() >= 6,
+        "runtime directory is not private"
+    );
+    Ok(())
+}
+
+fn validate_private_regular_file(path: &Path, uid: u32) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.file_type().is_file(),
+        "runtime artifact is not a regular file"
+    );
+    anyhow::ensure!(
+        !metadata.file_type().is_symlink(),
+        "runtime artifact is a symlink"
+    );
+    anyhow::ensure!(metadata.uid() == uid, "runtime artifact owner mismatch");
+    anyhow::ensure!(
+        metadata.permissions().mode().trailing_zeros() >= 6,
+        "runtime artifact is not private"
+    );
+    anyhow::ensure!(
+        metadata.len() <= MAX_RUNTIME_FILE_BYTES,
+        "runtime artifact exceeds maximum size"
+    );
+    Ok(())
+}
+
+fn validate_private_socket(path: &Path, uid: u32) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.file_type().is_socket(),
+        "runtime socket is not a socket"
+    );
+    anyhow::ensure!(
+        !metadata.file_type().is_symlink(),
+        "runtime socket is a symlink"
+    );
+    anyhow::ensure!(metadata.uid() == uid, "runtime socket owner mismatch");
+    anyhow::ensure!(
+        metadata.permissions().mode().trailing_zeros() >= 6,
+        "runtime socket is not private"
+    );
+    Ok(())
+}
+
+fn remove_stale_runtime_file(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            anyhow::ensure!(
+                !metadata.file_type().is_symlink(),
+                "refusing to remove runtime symlink"
+            );
+            anyhow::ensure!(
+                metadata.file_type().is_file() || metadata.file_type().is_socket(),
+                "refusing to remove unexpected runtime artifact"
+            );
+            std::fs::remove_file(path)?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+fn write_private_file(path: &Path, bytes: &[u8], create_new: bool) -> Result<()> {
+    anyhow::ensure!(
+        bytes.len() as u64 <= MAX_RUNTIME_FILE_BYTES,
+        "runtime artifact exceeds maximum size"
+    );
+    let uid = current_uid()?;
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => validate_private_regular_file(path, uid)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut options = OpenOptions::new();
+    options.write(true).mode(0o600);
+    if create_new {
+        options.create_new(true);
+    } else {
+        options.create(true).truncate(true);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    validate_private_regular_file(path, uid)
+}
+
+fn write_private_file_atomic(temp: &Path, destination: &Path, bytes: &[u8]) -> Result<()> {
+    remove_stale_runtime_file(temp)?;
+    if destination.exists() {
+        validate_private_regular_file(destination, current_uid()?)?;
+    }
+    write_private_file(temp, bytes, true)?;
+    std::fs::rename(temp, destination)?;
+    validate_private_regular_file(destination, current_uid()?)
+}
+
+fn generate_owner_token() -> Result<String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("secure owner-token generation failed: {error}"))?;
+    Ok(hex_encode(&bytes))
+}
+
+fn worktree_hash(worktree: &Path) -> String {
+    let digest = Sha256::digest(worktree.as_os_str().as_bytes());
+    hex_encode(&digest[..8])
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::EnvVarGuard;
+    use crate::test_support::process_state_lock;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn owner_lock_is_exclusive_and_releases_on_drop() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        assert!(OwnerRuntime::acquire(worktree.path()).is_err());
+        drop(owner);
+        assert!(OwnerRuntime::acquire(worktree.path()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn authenticated_response_roundtrip_is_single_use() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Permission,
+            request_id: "permission-1".to_string(),
+        };
+        owner.publish_pending(&correlation).unwrap();
+        let send = send_response(
+            worktree.path(),
+            InterruptionResponse::Permission { allow: true },
+        );
+        let receive = owner.await_response(&correlation);
+        let (send_result, received) = tokio::join!(send, receive);
+        send_result.unwrap();
+        assert_eq!(
+            received.unwrap(),
+            InterruptionResponse::Permission { allow: true }
+        );
+        assert!(
+            send_response(
+                worktree.path(),
+                InterruptionResponse::Permission { allow: true }
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_rejects_token_correlation_and_kind_mismatches() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let expected = InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Permission,
+            request_id: "permission-1".to_string(),
+        };
+        let mut request = IpcRequest {
+            protocol_version: PROTOCOL_VERSION,
+            worktree_hash: owner.worktree_hash.clone(),
+            owner_token: "wrong".to_string(),
+            correlation: expected.clone(),
+            response: InterruptionResponse::Permission { allow: true },
+        };
+        assert!(owner.validate_request(&request, &expected).is_err());
+        request.owner_token = owner.owner_token.clone();
+        request.protocol_version = PROTOCOL_VERSION + 1;
+        assert!(owner.validate_request(&request, &expected).is_err());
+        request.protocol_version = PROTOCOL_VERSION;
+        request.worktree_hash = "wrong-worktree".to_string();
+        assert!(owner.validate_request(&request, &expected).is_err());
+        request.worktree_hash = owner.worktree_hash.clone();
+        request.correlation.request_id = "wrong-request".to_string();
+        assert!(owner.validate_request(&request, &expected).is_err());
+        for correlation in [
+            InterruptionCorrelation {
+                run_id: "wrong-run".to_string(),
+                ..expected.clone()
+            },
+            InterruptionCorrelation {
+                invocation_id: "wrong-invocation".to_string(),
+                ..expected.clone()
+            },
+            InterruptionCorrelation {
+                session_id: "wrong-session".to_string(),
+                ..expected.clone()
+            },
+            InterruptionCorrelation {
+                command_message_id: "wrong-message".to_string(),
+                ..expected.clone()
+            },
+        ] {
+            request.correlation = correlation.clone();
+            assert!(owner.validate_request(&request, &expected).is_err());
+        }
+        request.correlation = expected.clone();
+        request.response = InterruptionResponse::Question {
+            answers: vec![vec!["yes".to_string()]],
+        };
+        assert!(owner.validate_request(&request, &expected).is_err());
+    }
+
+    #[tokio::test]
+    async fn oversized_frame_is_rejected_before_allocation() {
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        writer
+            .write_u32((MAX_FRAME_BYTES + 1).try_into().unwrap())
+            .await
+            .unwrap();
+        let result = read_frame::<IpcReply>(&mut reader).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn malformed_frame_is_rejected() {
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        writer.write_u32(1).await.unwrap();
+        writer.write_all(b"{").await.unwrap();
+        let result = read_frame::<IpcReply>(&mut reader).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn runtime_artifacts_are_private_and_socket_path_is_short() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Question,
+            request_id: "question-1".to_string(),
+        };
+        owner.publish_pending(&correlation).unwrap();
+        assert_eq!(
+            std::fs::metadata(owner.paths.socket.parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+        assert!(owner.paths.socket.as_os_str().len() < 100);
+        assert_eq!(
+            std::fs::metadata(&owner.paths.secret)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+        assert_eq!(
+            std::fs::metadata(&owner.paths.manifest)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+        assert_eq!(
+            std::fs::metadata(&owner.paths.socket)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+    }
+
+    #[test]
+    fn worktree_hash_is_stable_for_the_same_canonical_path() {
+        let worktree = TempDir::new().unwrap();
+        let canonical = worktree.path().canonicalize().unwrap();
+        assert_eq!(worktree_hash(&canonical), worktree_hash(&canonical));
+        assert_eq!(worktree_hash(&canonical).len(), 16);
+    }
+
+    #[test]
+    fn stale_cleanup_rejects_symlinks_and_unexpected_file_types() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("target");
+        std::fs::write(&target, "target").unwrap();
+        let link = temp.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(remove_stale_runtime_file(&link).is_err());
+
+        let directory = temp.path().join("directory");
+        std::fs::create_dir_all(&directory).unwrap();
+        assert!(remove_stale_runtime_file(&directory).is_err());
+    }
+
+    #[tokio::test]
+    async fn missing_owner_returns_conservative_guidance() {
+        let worktree = TempDir::new().unwrap();
+        let error = send_response(
+            worktree.path(),
+            InterruptionResponse::Permission { allow: true },
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("no live foreground owner"));
+    }
+
+    #[tokio::test]
+    async fn racing_responders_accept_exactly_one_response() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Permission,
+            request_id: "permission-1".to_string(),
+        };
+        owner.publish_pending(&correlation).unwrap();
+
+        let first = send_response(
+            worktree.path(),
+            InterruptionResponse::Permission { allow: true },
+        );
+        let second = send_response(
+            worktree.path(),
+            InterruptionResponse::Permission { allow: false },
+        );
+        let receive = owner.await_response(&correlation);
+        let (first, second, received) = tokio::join!(first, second, receive);
+
+        assert!(received.is_ok());
+        assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+    }
+
+    #[tokio::test]
+    async fn owner_acquisition_removes_stale_socket_artifact_while_locked() {
+        let worktree = TempDir::new().unwrap();
+        let canonical = worktree.path().canonicalize().unwrap();
+        let paths = runtime_paths(&worktree_hash(&canonical)).unwrap();
+        std::fs::write(&paths.socket, "stale").unwrap();
+
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&owner.paths.socket)
+                .unwrap()
+                .file_type()
+                .is_socket()
+        );
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "test intentionally serializes process-wide environment mutation"
+    )]
+    async fn responder_does_not_require_a_valid_opencode_binary() {
+        let _guard = process_state_lock().lock().unwrap();
+        let _binary = EnvVarGuard::set("OPENCODE_BINARY", "/does/not/exist");
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Permission,
+            request_id: "permission-1".to_string(),
+        };
+        owner.publish_pending(&correlation).unwrap();
+
+        let send = send_response(
+            worktree.path(),
+            InterruptionResponse::Permission { allow: true },
+        );
+        let receive = owner.await_response(&correlation);
+        let (send_result, received) = tokio::join!(send, receive);
+
+        assert!(send_result.is_ok());
+        assert!(received.is_ok());
+    }
+}

--- a/apps/agentic-outer-dag/src/owner.rs
+++ b/apps/agentic-outer-dag/src/owner.rs
@@ -17,7 +17,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 use thoughts_tool::utils::locks::FileLock;
+use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
@@ -37,6 +39,10 @@ pub struct OwnerRuntime {
     paths: RuntimePaths,
     owner_token: String,
     worktree_hash: String,
+}
+
+pub struct OwnerMutationLease {
+    _lock: FileLock,
 }
 
 #[derive(Debug, Clone)]
@@ -103,7 +109,7 @@ impl OwnerRuntime {
             anyhow::anyhow!("another agentic-outer-dag owner is active for this worktree")
         })?;
         std::fs::set_permissions(&paths.lock, std::fs::Permissions::from_mode(0o600))?;
-        validate_private_regular_file(&paths.lock, current_uid()?)?;
+        validate_private_regular_file(&paths.lock, current_uid())?;
 
         remove_stale_runtime_file(&paths.socket)?;
         remove_stale_runtime_file(&paths.manifest)?;
@@ -112,7 +118,7 @@ impl OwnerRuntime {
         let listener = UnixListener::bind(&paths.socket)
             .with_context(|| format!("failed to bind owner socket {}", paths.socket.display()))?;
         std::fs::set_permissions(&paths.socket, std::fs::Permissions::from_mode(0o600))?;
-        validate_private_socket(&paths.socket, current_uid()?)?;
+        validate_private_socket(&paths.socket, current_uid())?;
         let owner_token = generate_owner_token()?;
         write_private_file(&paths.secret, owner_token.as_bytes(), true)?;
 
@@ -123,16 +129,6 @@ impl OwnerRuntime {
             owner_token,
             worktree_hash,
         })
-    }
-
-    pub fn ensure_unlocked(worktree: &Path) -> Result<()> {
-        let canonical = worktree.canonicalize()?;
-        let paths = runtime_paths(&worktree_hash(&canonical))?;
-        let lock = FileLock::try_lock_exclusive(&paths.lock)?.ok_or_else(|| {
-            anyhow::anyhow!("another agentic-outer-dag owner is active for this worktree")
-        })?;
-        drop(lock);
-        Ok(())
     }
 
     pub fn publish_pending(&self, correlation: &InterruptionCorrelation) -> Result<()> {
@@ -156,19 +152,19 @@ impl OwnerRuntime {
     ) -> Result<InterruptionResponse> {
         loop {
             let (mut stream, _) = self.listener.accept().await?;
-            let request: IpcRequest = match read_frame(&mut stream).await {
+            let request: IpcRequest = match read_frame_bounded(&mut stream).await {
                 Ok(request) => request,
                 Err(error) => {
-                    let _ = write_reply(&mut stream, false, Some(error.to_string())).await;
+                    reject_reply(&mut stream, error.to_string()).await;
                     continue;
                 }
             };
             let validation = self.validate_request(&request, expected);
             if let Err(error) = validation {
-                write_reply(&mut stream, false, Some(error.to_string())).await?;
+                reject_reply(&mut stream, error.to_string()).await;
                 continue;
             }
-            write_reply(&mut stream, true, None).await?;
+            write_reply_bounded(&mut stream, true, None).await?;
             self.clear_pending()?;
             return Ok(request.response);
         }
@@ -203,6 +199,17 @@ impl OwnerRuntime {
     }
 }
 
+impl OwnerMutationLease {
+    pub fn acquire(worktree: &Path) -> Result<Self> {
+        let canonical = worktree.canonicalize()?;
+        let paths = runtime_paths(&worktree_hash(&canonical))?;
+        let lock = FileLock::try_lock_exclusive(&paths.lock)?.ok_or_else(|| {
+            anyhow::anyhow!("another agentic-outer-dag owner is active for this worktree")
+        })?;
+        Ok(Self { _lock: lock })
+    }
+}
+
 impl Drop for OwnerRuntime {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.paths.socket);
@@ -216,7 +223,7 @@ pub async fn send_response(worktree: &Path, response: InterruptionResponse) -> R
     let canonical = worktree.canonicalize()?;
     let hash = worktree_hash(&canonical);
     let paths = runtime_paths(&hash)?;
-    let uid = current_uid()?;
+    let uid = current_uid();
     validate_private_regular_file(&paths.manifest, uid).with_context(|| {
         "no live foreground owner is awaiting this response; keep persisted pending state and recover conservatively"
     })?;
@@ -268,11 +275,33 @@ fn response_kind(response: &InterruptionResponse) -> InterruptionKind {
     }
 }
 
-async fn write_reply(stream: &mut UnixStream, accepted: bool, error: Option<String>) -> Result<()> {
+async fn reject_reply<W: AsyncWrite + Unpin>(stream: &mut W, error: String) {
+    let _ = write_reply_bounded(stream, false, Some(error)).await;
+}
+
+async fn write_reply_bounded<W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    accepted: bool,
+    error: Option<String>,
+) -> Result<()> {
+    tokio::time::timeout(IPC_TIMEOUT, write_reply(stream, accepted, error))
+        .await
+        .context("timed out writing owner IPC reply")??;
+    Ok(())
+}
+
+async fn write_reply<W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    accepted: bool,
+    error: Option<String>,
+) -> Result<()> {
     write_frame(stream, &IpcReply { accepted, error }).await
 }
 
-async fn write_frame<T: Serialize + Sync>(stream: &mut UnixStream, value: &T) -> Result<()> {
+async fn write_frame<T: Serialize + Sync, W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    value: &T,
+) -> Result<()> {
     let bytes = serde_json::to_vec(value)?;
     anyhow::ensure!(
         bytes.len() <= MAX_FRAME_BYTES,
@@ -284,7 +313,17 @@ async fn write_frame<T: Serialize + Sync>(stream: &mut UnixStream, value: &T) ->
     Ok(())
 }
 
-async fn read_frame<T: for<'de> Deserialize<'de>>(stream: &mut UnixStream) -> Result<T> {
+async fn read_frame_bounded<T: for<'de> Deserialize<'de>, R: AsyncRead + Unpin>(
+    stream: &mut R,
+) -> Result<T> {
+    tokio::time::timeout(IPC_TIMEOUT, read_frame(stream))
+        .await
+        .context("timed out reading accepted owner IPC connection")?
+}
+
+async fn read_frame<T: for<'de> Deserialize<'de>, R: AsyncRead + Unpin>(
+    stream: &mut R,
+) -> Result<T> {
     let length = stream.read_u32().await? as usize;
     anyhow::ensure!(length <= MAX_FRAME_BYTES, "IPC frame exceeds maximum size");
     let mut bytes = vec![0; length];
@@ -293,7 +332,7 @@ async fn read_frame<T: for<'de> Deserialize<'de>>(stream: &mut UnixStream) -> Re
 }
 
 fn runtime_paths(worktree_hash: &str) -> Result<RuntimePaths> {
-    let uid = current_uid()?;
+    let uid = current_uid();
     let preferred_base = match std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from) {
         Some(path) if validate_private_directory(&path, uid).is_ok() => path,
         _ => short_runtime_fallback(uid),
@@ -338,11 +377,8 @@ fn short_runtime_fallback(uid: u32) -> PathBuf {
     std::env::temp_dir().join(format!("agentic-outer-dag-{uid}"))
 }
 
-fn current_uid() -> Result<u32> {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| anyhow::anyhow!("HOME is required to determine runtime ownership"))?;
-    Ok(std::fs::metadata(home)?.uid())
+fn current_uid() -> u32 {
+    rustix::process::geteuid().as_raw()
 }
 
 fn create_private_directory(path: &Path, uid: u32) -> Result<()> {
@@ -432,7 +468,7 @@ fn write_private_file(path: &Path, bytes: &[u8], create_new: bool) -> Result<()>
         bytes.len() as u64 <= MAX_RUNTIME_FILE_BYTES,
         "runtime artifact exceeds maximum size"
     );
-    let uid = current_uid()?;
+    let uid = current_uid();
     match std::fs::symlink_metadata(path) {
         Ok(_) => validate_private_regular_file(path, uid)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -454,11 +490,11 @@ fn write_private_file(path: &Path, bytes: &[u8], create_new: bool) -> Result<()>
 fn write_private_file_atomic(temp: &Path, destination: &Path, bytes: &[u8]) -> Result<()> {
     remove_stale_runtime_file(temp)?;
     if destination.exists() {
-        validate_private_regular_file(destination, current_uid()?)?;
+        validate_private_regular_file(destination, current_uid())?;
     }
     write_private_file(temp, bytes, true)?;
     std::fs::rename(temp, destination)?;
-    validate_private_regular_file(destination, current_uid()?)
+    validate_private_regular_file(destination, current_uid())
 }
 
 fn generate_owner_token() -> Result<String> {
@@ -502,6 +538,17 @@ mod tests {
     use crate::test_support::process_state_lock;
     use tempfile::TempDir;
 
+    fn permission_correlation() -> InterruptionCorrelation {
+        InterruptionCorrelation {
+            run_id: "run-1".to_string(),
+            invocation_id: "inv-1".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-1".to_string(),
+            kind: InterruptionKind::Permission,
+            request_id: "permission-1".to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn owner_lock_is_exclusive_and_releases_on_drop() {
         let worktree = TempDir::new().unwrap();
@@ -509,6 +556,26 @@ mod tests {
         assert!(OwnerRuntime::acquire(worktree.path()).is_err());
         drop(owner);
         assert!(OwnerRuntime::acquire(worktree.path()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn mutation_lease_blocks_owner_until_released() {
+        let worktree = TempDir::new().unwrap();
+        let lease = OwnerMutationLease::acquire(worktree.path()).unwrap();
+
+        assert!(OwnerRuntime::acquire(worktree.path()).is_err());
+        drop(lease);
+        assert!(OwnerRuntime::acquire(worktree.path()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn active_owner_blocks_mutation_lease_until_released() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+
+        assert!(OwnerMutationLease::acquire(worktree.path()).is_err());
+        drop(owner);
+        assert!(OwnerMutationLease::acquire(worktree.path()).is_ok());
     }
 
     #[tokio::test]
@@ -542,6 +609,99 @@ mod tests {
             )
             .await
             .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn stalled_length_prefix_times_out_then_valid_responder_succeeds() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = permission_correlation();
+        owner.publish_pending(&correlation).unwrap();
+
+        let receive = owner.await_response(&correlation);
+        let send_after_stall = async {
+            let _stalled = UnixStream::connect(&owner.paths.socket).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            send_response(
+                worktree.path(),
+                InterruptionResponse::Permission { allow: true },
+            )
+            .await
+        };
+        let (received, sent) = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(receive, send_after_stall)
+        })
+        .await
+        .unwrap();
+
+        sent.unwrap();
+        assert_eq!(
+            received.unwrap(),
+            InterruptionResponse::Permission { allow: true }
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_frame_body_times_out_then_valid_responder_succeeds() {
+        let worktree = TempDir::new().unwrap();
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+        let correlation = permission_correlation();
+        owner.publish_pending(&correlation).unwrap();
+
+        let receive = owner.await_response(&correlation);
+        let send_after_partial_frame = async {
+            let mut stalled = UnixStream::connect(&owner.paths.socket).await.unwrap();
+            stalled.write_u32(32).await.unwrap();
+            stalled.write_all(b"{").await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            send_response(
+                worktree.path(),
+                InterruptionResponse::Permission { allow: false },
+            )
+            .await
+        };
+        let (received, sent) = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(receive, send_after_partial_frame)
+        })
+        .await
+        .unwrap();
+
+        sent.unwrap();
+        assert_eq!(
+            received.unwrap(),
+            InterruptionResponse::Permission { allow: false }
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_rejection_reply_write_failure_is_nonfatal() {
+        let (mut writer, reader) = tokio::io::duplex(1);
+        drop(reader);
+
+        reject_reply(&mut writer, "malformed request".to_string()).await;
+    }
+
+    #[tokio::test]
+    async fn validation_rejection_reply_write_failure_is_nonfatal() {
+        let (mut writer, reader) = tokio::io::duplex(1);
+        drop(reader);
+
+        reject_reply(&mut writer, "owner authentication failed".to_string()).await;
+    }
+
+    #[tokio::test]
+    async fn valid_acceptance_reply_write_timeout_is_fatal() {
+        let (mut writer, _reader) = tokio::io::duplex(1);
+
+        let error = write_reply_bounded(&mut writer, true, None)
+            .await
+            .expect_err("valid acceptance acknowledgement timeout must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("timed out writing owner IPC reply")
         );
     }
 
@@ -609,7 +769,7 @@ mod tests {
             .write_u32((MAX_FRAME_BYTES + 1).try_into().unwrap())
             .await
             .unwrap();
-        let result = read_frame::<IpcReply>(&mut reader).await;
+        let result = read_frame::<IpcReply, _>(&mut reader).await;
         assert!(result.is_err());
     }
 
@@ -618,7 +778,7 @@ mod tests {
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
         writer.write_u32(1).await.unwrap();
         writer.write_all(b"{").await.unwrap();
-        let result = read_frame::<IpcReply>(&mut reader).await;
+        let result = read_frame::<IpcReply, _>(&mut reader).await;
         assert!(result.is_err());
     }
 
@@ -667,6 +827,23 @@ mod tests {
                 .mode()
                 & 0o077,
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_acquisition_is_independent_of_home() {
+        let _guard = process_state_lock().lock().unwrap();
+        let runtime = TempDir::new().unwrap();
+        std::fs::set_permissions(runtime.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let _home = EnvVarGuard::remove("HOME");
+        let _runtime_dir = EnvVarGuard::set("XDG_RUNTIME_DIR", runtime.path());
+        let worktree = TempDir::new().unwrap();
+
+        let owner = OwnerRuntime::acquire(worktree.path()).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&owner.paths.socket).unwrap().uid(),
+            rustix::process::geteuid().as_raw()
         );
     }
 

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -124,11 +124,170 @@ pub struct OpenCodeState {
     pub pending_question: Option<PendingQuestion>,
     #[serde(default)]
     pub last_diagnostics: Option<OpenCodeDiagnostics>,
+    #[serde(default)]
+    pub current_invocation: Option<OpenCodeInvocationState>,
+    #[serde(default)]
+    pub resolve_start_retries: u32,
+    #[serde(default)]
+    pub last_lifecycle_anomaly: Option<InvocationLifecycleAnomaly>,
+    #[serde(default)]
+    pub last_resolve_workflow_outcome: Option<ResolveWorkflowOutcome>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenCodeInvocationPhase {
+    Prepared,
+    PostAttempted,
+    RunningAssistantStarted,
+    PausedPermission,
+    PausedQuestion,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InvocationLifecycleResult {
+    Completed,
+    AcceptedButNotStarted,
+    Failed {
+        failure: InvocationFailure,
+    },
+    Cancelled {
+        cancellation: InvocationCancellation,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationFailure {
+    CommandTransport,
+    SessionError,
+    CompletionValidation,
+    ToolError,
+    InactivityTimeout,
+    SessionDeadline,
+    LocalTask,
+    Persistence,
+    OwnerIpc,
+    CleanupUncertain,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationCancellation {
+    Caller,
+    ServerAbort,
+    ManagedServerShutdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TaskDisposition {
+    #[serde(default)]
+    pub server_abort: ServerAbortDisposition,
+    #[serde(default)]
+    pub local_task: LocalTaskDisposition,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ServerAbortDisposition {
+    #[default]
+    NotRequired,
+    Succeeded {
+        aborted: bool,
+    },
+    Failed {
+        failure: CleanupFailure,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupFailure {
+    Transport,
+    Server,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalTaskDisposition {
+    #[default]
+    NotStarted,
+    Spawned,
+    Completed,
+    ReturnedError,
+    AbortedAndJoined,
+    JoinCancelled,
+    JoinPanicked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolveWorkflowOutcome {
+    Skipped,
+    ExternalProgress,
+    RetryScheduled,
+    RetriesExhausted,
+    ExecutedNoProgress,
+    ManualHandoff,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenCodeInvocationState {
+    pub invocation_id: String,
+    pub command: String,
+    pub session_id: String,
+    pub command_message_id: String,
+    pub phase: OpenCodeInvocationPhase,
+    #[serde(default)]
+    pub literal_post_attempts: u32,
+    #[serde(default)]
+    pub lifecycle_result: Option<InvocationLifecycleResult>,
+    #[serde(default)]
+    pub task_disposition: Option<TaskDisposition>,
+    #[serde(default)]
+    pub pending_interruption: Option<PendingInterruptionIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingInterruptionIdentity {
+    pub kind: InterruptionKind,
+    pub request_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InterruptionKind {
+    Permission,
+    Question,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InvocationLifecycleAnomaly {
+    pub invocation_id: String,
+    pub observed_at: String,
+    pub kind: InvocationLifecycleAnomalyKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InvocationLifecycleAnomalyKind {
+    AcceptedButNotStarted,
+    Failed {
+        failure: InvocationFailure,
+    },
+    Cancelled {
+        cancellation: InvocationCancellation,
+    },
+    CleanupUncertain,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OpenCodeDiagnostics {
     pub checked_at: String,
+    #[serde(default)]
+    pub literal_post_attempts: u32,
     #[serde(default)]
     pub command_message_id: Option<String>,
     #[serde(default)]
@@ -380,6 +539,7 @@ mod tests {
         });
         state.opencode.last_diagnostics = Some(OpenCodeDiagnostics {
             checked_at: "2026-01-01T00:00:00Z".to_string(),
+            literal_post_attempts: 1,
             command_message_id: Some("msg-outer-dag-1".to_string()),
             final_assistant_message_id: Some("msg-assistant-1".to_string()),
             final_finish_reason: Some("stop".to_string()),
@@ -390,6 +550,27 @@ mod tests {
             }),
             command_transport_error: None,
         });
+        state.opencode.current_invocation = Some(OpenCodeInvocationState {
+            invocation_id: "invocation-1".to_string(),
+            command: "resolve_pr_comments".to_string(),
+            session_id: "session-1".to_string(),
+            command_message_id: "msg-outer-dag-1".to_string(),
+            phase: OpenCodeInvocationPhase::PausedQuestion,
+            literal_post_attempts: 1,
+            lifecycle_result: None,
+            task_disposition: None,
+            pending_interruption: Some(PendingInterruptionIdentity {
+                kind: InterruptionKind::Question,
+                request_id: "question-1".to_string(),
+            }),
+        });
+        state.opencode.resolve_start_retries = 1;
+        state.opencode.last_lifecycle_anomaly = Some(InvocationLifecycleAnomaly {
+            invocation_id: "invocation-0".to_string(),
+            observed_at: "2026-01-01T00:00:00Z".to_string(),
+            kind: InvocationLifecycleAnomalyKind::AcceptedButNotStarted,
+        });
+        state.opencode.last_resolve_workflow_outcome = Some(ResolveWorkflowOutcome::RetryScheduled);
         state.stage.kind = StageKind::StoppedQuestionRequired;
 
         let json = serde_json::to_string_pretty(&state).unwrap();
@@ -421,6 +602,19 @@ mod tests {
         assert!(roundtrip.settings.linear_handoff_enabled);
         assert!(roundtrip.settings.opencode_dispatch_enabled);
         assert_eq!(roundtrip.pr.ready_for_review.attempts, 0);
+        assert_eq!(roundtrip.opencode.resolve_start_retries, 1);
+        assert_eq!(
+            roundtrip
+                .opencode
+                .current_invocation
+                .as_ref()
+                .map(|invocation| &invocation.phase),
+            Some(&OpenCodeInvocationPhase::PausedQuestion)
+        );
+        assert_eq!(
+            roundtrip.opencode.last_resolve_workflow_outcome.as_ref(),
+            Some(&ResolveWorkflowOutcome::RetryScheduled)
+        );
         assert!(
             !roundtrip
                 .pr
@@ -509,6 +703,10 @@ mod tests {
             DEFAULT_OPENCODE_INACTIVITY_TIMEOUT_SECONDS
         );
         assert!(roundtrip.opencode.last_diagnostics.is_none());
+        assert!(roundtrip.opencode.current_invocation.is_none());
+        assert_eq!(roundtrip.opencode.resolve_start_retries, 0);
+        assert!(roundtrip.opencode.last_lifecycle_anomaly.is_none());
+        assert!(roundtrip.opencode.last_resolve_workflow_outcome.is_none());
         assert_eq!(roundtrip.pr.last_described_head_sha, None);
         assert_eq!(roundtrip.pr.is_draft, None);
         assert_eq!(roundtrip.pr.ready_for_review.attempts, 0);
@@ -537,6 +735,134 @@ mod tests {
         .unwrap();
 
         assert!(opencode.last_diagnostics.is_none());
+        assert!(opencode.current_invocation.is_none());
+        assert_eq!(opencode.resolve_start_retries, 0);
+        assert!(opencode.last_lifecycle_anomaly.is_none());
+        assert!(opencode.last_resolve_workflow_outcome.is_none());
+    }
+
+    #[test]
+    fn invocation_phases_roundtrip_through_serde() {
+        for phase in [
+            OpenCodeInvocationPhase::Prepared,
+            OpenCodeInvocationPhase::PostAttempted,
+            OpenCodeInvocationPhase::RunningAssistantStarted,
+            OpenCodeInvocationPhase::PausedPermission,
+            OpenCodeInvocationPhase::PausedQuestion,
+            OpenCodeInvocationPhase::Terminal,
+        ] {
+            let json = serde_json::to_string(&phase).unwrap();
+            let roundtrip: OpenCodeInvocationPhase = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, phase);
+        }
+    }
+
+    #[test]
+    fn typed_invocation_facts_roundtrip_through_serde() {
+        let lifecycle_results = [
+            InvocationLifecycleResult::Completed,
+            InvocationLifecycleResult::AcceptedButNotStarted,
+            InvocationLifecycleResult::Failed {
+                failure: InvocationFailure::CompletionValidation,
+            },
+            InvocationLifecycleResult::Cancelled {
+                cancellation: InvocationCancellation::Caller,
+            },
+        ];
+        for result in lifecycle_results {
+            let json = serde_json::to_string(&result).unwrap();
+            let roundtrip: InvocationLifecycleResult = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, result);
+        }
+
+        for failure in [
+            InvocationFailure::CommandTransport,
+            InvocationFailure::SessionError,
+            InvocationFailure::CompletionValidation,
+            InvocationFailure::ToolError,
+            InvocationFailure::InactivityTimeout,
+            InvocationFailure::SessionDeadline,
+            InvocationFailure::LocalTask,
+            InvocationFailure::Persistence,
+            InvocationFailure::OwnerIpc,
+            InvocationFailure::CleanupUncertain,
+        ] {
+            let json = serde_json::to_string(&failure).unwrap();
+            let roundtrip: InvocationFailure = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, failure);
+        }
+
+        for cancellation in [
+            InvocationCancellation::Caller,
+            InvocationCancellation::ServerAbort,
+            InvocationCancellation::ManagedServerShutdown,
+        ] {
+            let json = serde_json::to_string(&cancellation).unwrap();
+            let roundtrip: InvocationCancellation = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, cancellation);
+        }
+
+        let dispositions = [
+            TaskDisposition::default(),
+            TaskDisposition {
+                server_abort: ServerAbortDisposition::Succeeded { aborted: true },
+                local_task: LocalTaskDisposition::AbortedAndJoined,
+            },
+            TaskDisposition {
+                server_abort: ServerAbortDisposition::Failed {
+                    failure: CleanupFailure::Transport,
+                },
+                local_task: LocalTaskDisposition::JoinPanicked,
+            },
+        ];
+        for disposition in dispositions {
+            let json = serde_json::to_string(&disposition).unwrap();
+            let roundtrip: TaskDisposition = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, disposition);
+        }
+
+        for local_task in [
+            LocalTaskDisposition::NotStarted,
+            LocalTaskDisposition::Spawned,
+            LocalTaskDisposition::Completed,
+            LocalTaskDisposition::ReturnedError,
+            LocalTaskDisposition::AbortedAndJoined,
+            LocalTaskDisposition::JoinCancelled,
+            LocalTaskDisposition::JoinPanicked,
+        ] {
+            let json = serde_json::to_string(&local_task).unwrap();
+            let roundtrip: LocalTaskDisposition = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, local_task);
+        }
+
+        for server_abort in [
+            ServerAbortDisposition::NotRequired,
+            ServerAbortDisposition::Succeeded { aborted: true },
+            ServerAbortDisposition::Succeeded { aborted: false },
+            ServerAbortDisposition::Failed {
+                failure: CleanupFailure::Transport,
+            },
+            ServerAbortDisposition::Failed {
+                failure: CleanupFailure::Server,
+            },
+        ] {
+            let json = serde_json::to_string(&server_abort).unwrap();
+            let roundtrip: ServerAbortDisposition = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, server_abort);
+        }
+
+        for outcome in [
+            ResolveWorkflowOutcome::Skipped,
+            ResolveWorkflowOutcome::ExternalProgress,
+            ResolveWorkflowOutcome::RetryScheduled,
+            ResolveWorkflowOutcome::RetriesExhausted,
+            ResolveWorkflowOutcome::ExecutedNoProgress,
+            ResolveWorkflowOutcome::ManualHandoff,
+        ] {
+            let json = serde_json::to_string(&outcome).unwrap();
+            let roundtrip: ResolveWorkflowOutcome = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, outcome);
+        }
     }
 
     #[test]

--- a/apps/agentic-outer-dag/src/state/mod.rs
+++ b/apps/agentic-outer-dag/src/state/mod.rs
@@ -256,7 +256,7 @@ pub struct PendingInterruptionIdentity {
     pub request_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum InterruptionKind {
     Permission,

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -59,12 +59,17 @@ use opencode_rs::types::session::CreateSessionRequest;
 use opencode_rs::types::session::SessionStatusInfo;
 use opencode_rs::types::session::SummarizeRequest;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 
 const SERVER_NAME: &str = "opencode-orchestrator-mcp";
+const PRECORRELATION_TOTAL_BYTES: usize = 64 * 1024;
+const PRECORRELATION_MESSAGE_BYTES: usize = 16 * 1024;
+const PRECORRELATION_MESSAGE_IDS: usize = 32;
 
 #[derive(Debug, Clone, Default)]
 struct ToolLogMeta {
@@ -86,6 +91,97 @@ enum PermissionPreflightMode {
 #[derive(Debug, Clone)]
 struct CommandTranscriptWindow {
     command_message_id: String,
+}
+
+#[derive(Debug)]
+struct BufferedDelta {
+    message_id: String,
+    text: String,
+}
+
+#[derive(Debug, Default)]
+struct PreCorrelationDeltaBuffer {
+    deltas: VecDeque<BufferedDelta>,
+    bytes_by_message: HashMap<String, usize>,
+    total_bytes: usize,
+}
+
+impl PreCorrelationDeltaBuffer {
+    fn push(&mut self, message_id: &str, delta: &str) {
+        if message_id.is_empty() || delta.is_empty() {
+            return;
+        }
+
+        let delta_bytes = delta.len();
+        if delta_bytes > PRECORRELATION_MESSAGE_BYTES || delta_bytes > PRECORRELATION_TOTAL_BYTES {
+            return;
+        }
+
+        if !self.bytes_by_message.contains_key(message_id)
+            && self.bytes_by_message.len() >= PRECORRELATION_MESSAGE_IDS
+        {
+            self.evict_oldest_message();
+        }
+
+        let message_bytes = self
+            .bytes_by_message
+            .get(message_id)
+            .copied()
+            .unwrap_or_default();
+        if message_bytes.saturating_add(delta_bytes) > PRECORRELATION_MESSAGE_BYTES {
+            return;
+        }
+
+        while self.total_bytes.saturating_add(delta_bytes) > PRECORRELATION_TOTAL_BYTES {
+            let Some(oldest_message_id) = self.deltas.front().map(|delta| delta.message_id.clone())
+            else {
+                return;
+            };
+            if oldest_message_id == message_id {
+                return;
+            }
+            self.evict_message(&oldest_message_id);
+        }
+
+        self.deltas.push_back(BufferedDelta {
+            message_id: message_id.to_string(),
+            text: delta.to_string(),
+        });
+        self.bytes_by_message
+            .insert(message_id.to_string(), message_bytes + delta_bytes);
+        self.total_bytes += delta_bytes;
+    }
+
+    fn take(&mut self, message_id: &str) -> String {
+        let Some(removed_bytes) = self.bytes_by_message.remove(message_id) else {
+            return String::new();
+        };
+
+        let mut text = String::with_capacity(removed_bytes);
+        self.deltas.retain(|delta| {
+            if delta.message_id == message_id {
+                text.push_str(&delta.text);
+                false
+            } else {
+                true
+            }
+        });
+        self.total_bytes -= removed_bytes;
+        text
+    }
+
+    fn evict_oldest_message(&mut self) {
+        if let Some(message_id) = self.deltas.front().map(|delta| delta.message_id.clone()) {
+            self.evict_message(&message_id);
+        }
+    }
+
+    fn evict_message(&mut self, message_id: &str) {
+        if let Some(removed_bytes) = self.bytes_by_message.remove(message_id) {
+            self.deltas.retain(|delta| delta.message_id != message_id);
+            self.total_bytes -= removed_bytes;
+        }
+    }
 }
 
 fn blocked_command_error(command: &str, decision: CommandPolicyDecision) -> ToolError {
@@ -702,6 +798,9 @@ impl OrchestratorRunTool {
         // session before our new work has started processing.
         let mut observed_busy = false;
         let mut correlated_assistant_ids = HashSet::new();
+        let mut precorrelation_deltas = command_transcript_window
+            .as_ref()
+            .map(|_| PreCorrelationDeltaBuffer::default());
 
         // Track whether SSE is still active. If the stream closes, we fall back
         // to polling-only mode rather than returning an error.
@@ -822,6 +921,12 @@ impl OrchestratorRunTool {
                             // Collect streaming text from field-level delta events.
                             if correlated && let Some(delta) = &properties.delta {
                                 partial_response.push_str(delta);
+                            } else if let (Some(buffer), Some(message_id), Some(delta)) = (
+                                precorrelation_deltas.as_mut(),
+                                properties.message_id.as_deref().filter(|id| !id.is_empty()),
+                                properties.delta.as_deref(),
+                            ) {
+                                buffer.push(message_id, delta);
                             }
                         }
 
@@ -831,11 +936,17 @@ impl OrchestratorRunTool {
                                 &properties.info.role,
                                 properties.info.parent_id.as_deref(),
                             );
+                            let message_id = properties.info.id;
                             if correlated {
-                                correlated_assistant_ids.insert(properties.info.id.clone());
+                                correlated_assistant_ids.insert(message_id.clone());
+                                if let Some(buffer) = precorrelation_deltas.as_mut() {
+                                    partial_response.push_str(&buffer.take(&message_id));
+                                }
                                 last_activity_time = tokio::time::Instant::now();
                                 observed_busy = true;
                                 awaiting_idle_grace_check = false;
+                            } else if let Some(buffer) = precorrelation_deltas.as_mut() {
+                                buffer.evict_message(&message_id);
                             }
                         }
 
@@ -2215,5 +2326,75 @@ mod tests {
             &correlated
         ));
         assert!(part_event_matches_command(None, None, &correlated));
+    }
+
+    #[test]
+    fn precorrelation_deltas_flush_only_after_matching_assistant_lineage() {
+        let window = CommandTranscriptWindow {
+            command_message_id: "msg-command".to_string(),
+        };
+        let mut buffer = PreCorrelationDeltaBuffer::default();
+        buffer.push("msg-assistant", "first ");
+        buffer.push("msg-other", "unrelated");
+        buffer.push("msg-assistant", "second");
+
+        assert!(assistant_update_matches_command(
+            Some(&window),
+            "assistant",
+            Some("msg-command")
+        ));
+        assert_eq!(buffer.take("msg-assistant"), "first second");
+        assert_eq!(buffer.take("msg-other"), "unrelated");
+    }
+
+    #[test]
+    fn precorrelation_deltas_do_not_flush_for_other_lineage() {
+        let window = CommandTranscriptWindow {
+            command_message_id: "msg-command".to_string(),
+        };
+        let mut buffer = PreCorrelationDeltaBuffer::default();
+        buffer.push("msg-assistant", "must remain unconfirmed");
+
+        assert!(!assistant_update_matches_command(
+            Some(&window),
+            "assistant",
+            Some("msg-other")
+        ));
+        buffer.evict_message("msg-assistant");
+        assert!(!buffer.bytes_by_message.contains_key("msg-assistant"));
+        assert_eq!(buffer.total_bytes, 0);
+    }
+
+    #[test]
+    fn precorrelation_delta_buffer_enforces_byte_and_message_caps() {
+        let mut buffer = PreCorrelationDeltaBuffer::default();
+        let per_message = "x".repeat(PRECORRELATION_MESSAGE_BYTES);
+        buffer.push("full", &per_message);
+        buffer.push("full", "overflow");
+        assert_eq!(buffer.take("full"), per_message);
+
+        for index in 0..PRECORRELATION_MESSAGE_IDS {
+            buffer.push(&format!("id-{index}"), "x");
+        }
+        buffer.push("newest", "y");
+        assert!(!buffer.bytes_by_message.contains_key("id-0"));
+        assert_eq!(buffer.bytes_by_message.len(), PRECORRELATION_MESSAGE_IDS);
+        assert_eq!(buffer.take("newest"), "y");
+
+        let mut total_capped = PreCorrelationDeltaBuffer::default();
+        for index in 0..(PRECORRELATION_TOTAL_BYTES / PRECORRELATION_MESSAGE_BYTES) {
+            total_capped.push(&format!("chunk-{index}"), &per_message);
+        }
+        assert_eq!(total_capped.total_bytes, PRECORRELATION_TOTAL_BYTES);
+        total_capped.push("replacement", "z");
+        assert!(!total_capped.bytes_by_message.contains_key("chunk-0"));
+        assert_eq!(
+            total_capped.total_bytes,
+            PRECORRELATION_TOTAL_BYTES - PRECORRELATION_MESSAGE_BYTES + 1
+        );
+
+        let oversized = "x".repeat(PRECORRELATION_MESSAGE_BYTES + 1);
+        total_capped.push("oversized", &oversized);
+        assert!(!total_capped.bytes_by_message.contains_key("oversized"));
     }
 }

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -59,6 +59,7 @@ use opencode_rs::types::session::CreateSessionRequest;
 use opencode_rs::types::session::SessionStatusInfo;
 use opencode_rs::types::session::SummarizeRequest;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -149,6 +150,25 @@ fn transcript_indicates_command_dispatch(
     messages
         .iter()
         .any(|message| message.id() == transcript_window.command_message_id)
+}
+
+fn assistant_update_matches_command(
+    transcript_window: Option<&CommandTranscriptWindow>,
+    role: &str,
+    parent_id: Option<&str>,
+) -> bool {
+    transcript_window.map_or(role == "assistant", |window| {
+        role == "assistant" && parent_id == Some(window.command_message_id.as_str())
+    })
+}
+
+fn part_event_matches_command(
+    transcript_window: Option<&CommandTranscriptWindow>,
+    message_id: Option<&str>,
+    correlated_assistant_ids: &HashSet<String>,
+) -> bool {
+    transcript_window.is_none()
+        || message_id.is_some_and(|message_id| correlated_assistant_ids.contains(message_id))
 }
 
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
@@ -681,6 +701,7 @@ impl OrchestratorRunTool {
         // This prevents completing immediately if we call run_impl on an already-idle
         // session before our new work has started processing.
         let mut observed_busy = false;
+        let mut correlated_assistant_ids = HashSet::new();
 
         // Track whether SSE is still active. If the stream closes, we fall back
         // to polling-only mode rather than returning an error.
@@ -788,20 +809,47 @@ impl OrchestratorRunTool {
                         }
 
                         Event::MessagePartDelta { properties } => {
-                            last_activity_time = tokio::time::Instant::now();
-                            // Message streaming means session is actively processing
-                            observed_busy = true;
-                            awaiting_idle_grace_check = false;
+                            let correlated = part_event_matches_command(
+                                command_transcript_window.as_ref(),
+                                properties.message_id.as_deref(),
+                                &correlated_assistant_ids,
+                            );
+                            if correlated {
+                                last_activity_time = tokio::time::Instant::now();
+                                observed_busy = true;
+                                awaiting_idle_grace_check = false;
+                            }
                             // Collect streaming text from field-level delta events.
-                            if let Some(delta) = &properties.delta {
+                            if correlated && let Some(delta) = &properties.delta {
                                 partial_response.push_str(delta);
                             }
                         }
 
-                        Event::MessagePartUpdated { .. } | Event::MessageUpdated { .. } => {
-                            last_activity_time = tokio::time::Instant::now();
-                            observed_busy = true;
-                            awaiting_idle_grace_check = false;
+                        Event::MessageUpdated { properties } => {
+                            let correlated = assistant_update_matches_command(
+                                command_transcript_window.as_ref(),
+                                &properties.info.role,
+                                properties.info.parent_id.as_deref(),
+                            );
+                            if correlated {
+                                correlated_assistant_ids.insert(properties.info.id.clone());
+                                last_activity_time = tokio::time::Instant::now();
+                                observed_busy = true;
+                                awaiting_idle_grace_check = false;
+                            }
+                        }
+
+                        Event::MessagePartUpdated { properties } => {
+                            let correlated = part_event_matches_command(
+                                command_transcript_window.as_ref(),
+                                properties.message_id.as_deref(),
+                                &correlated_assistant_ids,
+                            );
+                            if correlated {
+                                last_activity_time = tokio::time::Instant::now();
+                                observed_busy = true;
+                                awaiting_idle_grace_check = false;
+                            }
                         }
 
                         Event::SessionError { properties } => {
@@ -818,8 +866,18 @@ impl OrchestratorRunTool {
 
                         Event::SessionIdle { .. } => {
                             tracing::debug!(session_id = %session_id, "received SessionIdle event");
-                            let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
-                            return Ok(RunOutcome::with_tracker(output, &token_tracker));
+                            if !dispatched_new_work || observed_busy {
+                                let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                                return Ok(RunOutcome::with_tracker(output, &token_tracker));
+                            }
+                            match idle_grace_deadline {
+                                Some(deadline) if tokio::time::Instant::now() >= deadline => {
+                                    let output = Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+                                    return Ok(RunOutcome::with_tracker(output, &token_tracker));
+                                }
+                                Some(_) => awaiting_idle_grace_check = true,
+                                None => {}
+                            }
                         }
 
                         _ => {
@@ -2116,5 +2174,46 @@ mod tests {
     #[test]
     fn last_activity_falls_back_to_session_timestamp_when_messages_are_empty() {
         assert_eq!(get_last_activity_time(&[], Some(1_234)), Some(1_234));
+    }
+
+    #[test]
+    fn command_activity_requires_current_assistant_lineage() {
+        let window = CommandTranscriptWindow {
+            command_message_id: "msg-command".to_string(),
+        };
+        assert!(!assistant_update_matches_command(
+            Some(&window),
+            "user",
+            Some("msg-command")
+        ));
+        assert!(!assistant_update_matches_command(
+            Some(&window),
+            "assistant",
+            Some("msg-other")
+        ));
+        assert!(assistant_update_matches_command(
+            Some(&window),
+            "assistant",
+            Some("msg-command")
+        ));
+    }
+
+    #[test]
+    fn command_part_activity_requires_correlated_assistant_id() {
+        let window = CommandTranscriptWindow {
+            command_message_id: "msg-command".to_string(),
+        };
+        let correlated = HashSet::from(["msg-assistant".to_string()]);
+        assert!(!part_event_matches_command(
+            Some(&window),
+            Some("msg-command"),
+            &correlated
+        ));
+        assert!(part_event_matches_command(
+            Some(&window),
+            Some("msg-assistant"),
+            &correlated
+        ));
+        assert!(part_event_matches_command(None, None, &correlated));
     }
 }

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -44,6 +44,8 @@ use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
 use opencode_rs::OpencodeError;
 use opencode_rs::types::event::Event;
+use opencode_rs::types::event::MessagePartEventProps;
+use opencode_rs::types::event::MessageUpdatedProps;
 use opencode_rs::types::message::CommandRequest;
 use opencode_rs::types::message::Message;
 use opencode_rs::types::message::Part;
@@ -265,6 +267,54 @@ fn part_event_matches_command(
 ) -> bool {
     transcript_window.is_none()
         || message_id.is_some_and(|message_id| correlated_assistant_ids.contains(message_id))
+}
+
+fn record_message_part_delta(
+    properties: &MessagePartEventProps,
+    transcript_window: Option<&CommandTranscriptWindow>,
+    correlated_assistant_ids: &HashSet<String>,
+    precorrelation_deltas: &mut Option<PreCorrelationDeltaBuffer>,
+    partial_response: &mut String,
+) -> bool {
+    let correlated = part_event_matches_command(
+        transcript_window,
+        properties.message_id.as_deref(),
+        correlated_assistant_ids,
+    );
+    if correlated && let Some(delta) = &properties.delta {
+        partial_response.push_str(delta);
+    } else if let (Some(buffer), Some(message_id), Some(delta)) = (
+        precorrelation_deltas.as_mut(),
+        properties.message_id.as_deref().filter(|id| !id.is_empty()),
+        properties.delta.as_deref(),
+    ) {
+        buffer.push(message_id, delta);
+    }
+    correlated
+}
+
+fn record_message_updated(
+    properties: &MessageUpdatedProps,
+    transcript_window: Option<&CommandTranscriptWindow>,
+    correlated_assistant_ids: &mut HashSet<String>,
+    precorrelation_deltas: &mut Option<PreCorrelationDeltaBuffer>,
+    partial_response: &mut String,
+) -> bool {
+    let correlated = assistant_update_matches_command(
+        transcript_window,
+        &properties.info.role,
+        properties.info.parent_id.as_deref(),
+    );
+    let message_id = &properties.info.id;
+    if correlated {
+        correlated_assistant_ids.insert(message_id.clone());
+        if let Some(buffer) = precorrelation_deltas.as_mut() {
+            partial_response.push_str(&buffer.take(message_id));
+        }
+    } else if let Some(buffer) = precorrelation_deltas.as_mut() {
+        buffer.evict_message(message_id);
+    }
+    correlated
 }
 
 fn request_json<T: Serialize>(request: &T) -> serde_json::Value {
@@ -908,45 +958,32 @@ impl OrchestratorRunTool {
                         }
 
                         Event::MessagePartDelta { properties } => {
-                            let correlated = part_event_matches_command(
+                            let correlated = record_message_part_delta(
+                                &properties,
                                 command_transcript_window.as_ref(),
-                                properties.message_id.as_deref(),
                                 &correlated_assistant_ids,
+                                &mut precorrelation_deltas,
+                                &mut partial_response,
                             );
                             if correlated {
                                 last_activity_time = tokio::time::Instant::now();
                                 observed_busy = true;
                                 awaiting_idle_grace_check = false;
-                            }
-                            // Collect streaming text from field-level delta events.
-                            if correlated && let Some(delta) = &properties.delta {
-                                partial_response.push_str(delta);
-                            } else if let (Some(buffer), Some(message_id), Some(delta)) = (
-                                precorrelation_deltas.as_mut(),
-                                properties.message_id.as_deref().filter(|id| !id.is_empty()),
-                                properties.delta.as_deref(),
-                            ) {
-                                buffer.push(message_id, delta);
                             }
                         }
 
                         Event::MessageUpdated { properties } => {
-                            let correlated = assistant_update_matches_command(
+                            let correlated = record_message_updated(
+                                &properties,
                                 command_transcript_window.as_ref(),
-                                &properties.info.role,
-                                properties.info.parent_id.as_deref(),
+                                &mut correlated_assistant_ids,
+                                &mut precorrelation_deltas,
+                                &mut partial_response,
                             );
-                            let message_id = properties.info.id;
                             if correlated {
-                                correlated_assistant_ids.insert(message_id.clone());
-                                if let Some(buffer) = precorrelation_deltas.as_mut() {
-                                    partial_response.push_str(&buffer.take(&message_id));
-                                }
                                 last_activity_time = tokio::time::Instant::now();
                                 observed_busy = true;
                                 awaiting_idle_grace_check = false;
-                            } else if let Some(buffer) = precorrelation_deltas.as_mut() {
-                                buffer.evict_message(&message_id);
                             }
                         }
 
@@ -2333,18 +2370,55 @@ mod tests {
         let window = CommandTranscriptWindow {
             command_message_id: "msg-command".to_string(),
         };
-        let mut buffer = PreCorrelationDeltaBuffer::default();
-        buffer.push("msg-assistant", "first ");
-        buffer.push("msg-other", "unrelated");
-        buffer.push("msg-assistant", "second");
+        let mut correlated_assistant_ids = HashSet::new();
+        let mut buffer = Some(PreCorrelationDeltaBuffer::default());
+        let mut partial_response = String::new();
+        let delta: Event = serde_json::from_value(serde_json::json!({
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "session-1",
+                "messageID": "msg-assistant",
+                "delta": "buffered prefix"
+            }
+        }))
+        .unwrap();
+        let update: Event = serde_json::from_value(serde_json::json!({
+            "type": "message.updated",
+            "properties": {
+                "info": {
+                    "id": "msg-assistant",
+                    "sessionID": "session-1",
+                    "role": "assistant",
+                    "parentID": "msg-command",
+                    "time": { "created": 1 }
+                }
+            }
+        }))
+        .unwrap();
 
-        assert!(assistant_update_matches_command(
+        let Event::MessagePartDelta { properties } = delta else {
+            panic!("expected message delta event");
+        };
+        assert!(!record_message_part_delta(
+            &properties,
             Some(&window),
-            "assistant",
-            Some("msg-command")
+            &correlated_assistant_ids,
+            &mut buffer,
+            &mut partial_response,
         ));
-        assert_eq!(buffer.take("msg-assistant"), "first second");
-        assert_eq!(buffer.take("msg-other"), "unrelated");
+        assert!(partial_response.is_empty());
+
+        let Event::MessageUpdated { properties } = update else {
+            panic!("expected message update event");
+        };
+        assert!(record_message_updated(
+            &properties,
+            Some(&window),
+            &mut correlated_assistant_ids,
+            &mut buffer,
+            &mut partial_response,
+        ));
+        assert_eq!(partial_response, "buffered prefix");
     }
 
     #[test]

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -30,20 +30,20 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::path_regex;
 
+use support::CommandCorrelationFixture;
 use support::SequenceResponder;
 use support::SwitchAfterCallsResponder;
 use support::messages_fixture;
 use support::permission_fixture;
 use support::session_fixture;
 use support::short_timeout_test_orchestrator_server;
-use support::sse_body;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::status_v2_retry;
 use support::test_orchestrator_server;
 
 #[tokio::test]
-async fn sse_deltas_are_returned_in_permission_partial_response() {
+async fn command_precorrelation_deltas_are_returned_in_permission_partial_response() {
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
@@ -69,31 +69,25 @@ async fn sse_deltas_are_returned_in_permission_partial_response() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
+    let correlation = CommandCorrelationFixture::new();
     Mock::given(method("POST"))
-        .and(path(format!("/session/{sid}/prompt_async")))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(correlation.command_responder())
         .mount(&mock)
         .await;
 
-    let events = [
-        serde_json::json!({
-            "type": "message.part.delta",
-            "properties": {
-                "sessionID": sid,
-                "messageID": "assistant-preview",
-                "delta": "permission preview"
-            }
-        }),
-        serde_json::json!({
-            "type": "permission.asked",
-            "properties": permission_fixture("permission-preview", sid, "bash", &["*"])
-        }),
-    ];
+    let interruption = serde_json::json!({
+        "type": "permission.asked",
+        "properties": permission_fixture("permission-preview", sid, "bash", &["*"])
+    });
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_raw(sse_body(&events), "text/event-stream"),
-        )
+        .respond_with(correlation.sse_responder(
+            sid,
+            "assistant-preview",
+            "permission preview",
+            interruption,
+        ))
         .mount(&mock)
         .await;
 
@@ -102,7 +96,7 @@ async fn sse_deltas_are_returned_in_permission_partial_response() {
         tool.call(
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
-                command: None,
+                command: Some("implement_plan".into()),
                 agent: None,
                 message: Some("Do the work".into()),
                 wait_for_activity: None,

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -36,10 +36,94 @@ use support::messages_fixture;
 use support::permission_fixture;
 use support::session_fixture;
 use support::short_timeout_test_orchestrator_server;
+use support::sse_body;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::status_v2_retry;
 use support::test_orchestrator_server;
+
+#[tokio::test]
+async fn sse_deltas_are_returned_in_permission_partial_response() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "permission-sse-preview";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/prompt_async")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    let events = [
+        serde_json::json!({
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": sid,
+                "messageID": "assistant-preview",
+                "delta": "permission preview"
+            }
+        }),
+        serde_json::json!({
+            "type": "permission.asked",
+            "properties": permission_fixture("permission-preview", sid, "bash", &["*"])
+        }),
+    ];
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_body(&events), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(10),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: None,
+                agent: None,
+                message: Some("Do the work".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("run should not hang")
+    .expect("run should succeed");
+
+    assert!(matches!(result.status, RunStatus::PermissionRequired));
+    assert_eq!(
+        result.partial_response.as_deref(),
+        Some("permission preview")
+    );
+    assert_eq!(
+        result.permission_request_id.as_deref(),
+        Some("permission-preview")
+    );
+}
 
 /// IT-BUG1: Completion should retry message extraction when first attempt returns no assistant text.
 ///

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -22,12 +22,12 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 use wiremock::matchers::path_regex;
 
+use support::CommandCorrelationFixture;
 use support::SequenceResponder;
 use support::messages_fixture;
 use support::permission_fixture;
 use support::question_fixture;
 use support::session_fixture;
-use support::sse_body;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::test_orchestrator_server;
@@ -46,7 +46,7 @@ fn question_payload(question: &str) -> serde_json::Value {
 }
 
 #[tokio::test]
-async fn sse_deltas_are_returned_in_question_partial_response() {
+async fn command_precorrelation_deltas_are_returned_in_question_partial_response() {
     let mock = MockServer::start().await;
     let server = test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
@@ -72,35 +72,29 @@ async fn sse_deltas_are_returned_in_question_partial_response() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&mock)
         .await;
+    let correlation = CommandCorrelationFixture::new();
     Mock::given(method("POST"))
-        .and(path(format!("/session/{sid}/prompt_async")))
-        .respond_with(ResponseTemplate::new(204))
+        .and(path(format!("/session/{sid}/command")))
+        .respond_with(correlation.command_responder())
         .mount(&mock)
         .await;
 
-    let events = [
-        serde_json::json!({
-            "type": "message.part.delta",
-            "properties": {
-                "sessionID": sid,
-                "messageID": "assistant-preview",
-                "delta": "question preview"
-            }
-        }),
-        serde_json::json!({
-            "type": "question.asked",
-            "properties": question_fixture(
-                "question-preview",
-                sid,
-                &[question_payload("Continue?")]
-            )
-        }),
-    ];
+    let interruption = serde_json::json!({
+        "type": "question.asked",
+        "properties": question_fixture(
+            "question-preview",
+            sid,
+            &[question_payload("Continue?")]
+        )
+    });
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_raw(sse_body(&events), "text/event-stream"),
-        )
+        .respond_with(correlation.sse_responder(
+            sid,
+            "assistant-preview",
+            "question preview",
+            interruption,
+        ))
         .mount(&mock)
         .await;
 
@@ -109,7 +103,7 @@ async fn sse_deltas_are_returned_in_question_partial_response() {
         tool.call(
             OrchestratorRunInput {
                 session_id: Some(sid.into()),
-                command: None,
+                command: Some("implement_plan".into()),
                 agent: None,
                 message: Some("Do the work".into()),
                 wait_for_activity: None,

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -27,6 +27,7 @@ use support::messages_fixture;
 use support::permission_fixture;
 use support::question_fixture;
 use support::session_fixture;
+use support::sse_body;
 use support::status_v2_busy;
 use support::status_v2_idle;
 use support::test_orchestrator_server;
@@ -42,6 +43,90 @@ fn question_payload(question: &str) -> serde_json::Value {
         "multiple": false,
         "custom": false
     })
+}
+
+#[tokio::test]
+async fn sse_deltas_are_returned_in_question_partial_response() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "question-sse-preview";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/prompt_async")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    let events = [
+        serde_json::json!({
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": sid,
+                "messageID": "assistant-preview",
+                "delta": "question preview"
+            }
+        }),
+        serde_json::json!({
+            "type": "question.asked",
+            "properties": question_fixture(
+                "question-preview",
+                sid,
+                &[question_payload("Continue?")]
+            )
+        }),
+    ];
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_body(&events), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(10),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: None,
+                agent: None,
+                message: Some("Do the work".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("run should not hang")
+    .expect("run should succeed");
+
+    assert!(matches!(result.status, RunStatus::QuestionRequired));
+    assert_eq!(result.partial_response.as_deref(), Some("question preview"));
+    assert_eq!(
+        result.question_request_id.as_deref(),
+        Some("question-preview")
+    );
 }
 
 #[tokio::test]

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -12,8 +12,11 @@ use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
 use opencode_orchestrator_mcp::server::RecoveryMode;
 use serde_json::Value;
 use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::Request;
@@ -195,6 +198,112 @@ impl Respond for SequenceResponder {
             .get(idx)
             .cloned()
             .unwrap_or_else(|| self.responders.last().cloned().expect("non-empty"))
+    }
+}
+
+#[derive(Clone)]
+pub struct CommandCorrelationFixture {
+    command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
+}
+
+impl CommandCorrelationFixture {
+    pub fn new() -> Self {
+        Self {
+            command_message_id: Arc::new((Mutex::new(None), Condvar::new())),
+        }
+    }
+
+    pub fn command_responder(&self) -> CommandMessageIdResponder {
+        CommandMessageIdResponder {
+            command_message_id: Arc::clone(&self.command_message_id),
+        }
+    }
+
+    pub fn sse_responder(
+        &self,
+        session_id: &str,
+        assistant_message_id: &str,
+        delta: &str,
+        interruption: Value,
+    ) -> CommandCorrelatedSseResponder {
+        CommandCorrelatedSseResponder {
+            command_message_id: Arc::clone(&self.command_message_id),
+            session_id: session_id.to_string(),
+            assistant_message_id: assistant_message_id.to_string(),
+            delta: delta.to_string(),
+            interruption,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CommandMessageIdResponder {
+    command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
+}
+
+impl Respond for CommandMessageIdResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body: Value = serde_json::from_slice(&request.body).unwrap();
+        let message_id = body
+            .get("messageID")
+            .and_then(Value::as_str)
+            .unwrap()
+            .to_string();
+        let (lock, ready) = &*self.command_message_id;
+        *lock.lock().unwrap() = Some(message_id);
+        ready.notify_all();
+
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "ok"}))
+    }
+}
+
+#[derive(Clone)]
+pub struct CommandCorrelatedSseResponder {
+    command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
+    session_id: String,
+    assistant_message_id: String,
+    delta: String,
+    interruption: Value,
+}
+
+impl Respond for CommandCorrelatedSseResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let (lock, ready) = &*self.command_message_id;
+        let mut message_id = lock.lock().unwrap();
+        while message_id.is_none() {
+            let (guard, wait) = ready
+                .wait_timeout(message_id, Duration::from_secs(5))
+                .unwrap();
+            message_id = guard;
+            assert!(!wait.timed_out(), "command POST did not publish messageID");
+        }
+        let command_message_id = message_id.clone().unwrap();
+        drop(message_id);
+
+        let events = [
+            serde_json::json!({
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": self.session_id,
+                    "messageID": self.assistant_message_id,
+                    "delta": self.delta,
+                }
+            }),
+            serde_json::json!({
+                "type": "message.updated",
+                "properties": {
+                    "info": {
+                        "id": self.assistant_message_id,
+                        "sessionID": self.session_id,
+                        "role": "assistant",
+                        "parentID": command_message_id,
+                        "time": { "created": 1 },
+                    }
+                }
+            }),
+            self.interruption.clone(),
+        ];
+        ResponseTemplate::new(200).set_body_raw(sse_body(&events), "text/event-stream")
     }
 }
 

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -335,6 +335,17 @@ pub fn question_fixture(
     })
 }
 
+/// Encode typed event JSON values as an SSE response body.
+pub fn sse_body(events: &[Value]) -> String {
+    let mut body = String::new();
+    for event in events {
+        body.push_str("data: ");
+        body.push_str(&event.to_string());
+        body.push_str("\n\n");
+    }
+    body
+}
+
 /// Create a messages fixture with optional assistant text.
 ///
 /// If `assistant_text` is `Some`, includes an assistant message with that text.

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -201,16 +201,14 @@ impl Respond for SequenceResponder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CommandCorrelationFixture {
     command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
 }
 
 impl CommandCorrelationFixture {
     pub fn new() -> Self {
-        Self {
-            command_message_id: Arc::new((Mutex::new(None), Condvar::new())),
-        }
+        Self::default()
     }
 
     pub fn command_responder(&self) -> CommandMessageIdResponder {
@@ -269,14 +267,11 @@ pub struct CommandCorrelatedSseResponder {
 impl Respond for CommandCorrelatedSseResponder {
     fn respond(&self, _request: &Request) -> ResponseTemplate {
         let (lock, ready) = &*self.command_message_id;
-        let mut message_id = lock.lock().unwrap();
-        while message_id.is_none() {
-            let (guard, wait) = ready
-                .wait_timeout(message_id, Duration::from_secs(5))
-                .unwrap();
-            message_id = guard;
-            assert!(!wait.timed_out(), "command POST did not publish messageID");
-        }
+        let message_id = lock.lock().unwrap();
+        let (message_id, wait) = ready
+            .wait_timeout_while(message_id, Duration::from_secs(5), |id| id.is_none())
+            .unwrap();
+        assert!(!wait.timed_out(), "command POST did not publish messageID");
         let command_message_id = message_id.clone().unwrap();
         drop(message_id);
 

--- a/crates/services/opencode-rs/src/http/messages.rs
+++ b/crates/services/opencode-rs/src/http/messages.rs
@@ -22,6 +22,13 @@ pub struct MessagesApi {
     http: HttpClient,
 }
 
+/// A literal `POST /session/{id}/command` attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandPostAttempt {
+    /// One-based attempt number within this logical command call.
+    pub ordinal: usize,
+}
+
 impl MessagesApi {
     /// Create a new Messages API client.
     pub fn new(http: HttpClient) -> Self {
@@ -98,6 +105,27 @@ impl MessagesApi {
     ///
     /// Returns an error if the request fails.
     pub async fn command(&self, session_id: &str, req: &CommandRequest) -> Result<CommandResponse> {
+        self.command_with_attempt_observer(session_id, req, |_| {})
+            .await
+    }
+
+    /// Execute a command and observe every literal wire POST attempt.
+    ///
+    /// The observer receives only an ordinal and never receives request content,
+    /// headers, session identifiers, or other secrets.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn command_with_attempt_observer<F>(
+        &self,
+        session_id: &str,
+        req: &CommandRequest,
+        observer: F,
+    ) -> Result<CommandResponse>
+    where
+        F: Fn(CommandPostAttempt) + Send + Sync,
+    {
         const MAX_ATTEMPTS: usize = 2;
         const BACKOFF_MS: u64 = 50;
 
@@ -106,6 +134,7 @@ impl MessagesApi {
         let path = format!("/session/{sid}/command");
 
         for attempt in 1..=MAX_ATTEMPTS {
+            observer(CommandPostAttempt { ordinal: attempt });
             match self
                 .http
                 .request_json(Method::POST, &path, Some(body.clone()))
@@ -166,6 +195,9 @@ mod tests {
     use crate::types::message::CommandRequest;
     use crate::types::message::PromptPart;
     use crate::types::message::ShellRequest;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use wiremock::Mock;
     use wiremock::MockServer;
@@ -335,6 +367,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn command_attempt_observer_reports_immediate_success_once() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/session/s1/command"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "executed"
+            })))
+            .mount(&mock_server)
+            .await;
+        let http = HttpClient::new(HttpConfig {
+            base_url: mock_server.uri(),
+            directory: None,
+            workspace: None,
+            timeout: Duration::from_secs(30),
+        })
+        .unwrap();
+        let messages = MessagesApi::new(http);
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observer_count = Arc::clone(&observed);
+
+        messages
+            .command_with_attempt_observer(
+                "s1",
+                &CommandRequest {
+                    command: "test_command".to_string(),
+                    arguments: String::new(),
+                    message_id: None,
+                },
+                move |attempt| {
+                    assert_eq!(attempt.ordinal, 1);
+                    observer_count.fetch_add(1, Ordering::Relaxed);
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(observed.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn command_attempt_observer_reports_both_connect_attempts() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let http = HttpClient::new(HttpConfig {
+            base_url: format!("http://{address}"),
+            directory: None,
+            workspace: None,
+            timeout: Duration::from_secs(1),
+        })
+        .unwrap();
+        let messages = MessagesApi::new(http);
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observer_count = Arc::clone(&observed);
+
+        let result = messages
+            .command_with_attempt_observer(
+                "s1",
+                &CommandRequest {
+                    command: "test_command".to_string(),
+                    arguments: String::new(),
+                    message_id: None,
+                },
+                move |attempt| {
+                    assert!(attempt.ordinal == 1 || attempt.ordinal == 2);
+                    observer_count.fetch_add(1, Ordering::Relaxed);
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(OpencodeError::Transport(_))));
+        assert_eq!(observed.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
     async fn test_command_does_not_retry_on_timeout() {
         let mock_server = MockServer::start().await;
 
@@ -357,13 +464,18 @@ mod tests {
         .unwrap();
 
         let messages = MessagesApi::new(http);
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observer_count = Arc::clone(&observed);
         let result = messages
-            .command(
+            .command_with_attempt_observer(
                 "s1",
                 &CommandRequest {
                     command: "test_command".to_string(),
                     arguments: String::new(),
                     message_id: None,
+                },
+                move |_| {
+                    observer_count.fetch_add(1, Ordering::Relaxed);
                 },
             )
             .await;
@@ -378,6 +490,7 @@ mod tests {
             })
             .count();
         assert_eq!(command_requests, 1);
+        assert_eq!(observed.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

[ENG-1181](https://linear.app/generalwisdom/issue/ENG-1181) tracks a recurring failure where outer-DAG materialized `resolve_pr_comments` as a user message but did not actually start a corresponding assistant turn. In the retained corpus, all 13 post-threshold runs that dispatched the command had the same no-assistant/no-progress outcome.

The failure came from several lifecycle signals being conflated:

- any message activity, including the supplied user command, could count as execution activity;
- an absent session-status entry could be treated as completed idle before assistant start evidence existed;
- completion validation permitted a transcript window with no assistant descendant;
- an early supervisor return could detach the completion-coupled `/command` task and allow server teardown to terminate unfinished work.

The required invariant is that unresolved CodeRabbit comments must lead to proven current-command assistant execution, bounded safe start retries, or an explicit exhausted/manual-handoff result—never silent completion of an unstarted command.

## What user-facing changes did I ship?

- `resolve_pr_comments` now distinguishes `accepted_but_not_started` from successful execution and retries a failed start in a fresh session up to two times after the initial attempt. Failed starts do not consume `resolve_comments_runs` or `max_review_cycles`; exhaustion produces an explicit manual-handoff outcome.
- External CodeRabbit evidence remains authoritative: zero remaining threads can advance, and a decrease can continue the evidence-backed resolve loop, while the lifecycle anomaly remains recorded independently.
- Permission and question responses continue the same foreground invocation instead of redispatching another command POST. `start`/`resume` enforce one foreground owner per worktree, while responder commands target that live owner through local IPC.
- Status and persisted diagnostics now expose invocation phase, literal POST-attempt count, lifecycle result/anomaly, resolve-start retries, and local/server task disposition.
- The OpenCode orchestrator MCP only treats assistant messages and parts in the current command lineage as execution activity.

## How I implemented it

- Added an OpenCode SDK command-attempt observer that reports each literal `/session/{id}/command` POST ordinal without exposing request content, headers, session identifiers, or secrets. Existing command signatures and connect-only retry behavior remain intact.
- Split command preparation from execution, anchored supervision to a generated command message ID and baseline transcript tail, and required current-command assistant evidence. Absent status remains unknown before start evidence; user-only events cannot prove execution.
- Added explicit lifecycle outcomes and centralized terminalization. Every terminal/error path records server-abort and local-task disposition, and live local tasks are completed or abort-and-joined rather than silently detached.
- Persisted additive schema-v1 invocation state (`Prepared`, `PostAttempted`, `RunningAssistantStarted`, paused phases, and `Terminal`), diagnostics, lifecycle anomalies, task dispositions, and resolve workflow outcomes. New fields use serde defaults so existing state files load with conservative defaults.
- Implemented resolve-specific routing that checks CodeRabbit postconditions before retry decisions, uses a dedicated two-retry start budget, forces fresh sessions for retries, and preserves review-cycle accounting.
- Added a Unix-only per-worktree foreground owner with an exclusive RAII lock and authenticated, single-use Unix-socket IPC. Runtime directories/files are private (`0700`/`0600`), same-UID and non-symlink checks are enforced, frames are size- and time-bounded, and requests must match the protocol version, worktree, owner token, run, invocation, session, command message, interruption kind, and request ID. Owner tokens are generated securely, compared in constant time, and are not logged.
- Suspended both supervision clocks during authorized operator waits, then resumed the same invocation after forwarding the response to OpenCode.
- Applied equivalent assistant-lineage activity correlation and idle gating to `opencode-orchestrator-mcp`.

**Compatibility notes**

- No state reset or migration is required: the outer-DAG state schema remains version 1 and all new persisted fields default safely when reading older files.
- The public `MessagesApi::command` signature and existing command retry behavior are preserved; the observer is an additive API.
- `dispatch_attempt` now precisely represents literal wire POST attempts. Existing persisted values remain observational and are not used to infer retry safety.
- Ownership IPC is intentionally Unix-only, and the supervisor continues to require the repository-pinned OpenCode version.
- Older binaries may not understand state written with newly introduced enum variants; downgrade compatibility is not guaranteed.

## How to verify it

- [x] Focused checks passed via the Just MCP tools:
  - `just crate-check opencode_rs`
  - `just crate-check agentic-outer-dag-bin`
  - `just crate-check opencode-orchestrator-mcp`
- [x] Focused tests passed via the Just MCP tools:
  - `just crate-test opencode_rs` — 331 passed, 45 skipped
  - `just crate-test agentic-outer-dag-bin` — 190 passed
  - `just crate-test opencode-orchestrator-mcp` — 186 passed, 11 skipped
- [x] `just check` passed (workspace formatting and Clippy with warnings denied).
- [x] `just test` passed, including MCP schema validation and the workspace nextest run: **2,607 tests passed, 100 skipped**.
- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_cli_just_execute`) and they passed.

## Description for the changelog

Make outer-DAG OpenCode automation prove current-command assistant execution, safely retry unstarted `resolve_pr_comments` invocations, retain task and interruption ownership, and correlate orchestrator activity to the correct assistant lineage.
<!-- END:describe_pr:autogen -->

