### PR TITLE
fix(opencode): gate actions on SSE readiness

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,6 +70,8 @@ These items have dependencies and should be done in order.
 
 ## To classify/investigate:
 
+- TODO(2): ENG-1263 follow-up — adopt `SseSubscription::wait_for_initial_connection` in
+  `apps/agentic-outer-dag/src/opencode/supervisor.rs` before command dispatch.
 - TODO(2): Extract shared OpenCode session monitoring/completion detection helper used by both
   `apps/opencode-orchestrator-mcp` and `apps/agentic-outer-dag` (dispatch-confirmed idle grace gating, bounded transcript settling,
   conservative unresolved tool-state handling) to reduce drift.

--- a/agentic.schema.json
+++ b/agentic.schema.json
@@ -48,7 +48,8 @@
         },
         "compaction_threshold": 0.8,
         "inactivity_timeout_secs": 300,
-        "session_deadline_secs": 3600
+        "session_deadline_secs": 3600,
+        "sse_readiness_timeout_secs": 10
       }
     },
     "reasoning": {
@@ -389,6 +390,13 @@
           "type": "integer",
           "format": "uint64",
           "default": 3600,
+          "minimum": 0
+        },
+        "sse_readiness_timeout_secs": {
+          "description": "Timeout for initial SSE connection readiness (default: 10 seconds).",
+          "type": "integer",
+          "format": "uint64",
+          "default": 10,
           "minimum": 0
         }
       }

--- a/apps/opencode-orchestrator-mcp/CHANGELOG.md
+++ b/apps/opencode-orchestrator-mcp/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### 🐛 Bug Fixes
+- *(opencode-orchestrator)* Gate prompts, commands, and continuation replies on SSE readiness
+
+### 🧪 Testing
+- *(opencode-orchestrator)* Verify six action variants cannot dispatch before SSE Open
 ## [0.7.10] - 2026-08-12
 
 ### 🐛 Bug Fixes

--- a/apps/opencode-orchestrator-mcp/src/server.rs
+++ b/apps/opencode-orchestrator-mcp/src/server.rs
@@ -842,6 +842,11 @@ impl OrchestratorServer {
         Duration::from_secs(self.config.inactivity_timeout_secs)
     }
 
+    /// Get the initial SSE connection readiness timeout.
+    pub fn sse_readiness_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.sse_readiness_timeout_secs)
+    }
+
     /// Get the compaction threshold (0.0 - 1.0).
     pub fn compaction_threshold(&self) -> f64 {
         self.config.compaction_threshold
@@ -1148,6 +1153,19 @@ mod tests {
     async fn managed_server_with_exited_child(base_url: &str) -> OrchestratorServer {
         let managed = ManagedServer::from_child_for_testing(exited_child().await, base_url, 9);
         OrchestratorServer::from_managed_for_testing(managed, test_client(base_url), base_url)
+    }
+
+    #[test]
+    fn sse_readiness_timeout_uses_snapshot_config() {
+        let server = external_server_with_config(
+            "http://127.0.0.1:9",
+            OrchestratorConfig {
+                sse_readiness_timeout_secs: 17,
+                ..OrchestratorConfig::default()
+            },
+        );
+
+        assert_eq!(server.sse_readiness_timeout(), Duration::from_secs(17));
     }
 
     #[test]

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -43,6 +43,7 @@ use agentic_tools_core::fmt::TextFormat;
 use agentic_tools_core::fmt::TextOptions;
 use futures::future::BoxFuture;
 use opencode_rs::OpencodeError;
+use opencode_rs::sse::SseSubscription;
 use opencode_rs::types::event::Event;
 use opencode_rs::types::event::MessagePartEventProps;
 use opencode_rs::types::event::MessageUpdatedProps;
@@ -82,6 +83,20 @@ struct ToolLogMeta {
 struct RunOutcome {
     output: OrchestratorRunOutput,
     log_meta: ToolLogMeta,
+}
+
+struct PreparedMonitor {
+    server: Arc<OrchestratorServer>,
+    session_id: String,
+    subscription: SseSubscription<Event>,
+    warnings: Vec<String>,
+    dispatched_new_work: bool,
+    idle_grace: Duration,
+    idle_grace_deadline: Option<tokio::time::Instant>,
+    awaiting_idle_grace_check: bool,
+    command_task: Option<JoinHandle<Result<(), OpencodeError>>>,
+    command_name_for_logging: Option<String>,
+    command_transcript_window: Option<CommandTranscriptWindow>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -579,259 +594,27 @@ impl OrchestratorRunTool {
         }
     }
 
-    async fn run_impl_outcome(
-        &self,
-        input: OrchestratorRunInput,
+    async fn monitor_prepared(
+        prepared: PreparedMonitor,
         ctx: &ToolContext,
-        permission_preflight_mode: PermissionPreflightMode,
     ) -> Result<RunOutcome, ToolError> {
-        // Input validation
-        if input.session_id.is_none() && input.message.is_none() && input.command.is_none() {
-            return Err(ToolError::InvalidInput(
-                "Either session_id (to resume/check status) or message/command (to start work) is required"
-                    .into(),
-            ));
-        }
-
-        if input.command.is_some() && input.message.is_none() {
-            return Err(ToolError::InvalidInput(
-                "message is required when command is specified (becomes $ARGUMENTS for template expansion)"
-                    .into(),
-            ));
-        }
-
-        if input.command.is_some() && input.agent.is_some() {
-            return Err(ToolError::InvalidInput(
-                "agent cannot be provided when command is specified".into(),
-            ));
-        }
-
-        // Trim and validate message content
-        let message = input.message.map(|m| m.trim().to_string());
-        if let Some(ref m) = message
-            && m.is_empty()
-        {
-            return Err(ToolError::InvalidInput(
-                "message cannot be empty or whitespace-only".into(),
-            ));
-        }
-
-        let agent = input.agent.map(|value| value.trim().to_string());
-        if let Some(ref agent) = agent
-            && agent.is_empty()
-        {
-            return Err(ToolError::InvalidInput(
-                "agent cannot be empty or whitespace-only".into(),
-            ));
-        }
-
-        let wait_for_activity = input.wait_for_activity.unwrap_or(false);
-
-        // Lazy initialization: spawn server on first tool call
-        let server = self
-            .server
-            .acquire()
-            .await
-            .map_err(|e| ToolError::Internal(e.to_string()))?;
-
-        if let Some(command) = input.command.as_deref() {
-            let decision = server.command_policy_decision(command);
-            if !decision.is_allowed() {
-                return Err(blocked_command_error(command, decision));
-            }
-        }
-
-        if let Some(agent) = agent.as_deref() {
-            let decision = server.agent_policy_decision(agent);
-            if !decision.is_allowed() {
-                return Err(blocked_agent_error(agent, decision));
-            }
-        }
-
+        let PreparedMonitor {
+            server,
+            session_id,
+            mut subscription,
+            mut warnings,
+            dispatched_new_work,
+            idle_grace,
+            mut idle_grace_deadline,
+            mut awaiting_idle_grace_check,
+            mut command_task,
+            command_name_for_logging,
+            command_transcript_window,
+        } = prepared;
         let client = server.client();
 
-        tracing::debug!(
-            command = ?input.command,
-            has_message = message.is_some(),
-            message_len = message.as_ref().map(String::len),
-            session_id = ?input.session_id,
-            "run: starting"
-        );
-
-        // 1. Resolve session: validate existing or create new
-        let session_id = if let Some(sid) = input.session_id {
-            // Validate session exists
-            client.sessions().get(&sid).await.map_err(|e| {
-                if e.is_not_found() {
-                    ToolError::InvalidInput(format!(
-                        "Session '{sid}' not found. Use list_sessions to discover sessions, \
-                         or omit session_id to create a new session."
-                    ))
-                } else {
-                    ToolError::Internal(format!("Failed to get session: {e}"))
-                }
-            })?;
-            sid
-        } else {
-            // Create new session
-            let session = client
-                .sessions()
-                .create(&CreateSessionRequest::default())
-                .await
-                .map_err(|e| ToolError::Internal(format!("Failed to create session: {e}")))?;
-
-            {
-                let mut spawned = server.spawned_sessions().write().await;
-                spawned.insert(session.id.clone());
-            }
-
-            session.id
-        };
-
-        tracing::info!(session_id = %session_id, "run: session resolved");
-
-        let mut warnings = Vec::new();
-
-        // 2. Check if session is already idle (for resume-only case)
-        let status = client
-            .sessions()
-            .status_for(&session_id)
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to get session status: {e}")))?;
-
-        let is_idle = matches!(status, SessionStatusInfo::Idle);
-
-        // 3. Check for pending permissions before doing anything else
-        if let Some(perm) = Self::preflight_pending_permission(
-            client,
-            &session_id,
-            permission_preflight_mode,
-            &mut warnings,
-        )
-        .await?
-        {
-            tracing::info!(
-                session_id = %session_id,
-                permission_type = %perm.permission,
-                "run: pending permission found"
-            );
-            return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
-                session_id,
-                status: RunStatus::PermissionRequired,
-                response: None,
-                partial_response: None,
-                permission_request_id: Some(perm.id),
-                permission_type: Some(perm.permission),
-                permission_patterns: perm.patterns,
-                question_request_id: None,
-                questions: vec![],
-                warnings,
-            }));
-        }
-
-        let pending_questions = client
-            .question()
-            .list()
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?;
-
-        if let Some(question) = pending_questions
-            .into_iter()
-            .find(|question| question.session_id == session_id)
-        {
-            tracing::info!(session_id = %session_id, question_id = %question.id, "run: pending question found");
-            return Ok(RunOutcome::without_tokens(Self::question_required_output(
-                session_id, None, &question, warnings,
-            )));
-        }
-
-        // 4. If no message/command and session is idle, just return current state
-        // Uses finalize_completed to get retry logic for message extraction
-        if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
-            let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
-            let output =
-                Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
-            return Ok(RunOutcome::with_tracker(output, &token_tracker));
-        }
-
-        // 5. Subscribe to SSE BEFORE sending prompt/command
-        let mut subscription = client
-            .subscribe_session(&session_id)
-            .map_err(|e| ToolError::Internal(format!("Failed to subscribe to session: {e}")))?;
-
-        // Track whether this call is dispatching new work (command or message)
-        // vs just resuming/monitoring an existing session.
-        let dispatched_new_work = input.command.is_some() || message.is_some() || wait_for_activity;
-        let idle_grace = config::idle_grace();
-        let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
-        let mut awaiting_idle_grace_check = false;
-
-        if wait_for_activity && input.command.is_none() && message.is_none() {
-            idle_grace_deadline = Some(tokio::time::Instant::now() + idle_grace);
-        }
-
-        // 6. Kick off the work
-        let mut command_task: Option<JoinHandle<Result<(), OpencodeError>>> = None;
-        let mut command_name_for_logging: Option<String> = None;
-        let mut command_transcript_window: Option<CommandTranscriptWindow> = None;
-
-        if let Some(command) = &input.command {
-            command_name_for_logging = Some(command.clone());
-
-            let command_message_id = new_message_id();
-            command_transcript_window = Some(CommandTranscriptWindow {
-                command_message_id: command_message_id.clone(),
-            });
-
-            let cmd_client = client.clone();
-            let cmd_session_id = session_id.clone();
-            let cmd_name = command.clone();
-            let cmd_arguments = message.clone().unwrap_or_default();
-
-            command_task = Some(tokio::spawn(async move {
-                // OpenCode's /command request is completion-coupled rather than fire-and-forget.
-                // Once start evidence exists, later transport failures are ambiguous and we must
-                // continue supervision via SSE + status polling instead of retrying blindly.
-                let req = CommandRequest {
-                    command: cmd_name,
-                    arguments: cmd_arguments,
-                    message_id: Some(command_message_id),
-                };
-
-                cmd_client
-                    .messages()
-                    .command(&cmd_session_id, &req)
-                    .await
-                    .map(|_| ())
-            }));
-        } else if let Some(msg) = &message {
-            // Send prompt asynchronously
-            let req = PromptRequest {
-                parts: vec![PromptPart::Text {
-                    text: msg.clone(),
-                    synthetic: None,
-                    ignored: None,
-                    metadata: None,
-                }],
-                message_id: None,
-                model: None,
-                agent: agent.clone(),
-                no_reply: None,
-                system: None,
-                variant: None,
-            };
-
-            client
-                .messages()
-                .prompt_async(&session_id, &req)
-                .await
-                .map_err(|e| ToolError::Internal(format!("Failed to send prompt: {e}")))?;
-
-            idle_grace_deadline = Some(tokio::time::Instant::now() + idle_grace);
-        }
-
-        // 7. Event loop: wait for completion or permission
-        // Overall timeout to prevent infinite hangs (configurable, default 1 hour)
+        // Event loop: wait for completion or interruption.
+        // Overall timeout to prevent infinite hangs (configurable, default 1 hour).
         let deadline = tokio::time::Instant::now() + server.session_deadline();
         let inactivity_timeout = server.inactivity_timeout();
         let mut last_activity_time = tokio::time::Instant::now();
@@ -1340,6 +1123,433 @@ impl OrchestratorRunTool {
                 }
             }
         }
+    }
+
+    async fn wait_for_sse_readiness(
+        subscription: &mut SseSubscription<Event>,
+        ctx: &ToolContext,
+        readiness_timeout: Duration,
+        session_id: &str,
+    ) -> Result<(), ToolError> {
+        tokio::select! {
+            biased;
+            () = ctx.cancelled() => Err(ToolError::cancelled(None)),
+            () = tokio::time::sleep(readiness_timeout) => Err(ToolError::Internal(format!(
+                "SSE readiness timed out after {} seconds (session_id={session_id}); no OpenCode action was sent.",
+                readiness_timeout.as_secs()
+            ))),
+            result = subscription.wait_for_initial_connection() => result.map_err(|error| {
+                ToolError::Internal(format!(
+                    "SSE subscription closed before initial readiness (session_id={session_id}); no OpenCode action was sent: {error}"
+                ))
+            }),
+        }
+    }
+
+    async fn monitor_continuation(
+        server: Arc<OrchestratorServer>,
+        session_id: String,
+        subscription: SseSubscription<Event>,
+        ctx: &ToolContext,
+        permission_preflight_mode: PermissionPreflightMode,
+        wait_for_activity: bool,
+    ) -> Result<RunOutcome, ToolError> {
+        let client = server.client();
+        let mut warnings = Vec::new();
+        let status = client
+            .sessions()
+            .status_for(&session_id)
+            .await
+            .map_err(|error| {
+                ToolError::Internal(format!("Failed to get session status: {error}"))
+            })?;
+
+        if let Some(perm) = Self::preflight_pending_permission(
+            client,
+            &session_id,
+            permission_preflight_mode,
+            &mut warnings,
+        )
+        .await?
+        {
+            return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
+                session_id,
+                status: RunStatus::PermissionRequired,
+                response: None,
+                partial_response: None,
+                permission_request_id: Some(perm.id),
+                permission_type: Some(perm.permission),
+                permission_patterns: perm.patterns,
+                question_request_id: None,
+                questions: vec![],
+                warnings,
+            }));
+        }
+
+        let pending_questions =
+            client.question().list().await.map_err(|error| {
+                ToolError::Internal(format!("Failed to list questions: {error}"))
+            })?;
+        if let Some(question) = pending_questions
+            .into_iter()
+            .find(|question| question.session_id == session_id)
+        {
+            return Ok(RunOutcome::without_tokens(Self::question_required_output(
+                session_id, None, &question, warnings,
+            )));
+        }
+
+        if matches!(status, SessionStatusInfo::Idle) && !wait_for_activity {
+            let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
+            let output =
+                Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+            return Ok(RunOutcome::with_tracker(output, &token_tracker));
+        }
+
+        let idle_grace = config::idle_grace();
+        Self::monitor_prepared(
+            PreparedMonitor {
+                server,
+                session_id,
+                subscription,
+                warnings,
+                dispatched_new_work: wait_for_activity,
+                idle_grace,
+                idle_grace_deadline: wait_for_activity
+                    .then(|| tokio::time::Instant::now() + idle_grace),
+                awaiting_idle_grace_check: false,
+                command_task: None,
+                command_name_for_logging: None,
+                command_transcript_window: None,
+            },
+            ctx,
+        )
+        .await
+    }
+
+    async fn run_impl_outcome(
+        &self,
+        input: OrchestratorRunInput,
+        ctx: &ToolContext,
+        permission_preflight_mode: PermissionPreflightMode,
+    ) -> Result<RunOutcome, ToolError> {
+        // Input validation
+        if input.session_id.is_none() && input.message.is_none() && input.command.is_none() {
+            return Err(ToolError::InvalidInput(
+                "Either session_id (to resume/check status) or message/command (to start work) is required"
+                    .into(),
+            ));
+        }
+
+        if input.command.is_some() && input.message.is_none() {
+            return Err(ToolError::InvalidInput(
+                "message is required when command is specified (becomes $ARGUMENTS for template expansion)"
+                    .into(),
+            ));
+        }
+
+        if input.command.is_some() && input.agent.is_some() {
+            return Err(ToolError::InvalidInput(
+                "agent cannot be provided when command is specified".into(),
+            ));
+        }
+
+        // Trim and validate message content
+        let message = input.message.map(|m| m.trim().to_string());
+        if let Some(ref m) = message
+            && m.is_empty()
+        {
+            return Err(ToolError::InvalidInput(
+                "message cannot be empty or whitespace-only".into(),
+            ));
+        }
+
+        let agent = input.agent.map(|value| value.trim().to_string());
+        if let Some(ref agent) = agent
+            && agent.is_empty()
+        {
+            return Err(ToolError::InvalidInput(
+                "agent cannot be empty or whitespace-only".into(),
+            ));
+        }
+
+        let wait_for_activity = input.wait_for_activity.unwrap_or(false);
+
+        // Lazy initialization: spawn server on first tool call
+        let server = self
+            .server
+            .acquire()
+            .await
+            .map_err(|e| ToolError::Internal(e.to_string()))?;
+
+        if let Some(command) = input.command.as_deref() {
+            let decision = server.command_policy_decision(command);
+            if !decision.is_allowed() {
+                return Err(blocked_command_error(command, decision));
+            }
+        }
+
+        if let Some(agent) = agent.as_deref() {
+            let decision = server.agent_policy_decision(agent);
+            if !decision.is_allowed() {
+                return Err(blocked_agent_error(agent, decision));
+            }
+        }
+
+        let client = server.client();
+
+        tracing::debug!(
+            command = ?input.command,
+            has_message = message.is_some(),
+            message_len = message.as_ref().map(String::len),
+            session_id = ?input.session_id,
+            "run: starting"
+        );
+
+        // 1. Resolve session: validate existing or create new
+        let session_id = if let Some(sid) = input.session_id {
+            // Validate session exists
+            client.sessions().get(&sid).await.map_err(|e| {
+                if e.is_not_found() {
+                    ToolError::InvalidInput(format!(
+                        "Session '{sid}' not found. Use list_sessions to discover sessions, \
+                         or omit session_id to create a new session."
+                    ))
+                } else {
+                    ToolError::Internal(format!("Failed to get session: {e}"))
+                }
+            })?;
+            sid
+        } else {
+            // Create new session
+            let session = client
+                .sessions()
+                .create(&CreateSessionRequest::default())
+                .await
+                .map_err(|e| ToolError::Internal(format!("Failed to create session: {e}")))?;
+
+            {
+                let mut spawned = server.spawned_sessions().write().await;
+                spawned.insert(session.id.clone());
+            }
+
+            session.id
+        };
+
+        tracing::info!(session_id = %session_id, "run: session resolved");
+
+        let mut warnings = Vec::new();
+
+        // 2. Check if session is already idle (for resume-only case)
+        let status = client
+            .sessions()
+            .status_for(&session_id)
+            .await
+            .map_err(|e| ToolError::Internal(format!("Failed to get session status: {e}")))?;
+
+        let is_idle = matches!(status, SessionStatusInfo::Idle);
+
+        // 3. Check for pending permissions before doing anything else
+        if let Some(perm) = Self::preflight_pending_permission(
+            client,
+            &session_id,
+            permission_preflight_mode,
+            &mut warnings,
+        )
+        .await?
+        {
+            tracing::info!(
+                session_id = %session_id,
+                permission_type = %perm.permission,
+                "run: pending permission found"
+            );
+            return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
+                session_id,
+                status: RunStatus::PermissionRequired,
+                response: None,
+                partial_response: None,
+                permission_request_id: Some(perm.id),
+                permission_type: Some(perm.permission),
+                permission_patterns: perm.patterns,
+                question_request_id: None,
+                questions: vec![],
+                warnings,
+            }));
+        }
+
+        let pending_questions = client
+            .question()
+            .list()
+            .await
+            .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?;
+
+        if let Some(question) = pending_questions
+            .into_iter()
+            .find(|question| question.session_id == session_id)
+        {
+            tracing::info!(session_id = %session_id, question_id = %question.id, "run: pending question found");
+            return Ok(RunOutcome::without_tokens(Self::question_required_output(
+                session_id, None, &question, warnings,
+            )));
+        }
+
+        // 4. If no message/command and session is idle, just return current state
+        // Uses finalize_completed to get retry logic for message extraction
+        if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
+            let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
+            let output =
+                Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
+            return Ok(RunOutcome::with_tracker(output, &token_tracker));
+        }
+
+        // 5. Subscribe to SSE BEFORE sending prompt/command
+        let mut subscription = client
+            .subscribe_session(&session_id)
+            .map_err(|e| ToolError::Internal(format!("Failed to subscribe to session: {e}")))?;
+
+        Self::wait_for_sse_readiness(
+            &mut subscription,
+            ctx,
+            server.sse_readiness_timeout(),
+            &session_id,
+        )
+        .await?;
+
+        let dispatches_action = input.command.is_some() || message.is_some();
+        if dispatches_action {
+            if let Some(perm) = Self::preflight_pending_permission(
+                client,
+                &session_id,
+                permission_preflight_mode,
+                &mut warnings,
+            )
+            .await?
+            {
+                tracing::info!(
+                    session_id = %session_id,
+                    permission_type = %perm.permission,
+                    "run: pending permission found after SSE readiness"
+                );
+                return Ok(RunOutcome::without_tokens(OrchestratorRunOutput {
+                    session_id,
+                    status: RunStatus::PermissionRequired,
+                    response: None,
+                    partial_response: None,
+                    permission_request_id: Some(perm.id),
+                    permission_type: Some(perm.permission),
+                    permission_patterns: perm.patterns,
+                    question_request_id: None,
+                    questions: vec![],
+                    warnings,
+                }));
+            }
+
+            let pending_questions = client.question().list().await.map_err(|error| {
+                ToolError::Internal(format!("Failed to list questions: {error}"))
+            })?;
+            if let Some(question) = pending_questions
+                .into_iter()
+                .find(|question| question.session_id == session_id)
+            {
+                tracing::info!(
+                    session_id = %session_id,
+                    question_id = %question.id,
+                    "run: pending question found after SSE readiness"
+                );
+                return Ok(RunOutcome::without_tokens(Self::question_required_output(
+                    session_id, None, &question, warnings,
+                )));
+            }
+        }
+
+        // Track whether this call is dispatching new work (command or message)
+        // vs just resuming/monitoring an existing session.
+        let dispatched_new_work = input.command.is_some() || message.is_some() || wait_for_activity;
+        let idle_grace = config::idle_grace();
+        let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
+        let awaiting_idle_grace_check = false;
+
+        if wait_for_activity && input.command.is_none() && message.is_none() {
+            idle_grace_deadline = Some(tokio::time::Instant::now() + idle_grace);
+        }
+
+        // 6. Kick off the work
+        let mut command_task: Option<JoinHandle<Result<(), OpencodeError>>> = None;
+        let mut command_name_for_logging: Option<String> = None;
+        let mut command_transcript_window: Option<CommandTranscriptWindow> = None;
+
+        if let Some(command) = &input.command {
+            command_name_for_logging = Some(command.clone());
+
+            let command_message_id = new_message_id();
+            command_transcript_window = Some(CommandTranscriptWindow {
+                command_message_id: command_message_id.clone(),
+            });
+
+            let cmd_client = client.clone();
+            let cmd_session_id = session_id.clone();
+            let cmd_name = command.clone();
+            let cmd_arguments = message.clone().unwrap_or_default();
+
+            command_task = Some(tokio::spawn(async move {
+                // OpenCode's /command request is completion-coupled rather than fire-and-forget.
+                // Once start evidence exists, later transport failures are ambiguous and we must
+                // continue supervision via SSE + status polling instead of retrying blindly.
+                let req = CommandRequest {
+                    command: cmd_name,
+                    arguments: cmd_arguments,
+                    message_id: Some(command_message_id),
+                };
+
+                cmd_client
+                    .messages()
+                    .command(&cmd_session_id, &req)
+                    .await
+                    .map(|_| ())
+            }));
+        } else if let Some(msg) = &message {
+            // Send prompt asynchronously
+            let req = PromptRequest {
+                parts: vec![PromptPart::Text {
+                    text: msg.clone(),
+                    synthetic: None,
+                    ignored: None,
+                    metadata: None,
+                }],
+                message_id: None,
+                model: None,
+                agent: agent.clone(),
+                no_reply: None,
+                system: None,
+                variant: None,
+            };
+
+            client
+                .messages()
+                .prompt_async(&session_id, &req)
+                .await
+                .map_err(|e| ToolError::Internal(format!("Failed to send prompt: {e}")))?;
+
+            idle_grace_deadline = Some(tokio::time::Instant::now() + idle_grace);
+        }
+
+        Self::monitor_prepared(
+            PreparedMonitor {
+                server,
+                session_id,
+                subscription,
+                warnings,
+                dispatched_new_work,
+                idle_grace,
+                idle_grace_deadline,
+                awaiting_idle_grace_check,
+                command_task,
+                command_name_for_logging,
+                command_transcript_window,
+            },
+            ctx,
+        )
+        .await
     }
 }
 
@@ -2030,8 +2240,21 @@ Parameters:
                     PermissionReply::Reject => ApiPermissionReply::Reject,
                 };
 
-                // Send the reply
                 let session_id_for_error = input.session_id.clone();
+                let mut subscription = client
+                    .subscribe_session(&session_id_for_error)
+                    .map_err(|error| {
+                        ToolError::Internal(format!(
+                            "Failed to subscribe to session before permission reply: {error}"
+                        ))
+                    })?;
+                OrchestratorRunTool::wait_for_sse_readiness(
+                    &mut subscription,
+                    &ctx,
+                    server.sse_readiness_timeout(),
+                    &session_id_for_error,
+                )
+                .await?;
 
                 match client
                     .permissions()
@@ -2057,22 +2280,15 @@ Parameters:
                     }
                 }
 
-                // Now continue monitoring the session using run logic
-                let run_tool = OrchestratorRunTool::new(Arc::clone(&server_handle));
-                let wait_for_activity = (!is_reject).then_some(true);
-                let outcome = run_tool
-                    .run_impl_outcome(
-                        OrchestratorRunInput {
-                            session_id: Some(input.session_id),
-                            command: None,
-                            agent: None,
-                            message: None,
-                            wait_for_activity,
-                        },
-                        &ctx,
-                        PermissionPreflightMode::RespondPermissionContinuation,
-                    )
-                    .await?;
+                let outcome = OrchestratorRunTool::monitor_continuation(
+                    server,
+                    session_id_for_error,
+                    subscription,
+                    &ctx,
+                    PermissionPreflightMode::RespondPermissionContinuation,
+                    !is_reject,
+                )
+                .await?;
                 let mut out = outcome.output;
 
                 // Merge pre-warnings
@@ -2219,14 +2435,31 @@ Parameters:
                 }
             };
 
+            let wait_for_activity = matches!(input.action, QuestionAction::Reply);
+            if wait_for_activity && input.answers.is_empty() {
+                return Err(ToolError::InvalidInput(
+                    "answers is required when action=reply".into(),
+                ));
+            }
+
+            let session_id = input.session_id.clone();
+            let mut subscription = client
+                .subscribe_session(&session_id)
+                .map_err(|error| {
+                    ToolError::Internal(format!(
+                        "Failed to subscribe to session before question response: {error}"
+                    ))
+                })?;
+            OrchestratorRunTool::wait_for_sse_readiness(
+                &mut subscription,
+                &ctx,
+                server.sse_readiness_timeout(),
+                &session_id,
+            )
+            .await?;
+
             match input.action {
                 QuestionAction::Reply => {
-                    if input.answers.is_empty() {
-                        return Err(ToolError::InvalidInput(
-                            "answers is required when action=reply".into(),
-                        ));
-                    }
-
                     client
                         .question()
                         .reply(
@@ -2236,38 +2469,27 @@ Parameters:
                             },
                         )
                         .await
-                        .map_err(|e| {
-                            ToolError::Internal(format!("Failed to reply to question: {e}"))
+                        .map_err(|error| {
+                            ToolError::Internal(format!("Failed to reply to question: {error}"))
                         })?;
-
-                    let outcome = OrchestratorRunTool::new(Arc::clone(&server_handle))
-                        .run_impl_outcome(OrchestratorRunInput {
-                            session_id: Some(input.session_id),
-                            command: None,
-                            agent: None,
-                            message: None,
-                            wait_for_activity: Some(true),
-                        }, &ctx, PermissionPreflightMode::Strict)
-                        .await?;
-                    Ok((outcome.output, outcome.log_meta))
                 }
                 QuestionAction::Reject => {
-                    client.question().reject(&question.id).await.map_err(|e| {
-                        ToolError::Internal(format!("Failed to reject question: {e}"))
+                    client.question().reject(&question.id).await.map_err(|error| {
+                        ToolError::Internal(format!("Failed to reject question: {error}"))
                     })?;
-
-                    let outcome = OrchestratorRunTool::new(Arc::clone(&server_handle))
-                        .run_impl_outcome(OrchestratorRunInput {
-                            session_id: Some(input.session_id),
-                            command: None,
-                            agent: None,
-                            message: None,
-                            wait_for_activity: None,
-                        }, &ctx, PermissionPreflightMode::Strict)
-                        .await?;
-                    Ok((outcome.output, outcome.log_meta))
                 }
             }
+
+            let outcome = OrchestratorRunTool::monitor_continuation(
+                server,
+                session_id,
+                subscription,
+                &ctx,
+                PermissionPreflightMode::Strict,
+                wait_for_activity,
+            )
+            .await?;
+            Ok((outcome.output, outcome.log_meta))
         }
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -57,11 +57,7 @@ async fn run_returns_cancelled_when_request_context_is_cancelled() {
         .await;
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
     Mock::given(method("POST"))
@@ -154,11 +150,7 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
         .await;
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -396,11 +396,7 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
         .await;
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
     Mock::given(method("POST"))

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -95,11 +95,7 @@ async fn assert_command_dispatch_invalid_input(status: u16, body: serde_json::Va
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -188,11 +184,7 @@ async fn fast_idle_prompt_completes_without_hanging() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -279,11 +271,7 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -368,11 +356,7 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -489,11 +473,7 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -680,6 +660,12 @@ async fn respond_permission_reply_404_is_actionable_invalid_input() {
         .mount(&mock)
         .await;
 
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(support::open_sse_response())
+        .mount(&mock)
+        .await;
+
     let err = tool
         .call(
             RespondPermissionInput {
@@ -790,11 +776,7 @@ async fn command_transport_error_after_start_evidence_warns_and_completes() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -895,11 +877,7 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -1017,11 +995,7 @@ async fn command_dispatch_posts_server_valid_message_id() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -184,15 +184,10 @@ async fn it_bug1_completion_retries_messages_until_visible() {
         .mount(&mock)
         .await;
 
-    // GET /event - SSE endpoint: return empty response with delay to allow polling to complete
-    // The SSE subscription will fail/hang, but polling will detect idle status
+    // Open SSE readiness, then let polling detect completion after the stream closes.
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)), // Long delay to let polling win
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -296,6 +291,12 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
             ResponseTemplate::new(200)
                 .set_body_json(messages_fixture(sid, Some("I_WILL_CREATE_FILE"))),
         )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -416,6 +417,12 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
         .mount(&mock)
         .await;
 
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(support::open_sse_response())
+        .mount(&mock)
+        .await;
+
     // Act
     let result = timeout(
         Duration::from_secs(10),
@@ -532,14 +539,10 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
         .mount(&mock)
         .await;
 
-    // GET /event - delay SSE so polling drives completion
+    // Open SSE readiness, then let polling drive completion after closure.
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -617,14 +620,10 @@ async fn it_bug4_command_dispatch_transport_error_does_not_retry_without_start_e
         .mount(&mock)
         .await;
 
-    // GET /event - SSE endpoint: return empty response with delay to allow polling to complete
+    // Open SSE readiness before exercising command transport failure behavior.
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)), // Long delay to let polling win
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -225,11 +225,7 @@ async fn poll_detected_question_returns_question_required() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -318,11 +314,7 @@ async fn respond_question_reply_resumes_to_completed() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -395,6 +387,12 @@ async fn respond_question_reject_completes_cleanly() {
     Mock::given(method("GET"))
         .and(path(format!("/session/{sid}/message")))
         .respond_with(ResponseTemplate::new(200).set_body_json(messages_fixture(sid, None)))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 
@@ -542,11 +540,7 @@ async fn respond_question_by_id_lookup() {
 
     Mock::given(method("GET"))
         .and(path("/event"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
-        )
+        .respond_with(support::open_sse_response())
         .mount(&mock)
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/sse_readiness_ordering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/sse_readiness_ordering_wiremock.rs
@@ -1,0 +1,650 @@
+#![expect(clippy::expect_used)]
+
+mod support;
+
+use agentic_config::types::OrchestratorConfig;
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use opencode_orchestrator_mcp::tools::ListCommandsTool;
+use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
+use opencode_orchestrator_mcp::tools::RespondPermissionTool;
+use opencode_orchestrator_mcp::tools::RespondQuestionTool;
+use opencode_orchestrator_mcp::types::ListCommandsInput;
+use opencode_orchestrator_mcp::types::OrchestratorRunInput;
+use opencode_orchestrator_mcp::types::PermissionReply;
+use opencode_orchestrator_mcp::types::QuestionAction;
+use opencode_orchestrator_mcp::types::RespondPermissionInput;
+use opencode_orchestrator_mcp::types::RespondQuestionInput;
+use opencode_orchestrator_mcp::types::RunStatus;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+use support::CallCounter;
+use support::SequenceResponder;
+use support::messages_fixture;
+use support::permission_fixture;
+use support::question_fixture;
+use support::session_fixture;
+use support::status_v2_busy;
+use support::status_v2_idle;
+use support::test_orchestrator_server;
+use support::test_orchestrator_server_with_config;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn question_payload(prompt: &str) -> serde_json::Value {
+    serde_json::json!({
+        "question": prompt,
+        "header": "Readiness question",
+        "options": [{"label": "yes", "description": "Proceed"}],
+        "multiple": false,
+        "custom": false,
+    })
+}
+
+async fn mount_session(mock: &MockServer, session_id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{session_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(session_id)))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_empty_permissions(mock: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_empty_questions(mock: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_messages(mock: &MockServer, session_id: &str, response: Option<&str>) {
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{session_id}/message")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(messages_fixture(session_id, response)),
+        )
+        .mount(mock)
+        .await;
+}
+
+async fn mount_run_statuses(mock: &MockServer, session_id: &str) {
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_barrier(mock: &MockServer) -> support::SseReadinessBarrierControl {
+    let (responder, control) = support::sse_readiness_barrier();
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(responder)
+        .mount(mock)
+        .await;
+    control
+}
+
+fn counted_response(template: ResponseTemplate) -> (SequenceResponder, CallCounter) {
+    let responder = SequenceResponder::new(vec![template]);
+    let counter = responder.call_counter();
+    (responder, counter)
+}
+
+async fn assert_single_snapshot(mock: &MockServer) {
+    let requests = mock
+        .received_requests()
+        .await
+        .expect("request log unavailable");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.url.path() == "/global/health")
+            .count(),
+        1,
+        "tool call should acquire exactly one server snapshot"
+    );
+}
+
+async fn run_action_is_gated(command: bool) {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = if command {
+        "readiness-command"
+    } else {
+        "readiness-prompt"
+    };
+
+    mount_session(&mock, session_id).await;
+    mount_run_statuses(&mock, session_id).await;
+    mount_empty_permissions(&mock).await;
+    mount_empty_questions(&mock).await;
+    mount_messages(&mock, session_id, Some("READY_DONE")).await;
+    let mut barrier = mount_barrier(&mock).await;
+
+    let action_path = if command {
+        format!("/session/{session_id}/command")
+    } else {
+        format!("/session/{session_id}/prompt_async")
+    };
+    let action_response = if command {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "ok"}))
+    } else {
+        ResponseTemplate::new(204)
+    };
+    let (action_responder, action_calls) = counted_response(action_response);
+    Mock::given(method("POST"))
+        .and(path(action_path))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let input = OrchestratorRunInput {
+        session_id: Some(session_id.into()),
+        command: command.then(|| "implement_plan".into()),
+        agent: None,
+        message: Some("do the work".into()),
+        wait_for_activity: None,
+    };
+    let handle = tokio::spawn(async move { tool.call(input, &ToolContext::default()).await });
+
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0, "action was sent before SSE Open");
+    barrier.release();
+
+    let output = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("run action did not complete")
+        .expect("run task panicked")
+        .expect("run action failed");
+    assert!(matches!(output.status, RunStatus::Completed));
+    assert_eq!(output.response.as_deref(), Some("READY_DONE"));
+    assert!(output.warnings.is_empty());
+    assert_eq!(action_calls.get(), 1, "action should be sent exactly once");
+    assert_single_snapshot(&mock).await;
+}
+
+#[tokio::test]
+async fn raw_prompt_waits_for_sse_open_before_dispatch() {
+    run_action_is_gated(false).await;
+}
+
+#[tokio::test]
+async fn command_waits_for_sse_open_before_dispatch() {
+    run_action_is_gated(true).await;
+}
+
+async fn permission_action_is_gated(reply: PermissionReply) {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondPermissionTool::new(Arc::clone(&server));
+    let reject = matches!(reply, PermissionReply::Reject);
+    let session_id = if reject {
+        "readiness-permission-reject"
+    } else {
+        "readiness-permission-allow"
+    };
+    let permission_id = format!("permission-{session_id}");
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+                &permission_id,
+                session_id,
+                "file.write",
+                &["src/**"],
+            )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+        ]))
+        .mount(&mock)
+        .await;
+    mount_empty_questions(&mock).await;
+    let statuses = if reject {
+        vec![ResponseTemplate::new(200).set_body_json(status_v2_idle())]
+    } else {
+        vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]
+    };
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(statuses))
+        .mount(&mock)
+        .await;
+    mount_messages(
+        &mock,
+        session_id,
+        if reject {
+            None
+        } else {
+            Some("PERMISSION_DONE")
+        },
+    )
+    .await;
+    let mut barrier = mount_barrier(&mock).await;
+
+    let (action_responder, action_calls) =
+        counted_response(ResponseTemplate::new(200).set_body_json(true));
+    Mock::given(method("POST"))
+        .and(path(format!("/permission/{permission_id}/reply")))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let handle = tokio::spawn(async move {
+        tool.call(
+            RespondPermissionInput {
+                session_id: session_id.into(),
+                permission_request_id: Some(permission_id),
+                reply,
+                message: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0, "permission reply preceded SSE Open");
+    barrier.release();
+
+    let output = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("permission action did not complete")
+        .expect("permission task panicked")
+        .expect("permission action failed");
+    assert!(matches!(output.status, RunStatus::Completed));
+    if reject {
+        assert!(output.response.is_none());
+        assert!(
+            output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("rejected"))
+        );
+    } else {
+        assert_eq!(output.response.as_deref(), Some("PERMISSION_DONE"));
+        assert!(output.warnings.is_empty());
+    }
+    assert_eq!(action_calls.get(), 1, "permission action should occur once");
+    assert_single_snapshot(&mock).await;
+}
+
+#[tokio::test]
+async fn permission_allow_waits_for_sse_open_before_reply() {
+    permission_action_is_gated(PermissionReply::Once).await;
+}
+
+#[tokio::test]
+async fn permission_reject_waits_for_sse_open_before_reply() {
+    permission_action_is_gated(PermissionReply::Reject).await;
+}
+
+async fn question_action_is_gated(action: QuestionAction) {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = RespondQuestionTool::new(Arc::clone(&server));
+    let reject = matches!(action, QuestionAction::Reject);
+    let session_id = if reject {
+        "readiness-question-reject"
+    } else {
+        "readiness-question-reply"
+    };
+    let question_id = format!("question-{session_id}");
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
+                &question_id,
+                session_id,
+                &[question_payload("Continue?")],
+            )])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+        ]))
+        .mount(&mock)
+        .await;
+    mount_empty_permissions(&mock).await;
+    let statuses = if reject {
+        vec![ResponseTemplate::new(200).set_body_json(status_v2_idle())]
+    } else {
+        vec![
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(session_id)),
+            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ]
+    };
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(SequenceResponder::new(statuses))
+        .mount(&mock)
+        .await;
+    mount_messages(
+        &mock,
+        session_id,
+        if reject { None } else { Some("QUESTION_DONE") },
+    )
+    .await;
+    let mut barrier = mount_barrier(&mock).await;
+
+    let action_path = if reject {
+        format!("/question/{question_id}/reject")
+    } else {
+        format!("/question/{question_id}/reply")
+    };
+    let (action_responder, action_calls) =
+        counted_response(ResponseTemplate::new(200).set_body_json(true));
+    Mock::given(method("POST"))
+        .and(path(action_path))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let handle = tokio::spawn(async move {
+        tool.call(
+            RespondQuestionInput {
+                session_id: session_id.into(),
+                question_request_id: Some(question_id),
+                action,
+                answers: if reject {
+                    vec![]
+                } else {
+                    vec![vec!["yes".into()]]
+                },
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0, "question action preceded SSE Open");
+    barrier.release();
+
+    let output = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("question action did not complete")
+        .expect("question task panicked")
+        .expect("question action failed");
+    assert!(matches!(output.status, RunStatus::Completed));
+    assert_eq!(
+        output.response.as_deref(),
+        if reject { None } else { Some("QUESTION_DONE") }
+    );
+    assert!(output.warnings.is_empty());
+    assert_eq!(action_calls.get(), 1, "question action should occur once");
+    assert_single_snapshot(&mock).await;
+}
+
+#[tokio::test]
+async fn question_reply_waits_for_sse_open_before_action() {
+    question_action_is_gated(QuestionAction::Reply).await;
+}
+
+#[tokio::test]
+async fn question_reject_waits_for_sse_open_before_action() {
+    question_action_is_gated(QuestionAction::Reject).await;
+}
+
+#[tokio::test]
+async fn readiness_timeout_sends_no_prompt() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server_with_config(
+        &mock,
+        OrchestratorConfig {
+            sse_readiness_timeout_secs: 0,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = "readiness-timeout";
+    mount_session(&mock, session_id).await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+    mount_empty_permissions(&mock).await;
+    mount_empty_questions(&mock).await;
+    let _barrier = mount_barrier(&mock).await;
+    let (action_responder, action_calls) = counted_response(ResponseTemplate::new(204));
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{session_id}/prompt_async")))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let error = timeout(
+        TEST_TIMEOUT,
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(session_id.into()),
+                command: None,
+                agent: None,
+                message: Some("must not dispatch".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("readiness timeout test hung")
+    .expect_err("readiness timeout should fail");
+    assert!(error.to_string().contains("no OpenCode action was sent"));
+    assert_eq!(action_calls.get(), 0);
+}
+
+#[tokio::test]
+async fn readiness_cancellation_sends_no_command_and_handle_remains_reusable() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = "readiness-cancel";
+    mount_session(&mock, session_id).await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+    mount_empty_permissions(&mock).await;
+    mount_empty_questions(&mock).await;
+    let mut barrier = mount_barrier(&mock).await;
+    let (action_responder, action_calls) =
+        counted_response(ResponseTemplate::new(200).set_body_json(serde_json::json!({})));
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{session_id}/command")))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/command"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(support::commands_list_fixture()))
+        .mount(&mock)
+        .await;
+
+    let ctx = ToolContext::default();
+    let cancellation = ctx.cancellation_token();
+    let handle = tokio::spawn(async move {
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(session_id.into()),
+                command: Some("research".into()),
+                agent: None,
+                message: Some("must not dispatch".into()),
+                wait_for_activity: None,
+            },
+            &ctx,
+        )
+        .await
+    });
+
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0);
+    cancellation.cancel();
+    let result = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("cancelled readiness did not finish")
+        .expect("cancelled run task panicked");
+    assert!(matches!(result, Err(ToolError::Cancelled { .. })));
+    assert_eq!(action_calls.get(), 0);
+    barrier.release();
+
+    let commands = ListCommandsTool::new(Arc::clone(&server))
+        .call(ListCommandsInput {}, &ToolContext::default())
+        .await
+        .expect("server handle should remain reusable");
+    assert_eq!(commands.commands.len(), 3);
+}
+
+#[tokio::test]
+async fn post_ready_permission_blocker_prevents_prompt_dispatch() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = "readiness-permission-blocker";
+    mount_session(&mock, session_id).await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+                "post-ready-permission",
+                session_id,
+                "file.write",
+                &["src/**"],
+            )])),
+        ]))
+        .mount(&mock)
+        .await;
+    mount_empty_questions(&mock).await;
+    let mut barrier = mount_barrier(&mock).await;
+    let (action_responder, action_calls) = counted_response(ResponseTemplate::new(204));
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{session_id}/prompt_async")))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let handle = tokio::spawn(async move {
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(session_id.into()),
+                command: None,
+                agent: None,
+                message: Some("blocked".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0);
+    barrier.release();
+
+    let output = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("permission blocker test hung")
+        .expect("permission blocker task panicked")
+        .expect("permission blocker should return output");
+    assert!(matches!(output.status, RunStatus::PermissionRequired));
+    assert_eq!(
+        output.permission_request_id.as_deref(),
+        Some("post-ready-permission")
+    );
+    assert_eq!(action_calls.get(), 0);
+}
+
+#[tokio::test]
+async fn post_ready_question_blocker_prevents_command_dispatch() {
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let session_id = "readiness-question-blocker";
+    mount_session(&mock, session_id).await;
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_v2_idle()))
+        .mount(&mock)
+        .await;
+    mount_empty_permissions(&mock).await;
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(SequenceResponder::new(vec![
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
+                "post-ready-question",
+                session_id,
+                &[question_payload("Continue?")],
+            )])),
+        ]))
+        .mount(&mock)
+        .await;
+    let mut barrier = mount_barrier(&mock).await;
+    let (action_responder, action_calls) =
+        counted_response(ResponseTemplate::new(200).set_body_json(serde_json::json!({})));
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{session_id}/command")))
+        .respond_with(action_responder)
+        .mount(&mock)
+        .await;
+
+    let handle = tokio::spawn(async move {
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(session_id.into()),
+                command: Some("research".into()),
+                agent: None,
+                message: Some("blocked".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+    barrier.wait_for_arrival().await;
+    assert_eq!(action_calls.get(), 0);
+    barrier.release();
+
+    let output = timeout(TEST_TIMEOUT, handle)
+        .await
+        .expect("question blocker test hung")
+        .expect("question blocker task panicked")
+        .expect("question blocker should return output");
+    assert!(matches!(output.status, RunStatus::QuestionRequired));
+    assert_eq!(
+        output.question_request_id.as_deref(),
+        Some("post-ready-question")
+    );
+    assert_eq!(action_calls.get(), 0);
+}

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::Request;
@@ -201,6 +202,79 @@ impl Respond for SequenceResponder {
     }
 }
 
+const READINESS_BARRIER_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct SseReadinessBarrierResponder {
+    arrival: mpsc::Sender<()>,
+    release: Arc<(Mutex<bool>, Condvar)>,
+}
+
+pub struct SseReadinessBarrierControl {
+    arrival: mpsc::Receiver<()>,
+    release: Arc<(Mutex<bool>, Condvar)>,
+}
+
+pub fn sse_readiness_barrier() -> (SseReadinessBarrierResponder, SseReadinessBarrierControl) {
+    let (arrival_tx, arrival_rx) = mpsc::channel(1);
+    let release = Arc::new((Mutex::new(false), Condvar::new()));
+    (
+        SseReadinessBarrierResponder {
+            arrival: arrival_tx,
+            release: Arc::clone(&release),
+        },
+        SseReadinessBarrierControl {
+            arrival: arrival_rx,
+            release,
+        },
+    )
+}
+
+impl Respond for SseReadinessBarrierResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        if self.arrival.try_send(()).is_err() {
+            return ResponseTemplate::new(500)
+                .set_body_string("readiness arrival receiver unavailable");
+        }
+
+        let (lock, released) = &*self.release;
+        let guard = lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (guard, wait) = released
+            .wait_timeout_while(guard, READINESS_BARRIER_TIMEOUT, |released| !*released)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if wait.timed_out() && !*guard {
+            return ResponseTemplate::new(504).set_body_string("readiness barrier timed out");
+        }
+
+        open_sse_response()
+    }
+}
+
+impl SseReadinessBarrierControl {
+    pub async fn wait_for_arrival(&mut self) {
+        tokio::time::timeout(READINESS_BARRIER_TIMEOUT, self.arrival.recv())
+            .await
+            .expect("SSE request did not reach readiness barrier")
+            .expect("readiness barrier responder dropped before arrival");
+    }
+
+    pub fn release(&self) {
+        let (lock, released) = &*self.release;
+        *lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        released.notify_all();
+    }
+}
+
+impl Drop for SseReadinessBarrierControl {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct CommandCorrelationFixture {
     command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
@@ -266,14 +340,11 @@ pub struct CommandCorrelatedSseResponder {
 
 impl Respond for CommandCorrelatedSseResponder {
     fn respond(&self, _request: &Request) -> ResponseTemplate {
-        let (lock, ready) = &*self.command_message_id;
-        let message_id = lock.lock().unwrap();
-        let (message_id, wait) = ready
-            .wait_timeout_while(message_id, Duration::from_secs(5), |id| id.is_none())
-            .unwrap();
-        assert!(!wait.timed_out(), "command POST did not publish messageID");
-        let command_message_id = message_id.clone().unwrap();
-        drop(message_id);
+        let (lock, _) = &*self.command_message_id;
+        let command_message_id = lock.lock().unwrap().clone();
+        let Some(command_message_id) = command_message_id else {
+            return open_sse_response();
+        };
 
         let events = [
             serde_json::json!({
@@ -448,6 +519,11 @@ pub fn sse_body(events: &[Value]) -> String {
         body.push_str("\n\n");
     }
     body
+}
+
+/// Return a valid SSE response that opens immediately and then closes.
+pub fn open_sse_response() -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_raw(": open\n\n", "text/event-stream")
 }
 
 /// Create a messages fixture with optional assistant text.

--- a/crates/infra/agentic-config/src/loader.rs
+++ b/crates/infra/agentic-config/src/loader.rs
@@ -301,6 +301,7 @@ mod tests {
             "https://api.anthropic.com"
         );
         assert_eq!(loaded.config.orchestrator.session_deadline_secs, 3600);
+        assert_eq!(loaded.config.orchestrator.sse_readiness_timeout_secs, 10);
         assert_eq!(loaded.config.subagents.runtime_timeout_secs, 3600);
         assert_eq!(loaded.config.cli_tools.just_execute_timeout_secs, 1800);
         assert_eq!(loaded.config.cli_tools.just_execute_page_lines, 200);
@@ -325,14 +326,17 @@ mod tests {
             r"
 [orchestrator]
 session_deadline_secs = 7200
+sse_readiness_timeout_secs = 17
 ",
         )
         .unwrap();
 
         let loaded = load_merged(temp.path()).unwrap();
         assert_eq!(loaded.config.orchestrator.session_deadline_secs, 7200);
+        assert_eq!(loaded.config.orchestrator.sse_readiness_timeout_secs, 17);
         // Other fields should be defaults
         assert_eq!(loaded.config.orchestrator.inactivity_timeout_secs, 300);
+        assert!((loaded.config.orchestrator.compaction_threshold - 0.80).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/infra/agentic-config/src/types.rs
+++ b/crates/infra/agentic-config/src/types.rs
@@ -169,6 +169,8 @@ pub struct OrchestratorConfig {
     pub session_deadline_secs: u64,
     /// Inactivity timeout in seconds before session ends (default: 300 = 5 minutes).
     pub inactivity_timeout_secs: u64,
+    /// Timeout for initial SSE connection readiness (default: 10 seconds).
+    pub sse_readiness_timeout_secs: u64,
     /// Context compaction threshold as fraction 0.0-1.0 (default: 0.80).
     pub compaction_threshold: f64,
     /// Command filtering policy for orchestrator-exposed `OpenCode` commands.
@@ -202,6 +204,7 @@ impl Default for OrchestratorConfig {
         Self {
             session_deadline_secs: 3600,
             inactivity_timeout_secs: 300,
+            sse_readiness_timeout_secs: 10,
             compaction_threshold: 0.80,
             commands: OrchestratorCommandsConfig::default(),
             agents: OrchestratorAgentsConfig::default(),
@@ -632,6 +635,23 @@ deny = ["Bash"]
     }
 
     #[test]
+    fn test_orchestrator_readiness_timeout_round_trip() {
+        let toml_str = r"
+[orchestrator]
+sse_readiness_timeout_secs = 17
+";
+
+        let config: AgenticConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.orchestrator.sse_readiness_timeout_secs, 17);
+        assert_eq!(config.orchestrator.session_deadline_secs, 3600);
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let round_tripped: AgenticConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(round_tripped.orchestrator.sse_readiness_timeout_secs, 17);
+        assert_eq!(round_tripped.orchestrator.inactivity_timeout_secs, 300);
+    }
+
+    #[test]
     fn test_schema_field_optional() {
         let toml_str = r#""$schema" = "file://./agentic.schema.json""#;
         let config: AgenticConfig = toml::from_str(toml_str).unwrap();
@@ -670,6 +690,7 @@ deny = ["Bash"]
         let cfg = OrchestratorConfig::default();
         assert_eq!(cfg.session_deadline_secs, 3600);
         assert_eq!(cfg.inactivity_timeout_secs, 300);
+        assert_eq!(cfg.sse_readiness_timeout_secs, 10);
         assert!((cfg.compaction_threshold - 0.80).abs() < f64::EPSILON);
         assert!(cfg.commands.allow.is_empty());
         assert!(cfg.commands.deny.is_empty());

--- a/crates/services/opencode-rs/CHANGELOG.md
+++ b/crates/services/opencode-rs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### 🐛 Bug Fixes
+- *(opencode-rs)* Expose sticky initial SSE connection readiness and prompt cancellation
+
+### 🧪 Testing
+- *(opencode-rs)* Cover initial SSE readiness, reconnects, filtering, and cancellation
 ## [0.13.4] - 2026-08-12
 
 ### 🐛 Bug Fixes

--- a/crates/services/opencode-rs/Cargo.toml
+++ b/crates/services/opencode-rs/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 wiremock = "0.6"
 tokio-test = "0.4"
-tokio = { version = "1", features = ["test-util"] }
+tokio = { version = "1", features = ["io-util", "net", "test-util"] }
 anyhow = "1"
 tracing-subscriber = "0.3"
 

--- a/crates/services/opencode-rs/README.md
+++ b/crates/services/opencode-rs/README.md
@@ -132,7 +132,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Subscribe to session events BEFORE sending prompt
     let mut subscription = client.subscribe_session(&session.id)?;
-    println!("Subscribed to events");
+    subscription.wait_for_initial_connection().await?;
+    println!("Subscribed and connected to events");
 
     // Send prompt
     client
@@ -193,6 +194,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+`wait_for_initial_connection` completes after the first validated SSE connection opens. Readiness
+is sticky after success and does not describe the current connection or later reconnects. The
+method has no built-in timeout; callers should apply their own timeout and cancellation policy.
 
 ## Features
 

--- a/crates/services/opencode-rs/examples/full_workflow.rs
+++ b/crates/services/opencode-rs/examples/full_workflow.rs
@@ -53,7 +53,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 4: Subscribe to events BEFORE sending prompt
     println!("\n4. Subscribing to session events...");
     let mut subscription = client.subscribe_session(&session.id)?;
-    println!("   Subscribed successfully");
+    subscription.wait_for_initial_connection().await?;
+    println!("   Subscribed and connected successfully");
 
     // Step 5: Send a prompt
     println!("\n5. Sending prompt...");

--- a/crates/services/opencode-rs/examples/streaming.rs
+++ b/crates/services/opencode-rs/examples/streaming.rs
@@ -28,7 +28,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Subscribe to session events BEFORE sending prompt
     let mut subscription = client.subscribe_session(&session.id)?;
-    println!("Subscribed to events");
+    subscription.wait_for_initial_connection().await?;
+    println!("Subscribed and connected to events");
 
     // Send prompt
     client

--- a/crates/services/opencode-rs/src/sse.rs
+++ b/crates/services/opencode-rs/src/sse.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides SSE subscription with reconnection and backoff.
 
+use crate::error::OpencodeError;
 use crate::error::Result;
 use crate::types::event::Event;
 use crate::types::event::GlobalEvent;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 /// Options for SSE subscription.
@@ -43,6 +45,7 @@ impl Default for SseOptions {
 /// Dropping this handle will cancel the subscription.
 pub struct SseSubscription<T> {
     rx: mpsc::Receiver<T>,
+    initial_connection: watch::Receiver<bool>,
     cancel: CancellationToken,
     _task: tokio::task::JoinHandle<()>,
 }
@@ -53,6 +56,32 @@ impl<T> SseSubscription<T> {
     /// Returns `None` if the stream is closed.
     pub async fn recv(&mut self) -> Option<T> {
         self.rx.recv().await
+    }
+
+    /// Wait for the first validated SSE connection to open.
+    ///
+    /// This method has no internal timeout. Readiness is historical and sticky:
+    /// after the first successful connection it returns immediately, including
+    /// during later reconnects. Callers own timeout and cancellation policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OpencodeError::StreamClosed`] if the subscription worker exits
+    /// before the initial connection opens.
+    pub async fn wait_for_initial_connection(&mut self) -> Result<()> {
+        if *self.initial_connection.borrow() {
+            return Ok(());
+        }
+
+        loop {
+            self.initial_connection
+                .changed()
+                .await
+                .map_err(|_| OpencodeError::StreamClosed)?;
+            if *self.initial_connection.borrow() {
+                return Ok(());
+            }
+        }
     }
 
     /// Close the subscription explicitly.
@@ -159,6 +188,7 @@ impl SseSubscriber {
         F: Fn(&T) -> bool + Send + Sync + 'static,
     {
         let (tx, rx) = mpsc::channel(opts.capacity);
+        let (initial_connection_tx, initial_connection) = watch::channel(false);
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
 
@@ -216,17 +246,27 @@ impl SseSubscriber {
                     }
                 };
 
-                while let Some(event) = es.next().await {
-                    if cancel_clone.is_cancelled() {
-                        es.close();
-                        return;
-                    }
+                loop {
+                    let event = tokio::select! {
+                        biased;
+                        () = cancel_clone.cancelled() => {
+                            es.close();
+                            return;
+                        }
+                        event = es.next() => event,
+                    };
+                    let Some(event) = event else {
+                        break;
+                    };
 
                     match event {
                         Ok(EsEvent::Open) => {
                             // Reset backoff on successful connection
                             backoff = backoff_builder.build();
                             tracing::debug!("SSE connection opened");
+                            if !*initial_connection_tx.borrow() {
+                                initial_connection_tx.send_replace(true);
+                            }
                         }
                         Ok(EsEvent::Message(msg)) => {
                             // Track last event ID
@@ -269,6 +309,7 @@ impl SseSubscriber {
 
         Ok(SseSubscription {
             rx,
+            initial_connection,
             cancel,
             _task: task,
         })

--- a/crates/services/opencode-rs/tests/sse_readiness.rs
+++ b/crates/services/opencode-rs/tests/sse_readiness.rs
@@ -1,0 +1,283 @@
+#![expect(clippy::expect_used, clippy::unwrap_used)]
+
+use opencode_rs::ClientBuilder;
+use opencode_rs::OpencodeError;
+use opencode_rs::sse::SseOptions;
+use opencode_rs::types::event::Event;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+const FIXTURE_TIMEOUT: Duration = Duration::from_secs(2);
+const PENDING_CHECK: Duration = Duration::from_millis(25);
+const SSE_HEADERS: &str =
+    "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n";
+
+async fn read_request(stream: &mut TcpStream) {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        let read = timeout(FIXTURE_TIMEOUT, stream.read(&mut chunk))
+            .await
+            .expect("request read timed out")
+            .expect("request read failed");
+        assert!(read > 0, "connection closed before request headers");
+        request.extend_from_slice(&chunk[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            return;
+        }
+    }
+}
+
+async fn test_listener() -> (TcpListener, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    (listener, base_url)
+}
+
+fn options() -> SseOptions {
+    SseOptions {
+        capacity: 8,
+        initial_interval: Duration::from_millis(5),
+        max_interval: Duration::from_millis(10),
+    }
+}
+
+fn client(base_url: &str) -> opencode_rs::Client {
+    ClientBuilder::new().base_url(base_url).build().unwrap()
+}
+
+fn session_idle(session_id: &str) -> String {
+    format!(
+        "data: {{\"type\":\"session.idle\",\"properties\":{{\"sessionID\":\"{session_id}\"}}}}\n\n"
+    )
+}
+
+#[tokio::test]
+async fn readiness_waits_for_headers_is_repeatable_and_preserves_filtering() {
+    let (listener, base_url) = test_listener().await;
+    let (request_tx, request_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("accept timed out")
+            .expect("accept failed");
+        read_request(&mut stream).await;
+        request_tx.send(()).expect("request receiver dropped");
+        timeout(FIXTURE_TIMEOUT, release_rx)
+            .await
+            .expect("header release timed out")
+            .expect("header release sender dropped");
+        stream.write_all(SSE_HEADERS.as_bytes()).await.unwrap();
+        stream
+            .write_all(session_idle("other-session").as_bytes())
+            .await
+            .unwrap();
+        stream
+            .write_all(session_idle("target-session").as_bytes())
+            .await
+            .unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let mut subscription = client(&base_url)
+        .sse_subscriber()
+        .subscribe_session("target-session", options())
+        .unwrap();
+    timeout(FIXTURE_TIMEOUT, request_rx)
+        .await
+        .expect("SSE request did not arrive")
+        .expect("request signal sender dropped");
+
+    assert!(
+        timeout(PENDING_CHECK, subscription.wait_for_initial_connection())
+            .await
+            .is_err(),
+        "readiness completed before response headers"
+    );
+
+    release_tx.send(()).expect("fixture server dropped");
+    timeout(FIXTURE_TIMEOUT, subscription.wait_for_initial_connection())
+        .await
+        .expect("readiness timed out")
+        .expect("readiness failed");
+    timeout(PENDING_CHECK, subscription.wait_for_initial_connection())
+        .await
+        .expect("repeat readiness should return immediately")
+        .expect("repeat readiness failed");
+
+    let event = timeout(FIXTURE_TIMEOUT, subscription.recv())
+        .await
+        .expect("filtered event timed out")
+        .expect("event stream closed");
+    assert!(matches!(
+        event,
+        Event::SessionIdle { properties } if properties.session_id == "target-session"
+    ));
+    timeout(FIXTURE_TIMEOUT, server)
+        .await
+        .expect("fixture server did not terminate")
+        .expect("fixture server panicked");
+}
+
+#[tokio::test]
+async fn readiness_ignores_failed_attempts_before_open() {
+    let (listener, base_url) = test_listener().await;
+    let (second_request_tx, second_request_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut first, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("first accept timed out")
+            .expect("first accept failed");
+        read_request(&mut first).await;
+        first.shutdown().await.unwrap();
+
+        let (mut second, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("second accept timed out")
+            .expect("second accept failed");
+        read_request(&mut second).await;
+        second_request_tx
+            .send(())
+            .expect("second request receiver dropped");
+        timeout(FIXTURE_TIMEOUT, release_rx)
+            .await
+            .expect("second header release timed out")
+            .expect("second header release sender dropped");
+        second.write_all(SSE_HEADERS.as_bytes()).await.unwrap();
+        second.shutdown().await.unwrap();
+    });
+
+    let mut subscription = client(&base_url)
+        .sse_subscriber()
+        .subscribe(options())
+        .unwrap();
+    timeout(FIXTURE_TIMEOUT, second_request_rx)
+        .await
+        .expect("second SSE request did not arrive")
+        .expect("second request signal sender dropped");
+    assert!(
+        timeout(PENDING_CHECK, subscription.wait_for_initial_connection())
+            .await
+            .is_err(),
+        "failed connection attempt marked readiness"
+    );
+
+    release_tx.send(()).expect("fixture server dropped");
+    timeout(FIXTURE_TIMEOUT, subscription.wait_for_initial_connection())
+        .await
+        .expect("readiness timed out after successful retry")
+        .expect("readiness failed after successful retry");
+    subscription.close();
+    timeout(FIXTURE_TIMEOUT, server)
+        .await
+        .expect("fixture server did not terminate")
+        .expect("fixture server panicked");
+}
+
+#[tokio::test]
+async fn readiness_stays_true_during_reconnect() {
+    let (listener, base_url) = test_listener().await;
+    let (second_request_tx, second_request_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut first, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("first accept timed out")
+            .expect("first accept failed");
+        read_request(&mut first).await;
+        first.write_all(SSE_HEADERS.as_bytes()).await.unwrap();
+        first.shutdown().await.unwrap();
+
+        let (mut second, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("reconnect accept timed out")
+            .expect("reconnect accept failed");
+        read_request(&mut second).await;
+        second_request_tx
+            .send(())
+            .expect("reconnect request receiver dropped");
+        timeout(FIXTURE_TIMEOUT, release_rx)
+            .await
+            .expect("reconnect release timed out")
+            .expect("reconnect release sender dropped");
+        second.write_all(SSE_HEADERS.as_bytes()).await.unwrap();
+        second.shutdown().await.unwrap();
+    });
+
+    let mut subscription = client(&base_url)
+        .sse_subscriber()
+        .subscribe(options())
+        .unwrap();
+    timeout(FIXTURE_TIMEOUT, subscription.wait_for_initial_connection())
+        .await
+        .expect("initial readiness timed out")
+        .expect("initial readiness failed");
+    timeout(FIXTURE_TIMEOUT, second_request_rx)
+        .await
+        .expect("reconnect request did not arrive")
+        .expect("reconnect request signal sender dropped");
+
+    timeout(PENDING_CHECK, subscription.wait_for_initial_connection())
+        .await
+        .expect("sticky readiness blocked during reconnect")
+        .expect("sticky readiness failed during reconnect");
+    release_tx.send(()).expect("fixture server dropped");
+    subscription.close();
+    timeout(FIXTURE_TIMEOUT, server)
+        .await
+        .expect("fixture server did not terminate")
+        .expect("fixture server panicked");
+}
+
+#[tokio::test]
+async fn close_interrupts_pending_initial_eventsource_read() {
+    let (listener, base_url) = test_listener().await;
+    let (request_tx, request_rx) = oneshot::channel();
+    let (closed_tx, closed_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = timeout(FIXTURE_TIMEOUT, listener.accept())
+            .await
+            .expect("accept timed out")
+            .expect("accept failed");
+        read_request(&mut stream).await;
+        request_tx.send(()).expect("request receiver dropped");
+        let mut byte = [0_u8; 1];
+        let read = timeout(FIXTURE_TIMEOUT, stream.read(&mut byte))
+            .await
+            .expect("socket did not close after cancellation")
+            .expect("socket close read failed");
+        assert_eq!(read, 0, "expected peer EOF after cancellation");
+        closed_tx.send(()).expect("closed receiver dropped");
+    });
+
+    let mut subscription = client(&base_url)
+        .sse_subscriber()
+        .subscribe(options())
+        .unwrap();
+    timeout(FIXTURE_TIMEOUT, request_rx)
+        .await
+        .expect("SSE request did not arrive")
+        .expect("request signal sender dropped");
+    subscription.close();
+
+    let error = timeout(FIXTURE_TIMEOUT, subscription.wait_for_initial_connection())
+        .await
+        .expect("readiness did not terminate after close")
+        .expect_err("readiness unexpectedly succeeded after close");
+    assert!(matches!(error, OpencodeError::StreamClosed));
+    timeout(FIXTURE_TIMEOUT, closed_rx)
+        .await
+        .expect("fixture did not observe socket closure")
+        .expect("socket closure sender dropped");
+    timeout(FIXTURE_TIMEOUT, server)
+        .await
+        .expect("fixture server did not terminate")
+        .expect("fixture server panicked");
+}


### PR DESCRIPTION
## My Notes (preserved)

N/A.

<!--
Add any scratch notes, todos, and observations here.
This section is preserved when /describe_pr runs.
-->

<!-- /describe_pr overwrites everything inside the autogen block below -->
<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

[ENG-1263](https://linear.app/generalwisdom/issue/ENG-1263) tracks a race between OpenCode actions and the initial server-sent events connection. Prompts, commands, permission responses, and question responses could be sent before the event stream was ready, allowing early lifecycle events to be missed and leaving orchestration unable to reliably observe progress or completion.

## What user-facing changes did I ship?

- OpenCode actions now wait for the initial SSE connection before dispatching.
- Readiness failures are surfaced instead of sending an action without a live event stream.
- Readiness timeout and retry settings are configurable through `agentic-config` and represented in the generated schema.
- The existing request-scoped lifecycle remains unchanged: each request still owns its server snapshot and monitor rather than introducing a shared or long-lived monitor.

## How I implemented it

- Added `SseSubscription::wait_for_initial_connection` to the OpenCode SDK so callers can explicitly await the first successful stream connection.
- Gated orchestrator prompt, command, permission-response, and question-response dispatch on that readiness signal.
- Preserved request-scoped server snapshot and monitoring behavior after readiness is established.
- Added focused SDK and orchestrator ordering tests covering successful readiness, retries, timeouts, cancellation, and each gated action path.

Outer-DAG adoption is intentionally a follow-up recorded in `TODO.md`; this PR does not change `apps/agentic-outer-dag`, redesign session supervision, or introduce a process-wide SSE lifecycle.

## How to verify it

- [ ] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed
- [x] `just crate-test agentic-config` - 81 tests passed.
- [x] `just crate-test opencode_rs` - 335 tests passed.
- [x] `just crate-test opencode-orchestrator-mcp` - 206 tests passed.
- [x] Focused SSE readiness suites - 10 tests passed.
- [x] `just schema-generate` passed.
- [x] `just xtask-verify-check` passed.
- [x] `git diff --check` passed.

The full workspace `check` and `test` recipes were not part of the approved verification set; targeted crate tests and repository verification above were run instead.

## Description for the changelog

Gate OpenCode actions on initial SSE readiness so orchestration cannot miss lifecycle events dispatched before the event stream connects.
<!-- END:describe_pr:autogen -->
