### PR TITLE
fix: prevent OpenCode resume before SSE readiness

### DIFF
--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -1763,8 +1763,12 @@ mod tests {
 
         async fn wait_stream_connected(&self) {
             timeout(Duration::from_secs(5), async {
-                while self.stream_connections.load(AtomicOrdering::SeqCst) == 0 {
-                    self.stream_connected.notified().await;
+                loop {
+                    let notified = self.stream_connected.notified();
+                    if self.stream_connections.load(AtomicOrdering::SeqCst) > 0 {
+                        return;
+                    }
+                    notified.await;
                 }
             })
             .await
@@ -1778,8 +1782,12 @@ mod tests {
 
         async fn wait_command_post(&self) {
             timeout(Duration::from_secs(5), async {
-                while self.command_posts.load(AtomicOrdering::SeqCst) == 0 {
-                    self.command_posted.notified().await;
+                loop {
+                    let notified = self.command_posted.notified();
+                    if self.command_posts.load(AtomicOrdering::SeqCst) > 0 {
+                        return;
+                    }
+                    notified.await;
                 }
             })
             .await

--- a/apps/agentic-outer-dag/src/opencode/supervisor.rs
+++ b/apps/agentic-outer-dag/src/opencode/supervisor.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 
 const IDLE_GRACE: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SSE_READINESS_TIMEOUT: Duration = Duration::from_secs(5);
 const TRANSCRIPT_SETTLING_RETRY_BACKOFFS: [Duration; 4] = [
     Duration::from_millis(50),
     Duration::from_millis(100),
@@ -452,6 +453,15 @@ impl OpenCodeSupervisor {
             transcript_window,
             mut subscription,
         } = prepared;
+
+        tokio::time::timeout(SSE_READINESS_TIMEOUT, subscription.wait_ready())
+            .await
+            .context(
+                "timed out waiting for SSE readiness before initial OpenCode command dispatch",
+            )?
+            .context(
+                "SSE subscription closed before initial OpenCode command dispatch readiness",
+            )?;
 
         let cmd_client = self.client.clone();
         let dispatch_session_id = session_id.clone();
@@ -1638,10 +1648,16 @@ mod tests {
     use crate::test_support::process_state_lock;
     use std::process::Stdio;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering as AtomicOrdering;
     use tempfile::TempDir;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
     use tokio::process::Command;
+    use tokio::sync::Notify;
     use tokio::time::timeout;
     use wiremock::Mock;
     use wiremock::MockServer;
@@ -1679,6 +1695,235 @@ mod tests {
                 .cloned()
                 .unwrap_or_else(|| self.responders.last().cloned().expect("non-empty"))
         }
+    }
+
+    struct RawDispatchBarrierServer {
+        base_url: String,
+        stream_connections: Arc<AtomicUsize>,
+        command_posts: Arc<AtomicUsize>,
+        stream_connected: Arc<Notify>,
+        command_posted: Arc<Notify>,
+        sentinel_released: Arc<AtomicBool>,
+        release_sentinel: Arc<Notify>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl RawDispatchBarrierServer {
+        async fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let stream_connections = Arc::new(AtomicUsize::new(0));
+            let command_posts = Arc::new(AtomicUsize::new(0));
+            let stream_connected = Arc::new(Notify::new());
+            let command_posted = Arc::new(Notify::new());
+            let sentinel_released = Arc::new(AtomicBool::new(false));
+            let release_sentinel = Arc::new(Notify::new());
+            let task_stream_connections = Arc::clone(&stream_connections);
+            let task_command_posts = Arc::clone(&command_posts);
+            let task_stream_connected = Arc::clone(&stream_connected);
+            let task_command_posted = Arc::clone(&command_posted);
+            let task_sentinel_released = Arc::clone(&sentinel_released);
+            let task_release_sentinel = Arc::clone(&release_sentinel);
+
+            let task = tokio::spawn(async move {
+                loop {
+                    let (stream, _) = listener.accept().await.unwrap();
+                    let stream_connections = Arc::clone(&task_stream_connections);
+                    let command_posts = Arc::clone(&task_command_posts);
+                    let stream_connected = Arc::clone(&task_stream_connected);
+                    let command_posted = Arc::clone(&task_command_posted);
+                    let sentinel_released = Arc::clone(&task_sentinel_released);
+                    let release_sentinel = Arc::clone(&task_release_sentinel);
+                    tokio::spawn(async move {
+                        handle_raw_dispatch_request(
+                            stream,
+                            stream_connections,
+                            command_posts,
+                            stream_connected,
+                            command_posted,
+                            sentinel_released,
+                            release_sentinel,
+                        )
+                        .await;
+                    });
+                }
+            });
+
+            Self {
+                base_url: format!("http://{address}"),
+                stream_connections,
+                command_posts,
+                stream_connected,
+                command_posted,
+                sentinel_released,
+                release_sentinel,
+                task,
+            }
+        }
+
+        async fn wait_stream_connected(&self) {
+            timeout(Duration::from_secs(5), async {
+                while self.stream_connections.load(AtomicOrdering::SeqCst) == 0 {
+                    self.stream_connected.notified().await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+
+        fn release_readiness(&self) {
+            self.sentinel_released.store(true, AtomicOrdering::SeqCst);
+            self.release_sentinel.notify_waiters();
+        }
+
+        async fn wait_command_post(&self) {
+            timeout(Duration::from_secs(5), async {
+                while self.command_posts.load(AtomicOrdering::SeqCst) == 0 {
+                    self.command_posted.notified().await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+    }
+
+    impl Drop for RawDispatchBarrierServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn handle_raw_dispatch_request(
+        mut stream: TcpStream,
+        stream_connections: Arc<AtomicUsize>,
+        command_posts: Arc<AtomicUsize>,
+        stream_connected: Arc<Notify>,
+        command_posted: Arc<Notify>,
+        sentinel_released: Arc<AtomicBool>,
+        release_sentinel: Arc<Notify>,
+    ) {
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 2048];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut chunk).await.unwrap();
+            if read == 0 {
+                return;
+            }
+            request.extend_from_slice(&chunk[..read]);
+        }
+        let request = String::from_utf8(request).unwrap();
+        let mut request_line = request.lines().next().unwrap().split_whitespace();
+        let method = request_line.next().unwrap();
+        let path = request_line.next().unwrap().split('?').next().unwrap();
+
+        if method == "GET" && path == "/event" {
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+            stream_connections.fetch_add(1, AtomicOrdering::SeqCst);
+            stream_connected.notify_waiters();
+            while !sentinel_released.load(AtomicOrdering::SeqCst) {
+                release_sentinel.notified().await;
+            }
+            stream
+                .write_all(b"data: {\"type\":\"server.connected\",\"properties\":{}}\n\n")
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+            return;
+        }
+
+        let (status, body) = if method == "GET" && path == "/session/session-1" {
+            (
+                200,
+                serde_json::json!({
+                    "id": "session-1",
+                    "slug": "session-1",
+                    "projectId": "project-1",
+                    "directory": "/tmp",
+                    "title": "Barrier test",
+                    "version": "test",
+                    "time": {"created": 1, "updated": 1}
+                })
+                .to_string(),
+            )
+        } else if method == "GET"
+            && (path == "/permission"
+                || path == "/question"
+                || path == "/session/session-1/message")
+        {
+            (200, "[]".to_string())
+        } else if method == "GET" && path == "/session/status" {
+            (200, "{}".to_string())
+        } else if method == "POST" && path == "/session/session-1/command" {
+            command_posts.fetch_add(1, AtomicOrdering::SeqCst);
+            command_posted.notify_waiters();
+            (200, "{}".to_string())
+        } else {
+            (404, "{}".to_string())
+        };
+        let reason = if status == 200 { "OK" } else { "Not Found" };
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn initial_command_dispatch_waits_for_parsed_sse_readiness() {
+        let server = RawDispatchBarrierServer::start().await;
+        let child = Command::new("sleep")
+            .arg("60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let managed = ManagedServer::from_child_for_testing(child, server.base_url.clone(), 1234);
+        let client = Client::builder()
+            .base_url(&server.base_url)
+            .directory("/tmp")
+            .build()
+            .unwrap();
+        let supervisor = OpenCodeSupervisor {
+            _managed_server: managed,
+            client,
+            _directory: PathBuf::from("/tmp"),
+            timeouts: test_timeouts(),
+        };
+        let PreparedCommandOutcome::Prepared(prepared) = supervisor
+            .prepare_command(
+                SessionSelection::Reuse("session-1".to_string()),
+                "implement_plan",
+                Some("do it"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected prepared command");
+        };
+
+        let run = tokio::spawn(async move {
+            supervisor
+                .run_prepared_command(prepared, None, None, |_| Ok(()))
+                .await
+        });
+        server.wait_stream_connected().await;
+        assert_eq!(server.command_posts.load(AtomicOrdering::SeqCst), 0);
+        server.release_readiness();
+        server.wait_command_post().await;
+        assert_eq!(server.command_posts.load(AtomicOrdering::SeqCst), 1);
+        run.abort();
+        let _ = run.await;
     }
 
     fn test_timeouts() -> OpenCodeSupervisorTimeouts {
@@ -2377,11 +2622,10 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path("/event"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_delay(Duration::from_secs(30)),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                "data: {\"type\":\"server.connected\",\"properties\":{}}\n\n",
+                "text/event-stream",
+            ))
             .mount(&mock)
             .await;
         Mock::given(method("GET"))
@@ -2470,10 +2714,9 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/event"))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_body_string(
-                        "data: {\"type\":\"message.part.updated\",\"properties\":{\"sessionID\":\"session-1\"}}\n\n",
+                ResponseTemplate::new(200).set_body_raw(
+                        "data: {\"type\":\"server.connected\",\"properties\":{}}\n\ndata: {\"type\":\"message.part.updated\",\"properties\":{\"sessionID\":\"session-1\"}}\n\n",
+                        "text/event-stream",
                     ),
             )
             .mount(&mock)
@@ -2716,9 +2959,13 @@ mod tests {
                 .and(path("/event"))
                 .respond_with(
                     ResponseTemplate::new(200)
-                        .insert_header("content-type", "text/event-stream")
                         .set_delay(Duration::from_millis(300))
-                        .set_body_string(format!("data: {interruption_event}\n\n")),
+                        .set_body_raw(
+                            format!(
+                                "data: {{\"type\":\"server.connected\",\"properties\":{{}}}}\n\ndata: {interruption_event}\n\n"
+                            ),
+                            "text/event-stream",
+                        ),
                 )
                 .mount(&mock)
                 .await;
@@ -3095,11 +3342,10 @@ mod tests {
     async fn mount_stalled_event_stream(mock: &MockServer) {
         Mock::given(method("GET"))
             .and(path("/event"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_delay(Duration::from_secs(30)),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                "data: {\"type\":\"server.connected\",\"properties\":{}}\n\n",
+                "text/event-stream",
+            ))
             .mount(mock)
             .await;
     }

--- a/apps/opencode-orchestrator-mcp/Cargo.toml
+++ b/apps/opencode-orchestrator-mcp/Cargo.toml
@@ -65,7 +65,7 @@ pretty_assertions = "1.4"
 serial_test = "3.2"
 tempfile = "3"
 wiremock = "0.6"
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["io-util", "net", "test-util"] }
 
 # Enable test-support feature for integration tests
 [dev-dependencies.opencode-orchestrator-mcp]

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -205,12 +205,6 @@ async fn revalidate_question_target(
     )))
 }
 
-#[derive(Clone, Copy, Debug)]
-enum PermissionPreflightMode {
-    Strict,
-    RespondPermissionContinuation,
-}
-
 #[derive(Debug, Clone)]
 struct CommandTranscriptWindow {
     command_message_id: String,
@@ -661,7 +655,6 @@ impl OrchestratorRunTool {
     async fn preflight_pending_permission(
         client: &opencode_rs::Client,
         session_id: &str,
-        mode: PermissionPreflightMode,
         warnings: &mut Vec<String>,
     ) -> Result<Option<opencode_rs::types::permission::PermissionRequest>, ToolError> {
         match client.permissions().list().await {
@@ -669,29 +662,15 @@ impl OrchestratorRunTool {
                 .into_iter()
                 .find(|permission| permission.session_id == session_id)),
             Err(error) if error.is_validation_error() => {
-                match mode {
-                    PermissionPreflightMode::RespondPermissionContinuation => {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %error,
-                            "failed to list permissions during respond_permission continuation; falling back to polling"
-                        );
-                        warnings.push(format!(
-                            "Permission refresh failed after reply ({error}); permission state could not be listed and may be stale or malformed. Continuing with polling fallback."
-                        ));
-                    }
-                    PermissionPreflightMode::Strict => {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %error,
-                            "failed to list permissions during run preflight; continuing without permission preflight"
-                        );
-                        warnings.push(
-                            "Permission state could not be listed during preflight (HTTP 400). Permission state may be stale or malformed; pending permissions may be stale or undiscoverable."
-                                .to_string(),
-                        );
-                    }
-                }
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %error,
+                    "failed to list permissions during run preflight; continuing without permission preflight"
+                );
+                warnings.push(
+                    "Permission state could not be listed during preflight (HTTP 400). Permission state may be stale or malformed; pending permissions may be stale or undiscoverable."
+                        .to_string(),
+                );
                 Ok(None)
             }
             Err(error) => Err(ToolError::Internal(format!(
@@ -704,7 +683,6 @@ impl OrchestratorRunTool {
         &self,
         input: OrchestratorRunInput,
         ctx: &ToolContext,
-        permission_preflight_mode: PermissionPreflightMode,
         prepared: Option<PreparedMonitoring>,
     ) -> Result<RunOutcome, ToolError> {
         // Input validation
@@ -877,13 +855,7 @@ impl OrchestratorRunTool {
                 }
             }
         } else {
-            Self::preflight_pending_permission(
-                client,
-                &session_id,
-                permission_preflight_mode,
-                &mut warnings,
-            )
-            .await?
+            Self::preflight_pending_permission(client, &session_id, &mut warnings).await?
         };
 
         if let Some(perm) = pending_permission {
@@ -960,9 +932,10 @@ impl OrchestratorRunTool {
         let is_idle = reconciled_status
             .as_ref()
             .is_some_and(|status| matches!(status, SessionStatusInfo::Idle));
-        let initial_observed_busy = reconciled_status
-            .as_ref()
-            .is_some_and(SessionStatusInfo::is_busy_like);
+        let initial_observed_busy = is_prepared_continuation
+            && reconciled_status
+                .as_ref()
+                .is_some_and(SessionStatusInfo::is_busy_like);
 
         // 4. If no message/command and session is idle, just return current state
         // Uses finalize_completed to get retry logic for message extraction
@@ -1613,10 +1586,7 @@ Examples:
         let ctx = ctx.clone();
         Box::pin(async move {
             let timer = CallTimer::start();
-            match this
-                .run_impl_outcome(input.clone(), &ctx, PermissionPreflightMode::Strict, None)
-                .await
-            {
+            match this.run_impl_outcome(input.clone(), &ctx, None).await {
                 Ok(outcome) => {
                     log_tool_success(
                         &timer,
@@ -2336,7 +2306,6 @@ Parameters:
                             wait_for_activity,
                         },
                         &ctx,
-                        PermissionPreflightMode::RespondPermissionContinuation,
                         Some(prepared),
                     )
                     .await?;
@@ -2553,7 +2522,7 @@ Parameters:
                     agent: None,
                     message: None,
                     wait_for_activity,
-                }, &ctx, PermissionPreflightMode::Strict, Some(prepared))
+                }, &ctx, Some(prepared))
                 .await?;
             Ok((outcome.output, outcome.log_meta))
         }

--- a/apps/opencode-orchestrator-mcp/src/tools.rs
+++ b/apps/opencode-orchestrator-mcp/src/tools.rs
@@ -69,6 +69,7 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 
 const SERVER_NAME: &str = "opencode-orchestrator-mcp";
+const SSE_READINESS_TIMEOUT: Duration = Duration::from_secs(5);
 const PRECORRELATION_TOTAL_BYTES: usize = 64 * 1024;
 const PRECORRELATION_MESSAGE_BYTES: usize = 16 * 1024;
 const PRECORRELATION_MESSAGE_IDS: usize = 32;
@@ -82,6 +83,126 @@ struct ToolLogMeta {
 struct RunOutcome {
     output: OrchestratorRunOutput,
     log_meta: ToolLogMeta,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PreparedContinuationMode {
+    PermissionReply,
+    PermissionReject,
+    QuestionReply,
+    QuestionReject,
+}
+
+struct PreparedMonitoring {
+    server: Arc<OrchestratorServer>,
+    session_id: String,
+    subscription: opencode_rs::sse::SseSubscription<Event>,
+    continuation_mode: PreparedContinuationMode,
+    warnings: Vec<String>,
+    response_baseline: Option<String>,
+    command_transcript_window: Option<CommandTranscriptWindow>,
+}
+
+async fn wait_for_sse_readiness(
+    subscription: &mut opencode_rs::sse::SseSubscription<Event>,
+    ctx: &ToolContext,
+    operation: &str,
+) -> Result<(), ToolError> {
+    tokio::select! {
+        () = ctx.cancelled() => Err(ToolError::cancelled(None)),
+        result = tokio::time::timeout(SSE_READINESS_TIMEOUT, subscription.wait_ready()) => {
+            match result {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(error)) => Err(ToolError::Internal(format!(
+                    "SSE monitoring closed before readiness for {operation}: {error}"
+                ))),
+                Err(_) => Err(ToolError::Internal(format!(
+                    "SSE monitoring was not ready within 5 seconds for {operation}"
+                ))),
+            }
+        }
+    }
+}
+
+async fn revalidate_permission_target(
+    client: &opencode_rs::Client,
+    session_id: &str,
+    request_id: &str,
+) -> Result<(), ToolError> {
+    let pending = client.permissions().list().await.map_err(|error| {
+        if error.is_validation_error() {
+            ToolError::InvalidInput(format!(
+                "Permission request '{request_id}' could not be authoritatively revalidated because permission state returned HTTP 400. Do not retry the reply blindly; rerun orchestrator_run(session_id='{session_id}') to obtain current blocker state."
+            ))
+        } else {
+            ToolError::Internal(format!(
+                "Failed to revalidate permission request '{request_id}': {error}"
+            ))
+        }
+    })?;
+
+    if let Some(permission) = pending
+        .iter()
+        .find(|permission| permission.id == request_id)
+    {
+        if permission.session_id == session_id {
+            return Ok(());
+        }
+        return Err(ToolError::InvalidInput(format!(
+            "Permission request '{request_id}' now belongs to session '{}', not '{session_id}'. Rerun orchestrator_run for the latest blocker and retry.",
+            permission.session_id
+        )));
+    }
+
+    let replacements = pending
+        .iter()
+        .filter(|permission| permission.session_id == session_id)
+        .map(|permission| permission.id.as_str())
+        .collect::<Vec<_>>();
+    let replacement_detail = if replacements.is_empty() {
+        "no replacement permission is currently pending".to_string()
+    } else {
+        format!("replacement permission id(s): {}", replacements.join(", "))
+    };
+    Err(ToolError::InvalidInput(format!(
+        "Permission request '{request_id}' is no longer pending for session '{session_id}' ({replacement_detail}). No reply was sent. Rerun orchestrator_run and retry with the returned permission_request_id."
+    )))
+}
+
+async fn revalidate_question_target(
+    client: &opencode_rs::Client,
+    session_id: &str,
+    request_id: &str,
+) -> Result<(), ToolError> {
+    let pending = client.question().list().await.map_err(|error| {
+        ToolError::Internal(format!(
+            "Failed to revalidate question request '{request_id}': {error}"
+        ))
+    })?;
+
+    if let Some(question) = pending.iter().find(|question| question.id == request_id) {
+        if question.session_id == session_id {
+            return Ok(());
+        }
+        return Err(ToolError::InvalidInput(format!(
+            "Question request '{request_id}' now belongs to session '{}', not '{session_id}'. Rerun orchestrator_run for the latest blocker and retry.",
+            question.session_id
+        )));
+    }
+
+    let replacements = pending
+        .iter()
+        .filter(|question| question.session_id == session_id)
+        .map(|question| question.id.as_str())
+        .collect::<Vec<_>>();
+    let replacement_detail = if replacements.is_empty() {
+        "no replacement question is currently pending".to_string()
+    } else {
+        format!("replacement question id(s): {}", replacements.join(", "))
+    };
+    Err(ToolError::InvalidInput(format!(
+        "Question request '{request_id}' is no longer pending for session '{session_id}' ({replacement_detail}). No response was sent. Rerun orchestrator_run and retry with the returned question_request_id."
+    )))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -584,6 +705,7 @@ impl OrchestratorRunTool {
         input: OrchestratorRunInput,
         ctx: &ToolContext,
         permission_preflight_mode: PermissionPreflightMode,
+        prepared: Option<PreparedMonitoring>,
     ) -> Result<RunOutcome, ToolError> {
         // Input validation
         if input.session_id.is_none() && input.message.is_none() && input.command.is_none() {
@@ -626,13 +748,37 @@ impl OrchestratorRunTool {
         }
 
         let wait_for_activity = input.wait_for_activity.unwrap_or(false);
+        let is_prepared_continuation = prepared.is_some();
+        let prepared_continuation_mode =
+            prepared.as_ref().map(|prepared| prepared.continuation_mode);
+        let prepared_command_transcript_window = prepared
+            .as_ref()
+            .and_then(|prepared| prepared.command_transcript_window.clone());
 
-        // Lazy initialization: spawn server on first tool call
-        let server = self
-            .server
-            .acquire()
-            .await
-            .map_err(|e| ToolError::Internal(e.to_string()))?;
+        if let Some(prepared) = prepared.as_ref() {
+            tracing::trace!(
+                continuation_mode = ?prepared.continuation_mode,
+                has_response_baseline = prepared.response_baseline.is_some(),
+                "entering prepared response continuation"
+            );
+        }
+
+        if is_prepared_continuation && (input.command.is_some() || message.is_some()) {
+            return Err(ToolError::Internal(
+                "prepared monitoring cannot dispatch new work".into(),
+            ));
+        }
+
+        // Lazy initialization: spawn server on first tool call unless exact prepared resources
+        // were supplied by a response continuation.
+        let server = match prepared.as_ref() {
+            Some(prepared) => Arc::clone(&prepared.server),
+            None => self
+                .server
+                .acquire()
+                .await
+                .map_err(|e| ToolError::Internal(e.to_string()))?,
+        };
 
         if let Some(command) = input.command.as_deref() {
             let decision = server.command_policy_decision(command);
@@ -659,7 +805,9 @@ impl OrchestratorRunTool {
         );
 
         // 1. Resolve session: validate existing or create new
-        let session_id = if let Some(sid) = input.session_id {
+        let session_id = if let Some(prepared) = prepared.as_ref() {
+            prepared.session_id.clone()
+        } else if let Some(sid) = input.session_id {
             // Validate session exists
             client.sessions().get(&sid).await.map_err(|e| {
                 if e.is_not_found() {
@@ -690,26 +838,55 @@ impl OrchestratorRunTool {
 
         tracing::info!(session_id = %session_id, "run: session resolved");
 
-        let mut warnings = Vec::new();
+        let mut warnings = prepared
+            .as_ref()
+            .map_or_else(Vec::new, |prepared| prepared.warnings.clone());
 
-        // 2. Check if session is already idle (for resume-only case)
-        let status = client
-            .sessions()
-            .status_for(&session_id)
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to get session status: {e}")))?;
-
-        let is_idle = matches!(status, SessionStatusInfo::Idle);
+        // Ordinary runs preserve their existing status-first preflight. Prepared response
+        // continuations defer status until after blocker reconciliation.
+        let initial_status = if is_prepared_continuation {
+            None
+        } else {
+            Some(
+                client
+                    .sessions()
+                    .status_for(&session_id)
+                    .await
+                    .map_err(|e| {
+                        ToolError::Internal(format!("Failed to get session status: {e}"))
+                    })?,
+            )
+        };
 
         // 3. Check for pending permissions before doing anything else
-        if let Some(perm) = Self::preflight_pending_permission(
-            client,
-            &session_id,
-            permission_preflight_mode,
-            &mut warnings,
-        )
-        .await?
-        {
+        let pending_permission = if is_prepared_continuation {
+            match client.permissions().list().await {
+                Ok(permissions) => permissions
+                    .into_iter()
+                    .find(|permission| permission.session_id == session_id),
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed immediate permission reconciliation after response"
+                    );
+                    warnings.push(format!(
+                        "Permission refresh failed after response ({error}); continuing with ready SSE monitoring."
+                    ));
+                    None
+                }
+            }
+        } else {
+            Self::preflight_pending_permission(
+                client,
+                &session_id,
+                permission_preflight_mode,
+                &mut warnings,
+            )
+            .await?
+        };
+
+        if let Some(perm) = pending_permission {
             tracing::info!(
                 session_id = %session_id,
                 permission_type = %perm.permission,
@@ -729,11 +906,28 @@ impl OrchestratorRunTool {
             }));
         }
 
-        let pending_questions = client
-            .question()
-            .list()
-            .await
-            .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?;
+        let pending_questions = if is_prepared_continuation {
+            match client.question().list().await {
+                Ok(questions) => questions,
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed immediate question reconciliation after response"
+                    );
+                    warnings.push(format!(
+                        "Question refresh failed after response ({error}); continuing with ready SSE monitoring."
+                    ));
+                    Vec::new()
+                }
+            }
+        } else {
+            client
+                .question()
+                .list()
+                .await
+                .map_err(|e| ToolError::Internal(format!("Failed to list questions: {e}")))?
+        };
 
         if let Some(question) = pending_questions
             .into_iter()
@@ -745,9 +939,39 @@ impl OrchestratorRunTool {
             )));
         }
 
+        let reconciled_status = if is_prepared_continuation {
+            match client.sessions().status_for(&session_id).await {
+                Ok(status) => Some(status),
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed immediate status reconciliation after response"
+                    );
+                    warnings.push(format!(
+                        "Session status refresh failed after response ({error}); continuing with ready SSE monitoring."
+                    ));
+                    None
+                }
+            }
+        } else {
+            initial_status
+        };
+        let is_idle = reconciled_status
+            .as_ref()
+            .is_some_and(|status| matches!(status, SessionStatusInfo::Idle));
+        let initial_observed_busy = reconciled_status
+            .as_ref()
+            .is_some_and(SessionStatusInfo::is_busy_like);
+
         // 4. If no message/command and session is idle, just return current state
         // Uses finalize_completed to get retry logic for message extraction
-        if message.is_none() && input.command.is_none() && is_idle && !wait_for_activity {
+        if !is_prepared_continuation
+            && message.is_none()
+            && input.command.is_none()
+            && is_idle
+            && !wait_for_activity
+        {
             let token_tracker = TokenTracker::with_threshold(server.compaction_threshold());
             let output =
                 Self::finalize_completed(client, session_id, &token_tracker, warnings).await?;
@@ -755,25 +979,38 @@ impl OrchestratorRunTool {
         }
 
         // 5. Subscribe to SSE BEFORE sending prompt/command
-        let mut subscription = client
-            .subscribe_session(&session_id)
-            .map_err(|e| ToolError::Internal(format!("Failed to subscribe to session: {e}")))?;
+        let mut subscription = match prepared {
+            Some(prepared) => prepared.subscription,
+            None => client
+                .subscribe_session(&session_id)
+                .map_err(|e| ToolError::Internal(format!("Failed to subscribe to session: {e}")))?,
+        };
+
+        if input.command.is_some() || message.is_some() {
+            wait_for_sse_readiness(&mut subscription, ctx, "OpenCode dispatch").await?;
+        }
 
         // Track whether this call is dispatching new work (command or message)
         // vs just resuming/monitoring an existing session.
-        let dispatched_new_work = input.command.is_some() || message.is_some() || wait_for_activity;
+        let dispatched_new_work = input.command.is_some()
+            || message.is_some()
+            || wait_for_activity
+            || prepared_continuation_mode.is_some();
         let idle_grace = config::idle_grace();
         let mut idle_grace_deadline: Option<tokio::time::Instant> = None;
         let mut awaiting_idle_grace_check = false;
 
-        if wait_for_activity && input.command.is_none() && message.is_none() {
+        if (wait_for_activity || is_prepared_continuation)
+            && input.command.is_none()
+            && message.is_none()
+        {
             idle_grace_deadline = Some(tokio::time::Instant::now() + idle_grace);
         }
 
         // 6. Kick off the work
         let mut command_task: Option<JoinHandle<Result<(), OpencodeError>>> = None;
         let mut command_name_for_logging: Option<String> = None;
-        let mut command_transcript_window: Option<CommandTranscriptWindow> = None;
+        let mut command_transcript_window = prepared_command_transcript_window;
 
         if let Some(command) = &input.command {
             command_name_for_logging = Some(command.clone());
@@ -846,7 +1083,7 @@ impl OrchestratorRunTool {
         // Track whether we've observed the session as busy at least once.
         // This prevents completing immediately if we call run_impl on an already-idle
         // session before our new work has started processing.
-        let mut observed_busy = false;
+        let mut observed_busy = initial_observed_busy;
         let mut correlated_assistant_ids = HashSet::new();
         let mut precorrelation_deltas = command_transcript_window
             .as_ref()
@@ -1377,7 +1614,7 @@ Examples:
         Box::pin(async move {
             let timer = CallTimer::start();
             match this
-                .run_impl_outcome(input.clone(), &ctx, PermissionPreflightMode::Strict)
+                .run_impl_outcome(input.clone(), &ctx, PermissionPreflightMode::Strict, None)
                 .await
             {
                 Ok(outcome) => {
@@ -2023,6 +2260,22 @@ Parameters:
                     None
                 };
 
+                let mut subscription = client
+                    .subscribe_session(&input.session_id)
+                    .map_err(|error| {
+                        ToolError::Internal(format!(
+                            "Failed to subscribe before permission response: {error}"
+                        ))
+                    })?;
+                wait_for_sse_readiness(
+                    &mut subscription,
+                    &ctx,
+                    "permission response",
+                )
+                .await?;
+                revalidate_permission_target(client, &input.session_id, &permission_request_id)
+                    .await?;
+
                 // Convert our reply type to API type
                 let api_reply = match input.reply {
                     PermissionReply::Once => ApiPermissionReply::Once,
@@ -2060,6 +2313,19 @@ Parameters:
                 // Now continue monitoring the session using run logic
                 let run_tool = OrchestratorRunTool::new(Arc::clone(&server_handle));
                 let wait_for_activity = (!is_reject).then_some(true);
+                let prepared = PreparedMonitoring {
+                    server: Arc::clone(&server),
+                    session_id: input.session_id.clone(),
+                    subscription,
+                    continuation_mode: if is_reject {
+                        PreparedContinuationMode::PermissionReject
+                    } else {
+                        PreparedContinuationMode::PermissionReply
+                    },
+                    warnings: pre_warnings,
+                    response_baseline: baseline.clone(),
+                    command_transcript_window: None,
+                };
                 let outcome = run_tool
                     .run_impl_outcome(
                         OrchestratorRunInput {
@@ -2071,12 +2337,10 @@ Parameters:
                         },
                         &ctx,
                         PermissionPreflightMode::RespondPermissionContinuation,
+                        Some(prepared),
                     )
                     .await?;
                 let mut out = outcome.output;
-
-                // Merge pre-warnings
-                out.warnings.extend(pre_warnings);
 
                 // Apply rejection-aware output mutation
                 if is_reject && matches!(out.status, RunStatus::Completed) {
@@ -2219,14 +2483,24 @@ Parameters:
                 }
             };
 
-            match input.action {
-                QuestionAction::Reply => {
-                    if input.answers.is_empty() {
-                        return Err(ToolError::InvalidInput(
-                            "answers is required when action=reply".into(),
-                        ));
-                    }
+            if matches!(input.action, QuestionAction::Reply) && input.answers.is_empty() {
+                return Err(ToolError::InvalidInput(
+                    "answers is required when action=reply".into(),
+                ));
+            }
 
+            let mut subscription = client
+                .subscribe_session(&input.session_id)
+                .map_err(|error| {
+                    ToolError::Internal(format!(
+                        "Failed to subscribe before question response: {error}"
+                    ))
+                })?;
+            wait_for_sse_readiness(&mut subscription, &ctx, "question response").await?;
+            revalidate_question_target(client, &input.session_id, &question.id).await?;
+
+            let (continuation_mode, wait_for_activity) = match input.action {
+                QuestionAction::Reply => {
                     client
                         .question()
                         .reply(
@@ -2237,37 +2511,51 @@ Parameters:
                         )
                         .await
                         .map_err(|e| {
-                            ToolError::Internal(format!("Failed to reply to question: {e}"))
+                            if e.is_not_found() {
+                                ToolError::InvalidInput(format!(
+                                    "Question request '{}' was not found or is no longer pending (HTTP 404). Rerun orchestrator_run(session_id='{}') to get the latest question_request_id and retry.",
+                                    question.id, input.session_id
+                                ))
+                            } else {
+                                ToolError::Internal(format!("Failed to reply to question: {e}"))
+                            }
                         })?;
-
-                    let outcome = OrchestratorRunTool::new(Arc::clone(&server_handle))
-                        .run_impl_outcome(OrchestratorRunInput {
-                            session_id: Some(input.session_id),
-                            command: None,
-                            agent: None,
-                            message: None,
-                            wait_for_activity: Some(true),
-                        }, &ctx, PermissionPreflightMode::Strict)
-                        .await?;
-                    Ok((outcome.output, outcome.log_meta))
+                    (PreparedContinuationMode::QuestionReply, Some(true))
                 }
                 QuestionAction::Reject => {
                     client.question().reject(&question.id).await.map_err(|e| {
-                        ToolError::Internal(format!("Failed to reject question: {e}"))
+                        if e.is_not_found() {
+                            ToolError::InvalidInput(format!(
+                                "Question request '{}' was not found or is no longer pending (HTTP 404). Rerun orchestrator_run(session_id='{}') to get the latest question_request_id and retry.",
+                                question.id, input.session_id
+                            ))
+                        } else {
+                            ToolError::Internal(format!("Failed to reject question: {e}"))
+                        }
                     })?;
-
-                    let outcome = OrchestratorRunTool::new(Arc::clone(&server_handle))
-                        .run_impl_outcome(OrchestratorRunInput {
-                            session_id: Some(input.session_id),
-                            command: None,
-                            agent: None,
-                            message: None,
-                            wait_for_activity: None,
-                        }, &ctx, PermissionPreflightMode::Strict)
-                        .await?;
-                    Ok((outcome.output, outcome.log_meta))
+                    (PreparedContinuationMode::QuestionReject, None)
                 }
-            }
+            };
+
+            let prepared = PreparedMonitoring {
+                server: Arc::clone(&server),
+                session_id: input.session_id.clone(),
+                subscription,
+                continuation_mode,
+                warnings: Vec::new(),
+                response_baseline: None,
+                command_transcript_window: None,
+            };
+            let outcome = OrchestratorRunTool::new(Arc::clone(&server_handle))
+                .run_impl_outcome(OrchestratorRunInput {
+                    session_id: Some(input.session_id),
+                    command: None,
+                    agent: None,
+                    message: None,
+                    wait_for_activity,
+                }, &ctx, PermissionPreflightMode::Strict, Some(prepared))
+                .await?;
+            Ok((outcome.output, outcome.log_meta))
         }
         .await;
 

--- a/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/activity_timeout_wiremock.rs
@@ -108,9 +108,7 @@ async fn it_times_out_after_5_min_inactivity() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_hours(1)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -188,9 +186,7 @@ async fn it_does_not_timeout_while_busy() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_hours(1)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/cancellation_wiremock.rs
@@ -58,9 +58,7 @@ async fn run_returns_cancelled_when_request_context_is_cancelled() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -125,6 +123,12 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
             "write",
             &["src/**"]
         ),])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            permission_id,
+            session_id,
+            "write",
+            &["src/**"]
+        ),])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
@@ -155,9 +159,7 @@ async fn respond_permission_returns_cancelled_during_post_reply_monitoring() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/command_filtering_wiremock.rs
@@ -397,9 +397,7 @@ async fn run_prompt_forwards_agent_in_prompt_request() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -28,6 +28,7 @@ use wiremock::matchers::path_regex;
 use wiremock::matchers::query_param;
 
 use support::SequenceResponder;
+use support::SwitchAfterCallsResponder;
 use support::message_fixture;
 use support::message_history_fixture;
 use support::messages_fixture;
@@ -211,6 +212,96 @@ async fn fast_idle_prompt_completes_without_hanging() {
 
     assert!(matches!(result.status, RunStatus::Completed));
     assert_eq!(result.response.as_deref(), Some("FAST_IDLE_DONE"));
+}
+
+#[tokio::test]
+async fn ordinary_prompt_ignores_stale_response_from_initial_busy_status() {
+    let _guard = env_lock().await;
+    let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
+    // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
+    unsafe { std::env::set_var(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS, "1500") };
+
+    let mock = MockServer::start().await;
+    let server = test_orchestrator_server(&mock).await;
+    let tool = OrchestratorRunTool::new(Arc::clone(&server));
+    let sid = "ordinary-prompt-initial-busy";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_fixture(sid)))
+        .mount(&mock)
+        .await;
+
+    let status_sequence = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+        ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
+        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+    ]);
+    let status_calls = status_sequence.call_counter();
+    Mock::given(method("GET"))
+        .and(path("/session/status"))
+        .respond_with(status_sequence)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/permission"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/question"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/session/{sid}/prompt_async")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/session/{sid}/message")))
+        .respond_with(SwitchAfterCallsResponder::new(
+            status_calls.clone(),
+            3,
+            ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("OLD_RESPONSE"))),
+            ResponseTemplate::new(200).set_body_json(messages_fixture(sid, Some("NEW_RESPONSE"))),
+        ))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(5),
+        tool.call(
+            OrchestratorRunInput {
+                session_id: Some(sid.into()),
+                command: None,
+                agent: None,
+                message: Some("start new work".into()),
+                wait_for_activity: None,
+            },
+            &ToolContext::default(),
+        ),
+    )
+    .await
+    .expect("ordinary prompt stale-response regression should not hang")
+    .expect("ordinary prompt should complete");
+
+    assert!(matches!(result.status, RunStatus::Completed));
+    assert_eq!(result.response.as_deref(), Some("NEW_RESPONSE"));
+    assert!(status_calls.get() >= 4);
 }
 
 #[tokio::test]
@@ -849,7 +940,7 @@ async fn command_transport_error_after_start_evidence_warns_and_completes() {
 }
 
 #[tokio::test]
-async fn command_transport_error_before_start_evidence_fails_clearly() {
+async fn command_transport_error_after_initial_busy_without_start_evidence_fails_clearly() {
     let _guard = env_lock().await;
     let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
     // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
@@ -858,7 +949,7 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
     let mock = MockServer::start().await;
     let server = short_timeout_test_orchestrator_server(&mock).await;
     let tool = OrchestratorRunTool::new(Arc::clone(&server));
-    let sid = "command-transport-pre-start";
+    let sid = "command-transport-initial-busy-pre-start";
 
     Mock::given(method("GET"))
         .and(path(format!("/session/{sid}")))
@@ -869,7 +960,7 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
     Mock::given(method("GET"))
         .and(path("/session/status"))
         .respond_with(SequenceResponder::new(vec![
-            ResponseTemplate::new(200).set_body_json(status_v2_idle()),
+            ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
             ResponseTemplate::new(200).set_body_json(status_v2_idle()),
         ]))
         .mount(&mock)

--- a/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/fast_idle_race_wiremock.rs
@@ -96,9 +96,7 @@ async fn assert_command_dispatch_invalid_input(status: u16, body: serde_json::Va
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -189,9 +187,7 @@ async fn fast_idle_prompt_completes_without_hanging() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -231,6 +227,12 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
     let perm_id = "perm-fast-idle";
 
     let permission_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            &["/tmp/out.txt"],
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
             perm_id,
             sid,
@@ -280,9 +282,7 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -308,7 +308,7 @@ async fn fast_idle_resume_after_permission_reply_completes_without_hanging() {
 }
 
 #[tokio::test]
-async fn respond_permission_known_id_replies_even_when_permission_list_bad_requests() {
+async fn respond_permission_known_id_fails_closed_when_revalidation_bad_requests() {
     let _guard = env_lock().await;
     let _env = EnvVarGuard(OPENCODE_ORCHESTRATOR_IDLE_GRACE_MS);
     // SAFETY: ENV_LOCK serializes process-global environment access in these tests.
@@ -369,14 +369,12 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
 
-    let result = timeout(
+    let error = timeout(
         Duration::from_secs(2),
         tool.call(
             RespondPermissionInput {
@@ -390,28 +388,20 @@ async fn respond_permission_known_id_replies_even_when_permission_list_bad_reque
     )
     .await
     .expect("known-id continuation should not hang")
-    .expect("respond_permission should succeed with provided request id");
+    .expect_err("authoritative permission revalidation should fail closed");
 
-    assert!(matches!(result.status, RunStatus::Completed));
-    assert_eq!(result.response.as_deref(), Some("PRE_REPLY_DONE"));
-    assert!(
-        result
-            .warnings
-            .iter()
-            .any(|warning| warning.contains("Permission validation failed")),
-        "expected validation warning, got {:?}",
-        result.warnings
-    );
+    assert!(matches!(error, ToolError::InvalidInput(_)));
+    assert!(error.to_string().contains("authoritatively revalidated"));
 
     let requests = mock
         .received_requests()
         .await
         .expect("wiremock should capture requests");
     assert!(
-        requests
+        !requests
             .iter()
             .any(|request| request.url.path() == format!("/permission/{perm_id}/reply")),
-        "reply POST should be observed with a known request id: {:?}",
+        "reply POST must not be sent after failed revalidation: {:?}",
         requests
             .iter()
             .map(|request| request.url.path().to_string())
@@ -433,6 +423,15 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
     let perm_id = "perm-patch-post";
 
     let permission_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            permission_fixture_with_metadata(
+                perm_id,
+                sid,
+                "edit",
+                &["src/lib.rs"],
+                &serde_json::json!({"files": [patch_file_metadata_fixture()]}),
+            )
+        ])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([
             permission_fixture_with_metadata(
                 perm_id,
@@ -490,9 +489,7 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -519,7 +516,7 @@ async fn respond_permission_continues_after_reply_when_follow_up_permission_list
         result
             .warnings
             .iter()
-            .any(|warning| warning.contains("Permission refresh failed after reply")),
+            .any(|warning| warning.contains("Permission refresh failed after response")),
         "expected continuation warning, got {:?}",
         result.warnings
     );
@@ -680,6 +677,14 @@ async fn respond_permission_reply_404_is_actionable_invalid_input() {
         .mount(&mock)
         .await;
 
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
     let err = tool
         .call(
             RespondPermissionInput {
@@ -791,9 +796,7 @@ async fn command_transport_error_after_start_evidence_warns_and_completes() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -896,9 +899,7 @@ async fn command_transport_error_before_start_evidence_fails_clearly() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -1018,9 +1019,7 @@ async fn command_dispatch_posts_server_valid_message_id() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/permission_flow_wiremock.rs
@@ -189,9 +189,7 @@ async fn it_bug1_completion_retries_messages_until_visible() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)), // Long delay to let polling win
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -268,6 +266,12 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
             "file.write",
             &["/tmp/test.txt"]
         )])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            &["/tmp/test.txt"]
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
@@ -295,6 +299,14 @@ async fn it_bug2_reject_returns_none_and_warning_not_stale_text() {
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(messages_fixture(sid, Some("I_WILL_CREATE_FILE"))),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -379,6 +391,12 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
             "file.write",
             &["/tmp/out.txt"]
         )])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            &["/tmp/out.txt"]
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
@@ -413,6 +431,14 @@ async fn it_bug3_respond_permission_returns_response_without_resumption() {
             msg_before,
             msg_after,
         ))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
+        )
         .mount(&mock)
         .await;
 
@@ -475,6 +501,12 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
             "file.write",
             &["/tmp/out.txt"],
         )])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([permission_fixture(
+            perm_id,
+            sid,
+            "file.write",
+            &["/tmp/out.txt"],
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
     Mock::given(method("GET"))
@@ -503,7 +535,6 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     // 4) idle  (fixed path finalizes)
     let status_seq = SequenceResponder::new(vec![
         ResponseTemplate::new(200).set_body_json(status_v2_busy(sid)),
-        ResponseTemplate::new(200).set_body_json(status_v2_idle()),
         ResponseTemplate::new(200).set_body_json(status_v2_retry(sid, 1)),
         ResponseTemplate::new(200).set_body_json(status_v2_idle()),
     ]);
@@ -536,9 +567,7 @@ async fn it_bug5_respond_permission_waits_and_does_not_return_stale_pre_permissi
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -621,9 +650,7 @@ async fn it_bug4_command_dispatch_transport_error_does_not_retry_without_start_e
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)), // Long delay to let polling win
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
+++ b/apps/opencode-orchestrator-mcp/tests/question_flow_wiremock.rs
@@ -226,9 +226,7 @@ async fn poll_detected_question_returns_question_required() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -264,6 +262,11 @@ async fn respond_question_reply_resumes_to_completed() {
     let question_id = "question-3";
 
     let question_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
+            question_id,
+            sid,
+            &[question_payload("Continue deployment?")]
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
             question_id,
             sid,
@@ -319,9 +322,7 @@ async fn respond_question_reply_resumes_to_completed() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;
@@ -355,6 +356,11 @@ async fn respond_question_reject_completes_cleanly() {
     let question_id = "question-4";
 
     let question_seq = SequenceResponder::new(vec![
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
+            question_id,
+            sid,
+            &[question_payload("Reject this?")]
+        )])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([question_fixture(
             question_id,
             sid,
@@ -398,8 +404,16 @@ async fn respond_question_reject_completes_cleanly() {
         .mount(&mock)
         .await;
 
+    Mock::given(method("GET"))
+        .and(path("/event"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
     let result = timeout(
-        Duration::from_secs(2),
+        Duration::from_secs(4),
         tool.call(
             RespondQuestionInput {
                 session_id: sid.into(),
@@ -492,6 +506,14 @@ async fn respond_question_by_id_lookup() {
             ),
             question_fixture(question_id, sid, &[question_payload("Second question?")])
         ])),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            question_fixture(
+                "question-other",
+                sid,
+                &[question_payload("First question?")]
+            ),
+            question_fixture(question_id, sid, &[question_payload("Second question?")])
+        ])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
         ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
     ]);
@@ -543,9 +565,7 @@ async fn respond_question_by_id_lookup() {
     Mock::given(method("GET"))
         .and(path("/event"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_secs(30)),
+            ResponseTemplate::new(200).set_body_raw(support::sse_body(&[]), "text/event-stream"),
         )
         .mount(&mock)
         .await;

--- a/apps/opencode-orchestrator-mcp/tests/sse_readiness.rs
+++ b/apps/opencode-orchestrator-mcp/tests/sse_readiness.rs
@@ -1,0 +1,450 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod support;
+
+use agentic_tools_core::Tool;
+use agentic_tools_core::ToolContext;
+use agentic_tools_core::ToolError;
+use opencode_orchestrator_mcp::tools::OrchestratorRunTool;
+use opencode_orchestrator_mcp::tools::RespondPermissionTool;
+use opencode_orchestrator_mcp::tools::RespondQuestionTool;
+use opencode_orchestrator_mcp::types::OrchestratorRunInput;
+use opencode_orchestrator_mcp::types::PermissionReply;
+use opencode_orchestrator_mcp::types::QuestionAction;
+use opencode_orchestrator_mcp::types::RespondPermissionInput;
+use opencode_orchestrator_mcp::types::RespondQuestionInput;
+use opencode_orchestrator_mcp::types::RunStatus;
+use std::time::Duration;
+use support::permission_fixture;
+use support::question_fixture;
+use support::readiness_server::ReadinessServer;
+use support::readiness_server::ResponseAction;
+use tokio::time::timeout;
+
+const DEADLOCK_GUARD: Duration = Duration::from_secs(10);
+
+fn permission(id: &str, session_id: &str) -> serde_json::Value {
+    permission_fixture(id, session_id, "file.write", &["src/**"])
+}
+
+fn question(id: &str, session_id: &str) -> serde_json::Value {
+    question_fixture(
+        id,
+        session_id,
+        &[serde_json::json!({
+            "question": "Continue?",
+            "header": "Confirmation",
+            "options": [{"label": "yes", "description": "Proceed"}],
+            "multiple": false,
+            "custom": false
+        })],
+    )
+}
+
+fn ok_list(items: Vec<serde_json::Value>) -> ResponseAction {
+    ResponseAction::json(200, serde_json::Value::Array(items))
+}
+
+fn command_input(session_id: &str) -> OrchestratorRunInput {
+    OrchestratorRunInput {
+        session_id: Some(session_id.to_string()),
+        command: Some("implement_plan".to_string()),
+        agent: None,
+        message: Some("do it".to_string()),
+        wait_for_activity: None,
+    }
+}
+
+fn prompt_input(session_id: &str) -> OrchestratorRunInput {
+    OrchestratorRunInput {
+        session_id: Some(session_id.to_string()),
+        command: None,
+        agent: None,
+        message: Some("do it".to_string()),
+        wait_for_activity: None,
+    }
+}
+
+#[tokio::test]
+async fn command_dispatch_waits_for_parsed_readiness() {
+    let session_id = "command-readiness";
+    let server = ReadinessServer::start(session_id).await;
+    let tool = OrchestratorRunTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(command_input(session_id), &ToolContext::default())
+            .await
+    });
+
+    server.wait_stream_connected().await;
+    assert_eq!(server.command_count(), 0);
+    server.release_readiness();
+    server.wait_command().await;
+    assert_eq!(server.command_count(), 1);
+    run.abort();
+    let _ = run.await;
+}
+
+#[tokio::test]
+async fn prompt_dispatch_waits_for_parsed_readiness() {
+    let session_id = "prompt-readiness";
+    let server = ReadinessServer::start(session_id).await;
+    let tool = OrchestratorRunTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(prompt_input(session_id), &ToolContext::default())
+            .await
+    });
+
+    server.wait_stream_connected().await;
+    assert_eq!(server.prompt_count(), 0);
+    server.release_readiness();
+    server.wait_prompt().await;
+    assert_eq!(server.prompt_count(), 1);
+    run.abort();
+    let _ = run.await;
+}
+
+#[tokio::test]
+async fn permission_reply_surfaces_immediate_second_blocker_from_same_stream() {
+    let session_id = "permission-second";
+    let first_id = "permission-first";
+    let second_id = "permission-second";
+    let server = ReadinessServer::start(session_id).await;
+    server.push_permissions(ok_list(vec![permission(first_id, session_id)]));
+    server.push_permissions(ok_list(vec![permission(first_id, session_id)]));
+    server.push_permissions(ok_list(vec![]));
+    let tool = RespondPermissionTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(
+            RespondPermissionInput {
+                session_id: session_id.to_string(),
+                permission_request_id: Some(first_id.to_string()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+
+    server.wait_stream_connected().await;
+    assert_eq!(server.permission_response_count(), 0);
+    server.release_readiness();
+    server.wait_permission_response().await;
+    server.append_event(serde_json::json!({
+        "type": "permission.asked",
+        "properties": permission(second_id, session_id)
+    }));
+
+    let output = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("permission continuation should not deadlock")
+        .expect("permission continuation task should not panic")
+        .expect("permission continuation should succeed");
+    assert!(matches!(output.status, RunStatus::PermissionRequired));
+    assert_eq!(output.permission_request_id.as_deref(), Some(second_id));
+    assert_eq!(server.permission_response_count(), 1);
+}
+
+#[tokio::test]
+async fn question_reply_surfaces_immediate_second_blocker_from_same_stream() {
+    let session_id = "question-second";
+    let first_id = "question-first";
+    let second_id = "question-second";
+    let server = ReadinessServer::start(session_id).await;
+    server.push_questions(ok_list(vec![question(first_id, session_id)]));
+    server.push_questions(ok_list(vec![question(first_id, session_id)]));
+    server.push_questions(ok_list(vec![]));
+    let tool = RespondQuestionTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(
+            RespondQuestionInput {
+                session_id: session_id.to_string(),
+                question_request_id: Some(first_id.to_string()),
+                action: QuestionAction::Reply,
+                answers: vec![vec!["yes".to_string()]],
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+
+    server.wait_stream_connected().await;
+    assert_eq!(server.question_response_count(), 0);
+    server.release_readiness();
+    server.wait_question_response().await;
+    server.append_event(serde_json::json!({
+        "type": "question.asked",
+        "properties": question(second_id, session_id)
+    }));
+
+    let output = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("question continuation should not deadlock")
+        .expect("question continuation task should not panic")
+        .expect("question continuation should succeed");
+    assert!(matches!(output.status, RunStatus::QuestionRequired));
+    assert_eq!(output.question_request_id.as_deref(), Some(second_id));
+    assert_eq!(server.question_response_count(), 1);
+}
+
+#[tokio::test]
+async fn readiness_cancellation_prevents_dispatch() {
+    let session_id = "cancel-readiness";
+    let server = ReadinessServer::start(session_id).await;
+    let tool = OrchestratorRunTool::new(server.orchestrator_server());
+    let ctx = ToolContext::default();
+    let cancellation = ctx.cancellation_token();
+    let run = tokio::spawn(async move { tool.call(command_input(session_id), &ctx).await });
+
+    server.wait_stream_connected().await;
+    assert_eq!(server.command_count(), 0);
+    cancellation.cancel();
+    let error = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("cancelled readiness should not deadlock")
+        .expect("cancelled readiness task should not panic")
+        .expect_err("cancelled readiness should fail");
+    assert!(matches!(error, ToolError::Cancelled { .. }));
+    assert_eq!(server.command_count(), 0);
+}
+
+#[tokio::test]
+async fn readiness_timeout_prevents_dispatch() {
+    let session_id = "timeout-readiness";
+    let server = ReadinessServer::start(session_id).await;
+    let tool = OrchestratorRunTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(command_input(session_id), &ToolContext::default())
+            .await
+    });
+
+    server.wait_stream_connected().await;
+    let error = timeout(Duration::from_secs(7), run)
+        .await
+        .expect("application readiness timeout should fire")
+        .expect("readiness timeout task should not panic")
+        .expect_err("readiness timeout should fail");
+    assert!(matches!(error, ToolError::Internal(_)));
+    assert!(error.to_string().contains("not ready within 5 seconds"));
+    assert_eq!(server.command_count(), 0);
+}
+
+#[tokio::test]
+async fn stream_closure_before_readiness_fails_closed() {
+    let session_id = "closed-readiness";
+    let server = ReadinessServer::start(session_id).await;
+    let tool = OrchestratorRunTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(prompt_input(session_id), &ToolContext::default())
+            .await
+    });
+
+    server.wait_stream_connected().await;
+    server.close_stream_before_ready();
+    let error = timeout(Duration::from_secs(7), run)
+        .await
+        .expect("closed-stream readiness should terminate")
+        .expect("closed-stream task should not panic")
+        .expect_err("closed stream must fail readiness");
+    assert!(matches!(error, ToolError::Internal(_)));
+    assert_eq!(server.prompt_count(), 0);
+}
+
+#[derive(Clone, Copy)]
+enum PermissionRevalidationCase {
+    BadRequest,
+    Transport,
+    Stale,
+    Replacement,
+    WrongSession,
+}
+
+async fn assert_permission_revalidation_fails_closed(case: PermissionRevalidationCase) {
+    let session_id = "permission-revalidate";
+    let request_id = "permission-target";
+    let server = ReadinessServer::start(session_id).await;
+    server.push_permissions(ok_list(vec![permission(request_id, session_id)]));
+    server.push_permissions(match case {
+        PermissionRevalidationCase::BadRequest => {
+            ResponseAction::json(400, serde_json::json!({"message": "bad permission state"}))
+        }
+        PermissionRevalidationCase::Transport => ResponseAction::Close,
+        PermissionRevalidationCase::Stale => ok_list(vec![]),
+        PermissionRevalidationCase::Replacement => {
+            ok_list(vec![permission("permission-replacement", session_id)])
+        }
+        PermissionRevalidationCase::WrongSession => {
+            ok_list(vec![permission(request_id, "other-session")])
+        }
+    });
+    let tool = RespondPermissionTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(
+            RespondPermissionInput {
+                session_id: session_id.to_string(),
+                permission_request_id: Some(request_id.to_string()),
+                reply: PermissionReply::Once,
+                message: None,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+    server.wait_stream_connected().await;
+    server.release_readiness();
+    let error = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("permission revalidation should not deadlock")
+        .expect("permission revalidation task should not panic")
+        .expect_err("permission revalidation should fail");
+    match case {
+        PermissionRevalidationCase::Transport => assert!(matches!(error, ToolError::Internal(_))),
+        _ => assert!(matches!(error, ToolError::InvalidInput(_))),
+    }
+    assert_eq!(server.permission_response_count(), 0);
+}
+
+#[tokio::test]
+async fn permission_revalidation_failures_never_send_a_reply() {
+    for case in [
+        PermissionRevalidationCase::BadRequest,
+        PermissionRevalidationCase::Transport,
+        PermissionRevalidationCase::Stale,
+        PermissionRevalidationCase::Replacement,
+        PermissionRevalidationCase::WrongSession,
+    ] {
+        assert_permission_revalidation_fails_closed(case).await;
+    }
+}
+
+#[tokio::test]
+async fn question_revalidation_replacement_never_sends_a_response() {
+    let session_id = "question-revalidate";
+    let request_id = "question-target";
+    let server = ReadinessServer::start(session_id).await;
+    server.push_questions(ok_list(vec![question(request_id, session_id)]));
+    server.push_questions(ok_list(vec![question("question-replacement", session_id)]));
+    let tool = RespondQuestionTool::new(server.orchestrator_server());
+    let run = tokio::spawn(async move {
+        tool.call(
+            RespondQuestionInput {
+                session_id: session_id.to_string(),
+                question_request_id: Some(request_id.to_string()),
+                action: QuestionAction::Reply,
+                answers: vec![vec!["yes".to_string()]],
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+    server.wait_stream_connected().await;
+    server.release_readiness();
+    let error = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("question revalidation should not deadlock")
+        .expect("question revalidation task should not panic")
+        .expect_err("replacement question should fail revalidation");
+    assert!(matches!(error, ToolError::InvalidInput(_)));
+    assert!(error.to_string().contains("question-replacement"));
+    assert_eq!(server.question_response_count(), 0);
+}
+
+async fn assert_question_404_is_invalid_input(action: QuestionAction) {
+    let session_id = "question-404";
+    let request_id = "question-target";
+    let server = ReadinessServer::start(session_id).await;
+    server.push_questions(ok_list(vec![question(request_id, session_id)]));
+    server.push_questions(ok_list(vec![question(request_id, session_id)]));
+    server.set_question_response_status(404);
+    let tool = RespondQuestionTool::new(server.orchestrator_server());
+    let answers = if matches!(action, QuestionAction::Reply) {
+        vec![vec!["yes".to_string()]]
+    } else {
+        Vec::new()
+    };
+    let run = tokio::spawn(async move {
+        tool.call(
+            RespondQuestionInput {
+                session_id: session_id.to_string(),
+                question_request_id: Some(request_id.to_string()),
+                action,
+                answers,
+            },
+            &ToolContext::default(),
+        )
+        .await
+    });
+    server.wait_stream_connected().await;
+    server.release_readiness();
+    let error = timeout(DEADLOCK_GUARD, run)
+        .await
+        .expect("question 404 should not deadlock")
+        .expect("question 404 task should not panic")
+        .expect_err("question 404 should fail");
+    assert!(matches!(error, ToolError::InvalidInput(_)));
+    assert!(error.to_string().contains("HTTP 404"));
+    assert_eq!(server.question_response_count(), 1);
+}
+
+#[tokio::test]
+async fn question_reply_and_reject_404_are_actionable() {
+    assert_question_404_is_invalid_input(QuestionAction::Reply).await;
+    assert_question_404_is_invalid_input(QuestionAction::Reject).await;
+}
+
+#[tokio::test]
+async fn permission_and_question_rejects_wait_for_readiness() {
+    let permission_session = "permission-reject";
+    let permission_id = "permission-target";
+    let permission_server = ReadinessServer::start(permission_session).await;
+    permission_server
+        .push_permissions(ok_list(vec![permission(permission_id, permission_session)]));
+    permission_server
+        .push_permissions(ok_list(vec![permission(permission_id, permission_session)]));
+    let permission_tool = RespondPermissionTool::new(permission_server.orchestrator_server());
+    let permission_run = tokio::spawn(async move {
+        permission_tool
+            .call(
+                RespondPermissionInput {
+                    session_id: permission_session.to_string(),
+                    permission_request_id: Some(permission_id.to_string()),
+                    reply: PermissionReply::Reject,
+                    message: None,
+                },
+                &ToolContext::default(),
+            )
+            .await
+    });
+    permission_server.wait_stream_connected().await;
+    assert_eq!(permission_server.permission_response_count(), 0);
+    permission_server.release_readiness();
+    permission_server.wait_permission_response().await;
+    permission_run.abort();
+    let _ = permission_run.await;
+
+    let question_session = "question-reject";
+    let question_id = "question-target";
+    let question_server = ReadinessServer::start(question_session).await;
+    question_server.push_questions(ok_list(vec![question(question_id, question_session)]));
+    question_server.push_questions(ok_list(vec![question(question_id, question_session)]));
+    let question_tool = RespondQuestionTool::new(question_server.orchestrator_server());
+    let question_run = tokio::spawn(async move {
+        question_tool
+            .call(
+                RespondQuestionInput {
+                    session_id: question_session.to_string(),
+                    question_request_id: Some(question_id.to_string()),
+                    action: QuestionAction::Reject,
+                    answers: Vec::new(),
+                },
+                &ToolContext::default(),
+            )
+            .await
+    });
+    question_server.wait_stream_connected().await;
+    assert_eq!(question_server.question_response_count(), 0);
+    question_server.release_readiness();
+    question_server.wait_question_response().await;
+    question_run.abort();
+    let _ = question_run.await;
+}

--- a/apps/opencode-orchestrator-mcp/tests/support/mod.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/mod.rs
@@ -6,6 +6,8 @@
 #![allow(clippy::unwrap_used)]
 #![allow(dead_code)]
 
+pub mod readiness_server;
+
 use agentic_config::types::OrchestratorConfig;
 use opencode_orchestrator_mcp::server::OrchestratorServer;
 use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
@@ -204,6 +206,7 @@ impl Respond for SequenceResponder {
 #[derive(Clone, Default)]
 pub struct CommandCorrelationFixture {
     command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
+    sse_calls: Arc<AtomicUsize>,
 }
 
 impl CommandCorrelationFixture {
@@ -226,6 +229,7 @@ impl CommandCorrelationFixture {
     ) -> CommandCorrelatedSseResponder {
         CommandCorrelatedSseResponder {
             command_message_id: Arc::clone(&self.command_message_id),
+            sse_calls: Arc::clone(&self.sse_calls),
             session_id: session_id.to_string(),
             assistant_message_id: assistant_message_id.to_string(),
             delta: delta.to_string(),
@@ -258,6 +262,7 @@ impl Respond for CommandMessageIdResponder {
 #[derive(Clone)]
 pub struct CommandCorrelatedSseResponder {
     command_message_id: Arc<(Mutex<Option<String>>, Condvar)>,
+    sse_calls: Arc<AtomicUsize>,
     session_id: String,
     assistant_message_id: String,
     delta: String,
@@ -266,6 +271,10 @@ pub struct CommandCorrelatedSseResponder {
 
 impl Respond for CommandCorrelatedSseResponder {
     fn respond(&self, _request: &Request) -> ResponseTemplate {
+        if self.sse_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return ResponseTemplate::new(200).set_body_raw(sse_body(&[]), "text/event-stream");
+        }
+
         let (lock, ready) = &*self.command_message_id;
         let message_id = lock.lock().unwrap();
         let (message_id, wait) = ready
@@ -441,7 +450,7 @@ pub fn question_fixture(
 
 /// Encode typed event JSON values as an SSE response body.
 pub fn sse_body(events: &[Value]) -> String {
-    let mut body = String::new();
+    let mut body = "data: {\"type\":\"server.connected\",\"properties\":{}}\n\n".to_string();
     for event in events {
         body.push_str("data: ");
         body.push_str(&event.to_string());

--- a/apps/opencode-orchestrator-mcp/tests/support/readiness_server.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/readiness_server.rs
@@ -1,0 +1,496 @@
+#![allow(clippy::expect_used, clippy::unwrap_used, dead_code)]
+
+use agentic_config::types::OrchestratorConfig;
+use opencode_orchestrator_mcp::server::OrchestratorServer;
+use opencode_orchestrator_mcp::server::OrchestratorServerHandle;
+use opencode_orchestrator_mcp::server::RecoveryMode;
+use serde_json::Value;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU16;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::Notify;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::time::timeout;
+
+const DEADLOCK_GUARD: Duration = Duration::from_secs(10);
+
+#[derive(Clone)]
+pub enum ResponseAction {
+    Json { status: u16, body: Value },
+    Close,
+}
+
+impl ResponseAction {
+    pub fn json(status: u16, body: Value) -> Self {
+        Self::Json { status, body }
+    }
+}
+
+#[derive(Default)]
+struct ResponseSequences {
+    permissions: VecDeque<ResponseAction>,
+    questions: VecDeque<ResponseAction>,
+    statuses: VecDeque<ResponseAction>,
+    messages: VecDeque<ResponseAction>,
+}
+
+#[derive(Default)]
+struct RequestCounters {
+    event: AtomicUsize,
+    command: AtomicUsize,
+    prompt: AtomicUsize,
+    permission_response: AtomicUsize,
+    question_response: AtomicUsize,
+}
+
+struct Shared {
+    session_id: String,
+    sequences: Mutex<ResponseSequences>,
+    counters: RequestCounters,
+    stream_connected: Notify,
+    sentinel_released: AtomicBool,
+    release_sentinel: Notify,
+    permission_response: Notify,
+    question_response: Notify,
+    command_request: Notify,
+    prompt_request: Notify,
+    permission_response_status: AtomicU16,
+    question_response_status: AtomicU16,
+    close_stream_before_ready: AtomicBool,
+    events: mpsc::UnboundedSender<Value>,
+    event_rx: Mutex<Option<mpsc::UnboundedReceiver<Value>>>,
+}
+
+pub struct ReadinessServer {
+    base_url: String,
+    shared: Arc<Shared>,
+    shutdown: watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ReadinessServer {
+    pub async fn start(session_id: &str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("readiness server should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let (events, event_rx) = mpsc::unbounded_channel();
+        let shared = Arc::new(Shared {
+            session_id: session_id.to_string(),
+            sequences: Mutex::new(ResponseSequences::default()),
+            counters: RequestCounters::default(),
+            stream_connected: Notify::new(),
+            sentinel_released: AtomicBool::new(false),
+            release_sentinel: Notify::new(),
+            permission_response: Notify::new(),
+            question_response: Notify::new(),
+            command_request: Notify::new(),
+            prompt_request: Notify::new(),
+            permission_response_status: AtomicU16::new(200),
+            question_response_status: AtomicU16::new(200),
+            close_stream_before_ready: AtomicBool::new(false),
+            events,
+            event_rx: Mutex::new(Some(event_rx)),
+        });
+        let (shutdown, mut shutdown_rx) = watch::channel(false);
+        let task_shared = Arc::clone(&shared);
+        let task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    accepted = listener.accept() => {
+                        let (stream, _) = accepted.expect("readiness server should accept connections");
+                        let connection_shared = Arc::clone(&task_shared);
+                        let connection_shutdown = shutdown_rx.clone();
+                        tokio::spawn(async move {
+                            handle_connection(stream, connection_shared, connection_shutdown).await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            shared,
+            shutdown,
+            task,
+        }
+    }
+
+    pub fn orchestrator_server(&self) -> Arc<OrchestratorServerHandle> {
+        let client = opencode_rs::Client::builder()
+            .base_url(&self.base_url)
+            .directory("/tmp")
+            .timeout_secs(30)
+            .build()
+            .expect("readiness test client should build");
+        Arc::new(OrchestratorServerHandle::from_server_unshared(
+            OrchestratorServer::from_client_unshared_with_config(
+                client,
+                self.base_url.clone(),
+                RecoveryMode::External,
+                OrchestratorConfig::default(),
+            ),
+        ))
+    }
+
+    pub fn push_permissions(&self, action: ResponseAction) {
+        self.shared
+            .sequences
+            .lock()
+            .unwrap()
+            .permissions
+            .push_back(action);
+    }
+
+    pub fn push_questions(&self, action: ResponseAction) {
+        self.shared
+            .sequences
+            .lock()
+            .unwrap()
+            .questions
+            .push_back(action);
+    }
+
+    pub fn push_status(&self, action: ResponseAction) {
+        self.shared
+            .sequences
+            .lock()
+            .unwrap()
+            .statuses
+            .push_back(action);
+    }
+
+    pub fn push_messages(&self, action: ResponseAction) {
+        self.shared
+            .sequences
+            .lock()
+            .unwrap()
+            .messages
+            .push_back(action);
+    }
+
+    pub fn set_permission_response_status(&self, status: u16) {
+        self.shared
+            .permission_response_status
+            .store(status, Ordering::SeqCst);
+    }
+
+    pub fn set_question_response_status(&self, status: u16) {
+        self.shared
+            .question_response_status
+            .store(status, Ordering::SeqCst);
+    }
+
+    pub fn close_stream_before_ready(&self) {
+        self.shared
+            .close_stream_before_ready
+            .store(true, Ordering::SeqCst);
+        self.release_readiness();
+    }
+
+    pub async fn wait_stream_connected(&self) {
+        wait_for_counter(&self.shared.counters.event, &self.shared.stream_connected).await;
+    }
+
+    pub fn release_readiness(&self) {
+        self.shared.sentinel_released.store(true, Ordering::SeqCst);
+        self.shared.release_sentinel.notify_waiters();
+    }
+
+    pub fn append_event(&self, event: Value) {
+        self.shared
+            .events
+            .send(event)
+            .expect("SSE connection should remain active");
+    }
+
+    pub fn command_count(&self) -> usize {
+        self.shared.counters.command.load(Ordering::SeqCst)
+    }
+
+    pub fn prompt_count(&self) -> usize {
+        self.shared.counters.prompt.load(Ordering::SeqCst)
+    }
+
+    pub fn permission_response_count(&self) -> usize {
+        self.shared
+            .counters
+            .permission_response
+            .load(Ordering::SeqCst)
+    }
+
+    pub fn question_response_count(&self) -> usize {
+        self.shared
+            .counters
+            .question_response
+            .load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_command(&self) {
+        wait_for_counter(&self.shared.counters.command, &self.shared.command_request).await;
+    }
+
+    pub async fn wait_prompt(&self) {
+        wait_for_counter(&self.shared.counters.prompt, &self.shared.prompt_request).await;
+    }
+
+    pub async fn wait_permission_response(&self) {
+        wait_for_counter(
+            &self.shared.counters.permission_response,
+            &self.shared.permission_response,
+        )
+        .await;
+    }
+
+    pub async fn wait_question_response(&self) {
+        wait_for_counter(
+            &self.shared.counters.question_response,
+            &self.shared.question_response,
+        )
+        .await;
+    }
+}
+
+impl Drop for ReadinessServer {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(true);
+        self.task.abort();
+    }
+}
+
+async fn wait_for_counter(counter: &AtomicUsize, notification: &Notify) {
+    timeout(DEADLOCK_GUARD, async {
+        while counter.load(Ordering::SeqCst) == 0 {
+            notification.notified().await;
+        }
+    })
+    .await
+    .expect("request notification should not deadlock");
+}
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    shared: Arc<Shared>,
+    shutdown: watch::Receiver<bool>,
+) {
+    let Some((method, path)) = read_request(&mut stream).await else {
+        return;
+    };
+    if method == "GET" && path == "/event" {
+        handle_event_stream(stream, shared, shutdown).await;
+        return;
+    }
+
+    let action = route_request(&method, &path, &shared);
+    match action {
+        ResponseAction::Json { status, body } => write_json(&mut stream, status, &body).await,
+        ResponseAction::Close => {}
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 2048];
+    loop {
+        let read = stream.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let request = String::from_utf8(request).ok()?;
+    let mut parts = request.lines().next()?.split_whitespace();
+    let method = parts.next()?.to_string();
+    let path = parts.next()?.split('?').next()?.to_string();
+    Some((method, path))
+}
+
+fn route_request(method: &str, path: &str, shared: &Shared) -> ResponseAction {
+    if method == "GET" && path == "/global/health" {
+        return ResponseAction::json(200, serde_json::json!({"healthy": true, "version": "test"}));
+    }
+    if method == "GET" && path == format!("/session/{}", shared.session_id) {
+        return ResponseAction::json(
+            200,
+            serde_json::json!({
+                "id": shared.session_id,
+                "slug": shared.session_id,
+                "projectId": "project-1",
+                "directory": "/tmp",
+                "title": "Readiness test",
+                "version": "test",
+                "time": {"created": 1, "updated": 1}
+            }),
+        );
+    }
+    if method == "GET" && path == "/permission" {
+        return next_action(
+            &mut shared.sequences.lock().unwrap().permissions,
+            Value::Array(vec![]),
+        );
+    }
+    if method == "GET" && path == "/question" {
+        return next_action(
+            &mut shared.sequences.lock().unwrap().questions,
+            Value::Array(vec![]),
+        );
+    }
+    if method == "GET" && path == "/session/status" {
+        return next_action(
+            &mut shared.sequences.lock().unwrap().statuses,
+            serde_json::json!({}),
+        );
+    }
+    if method == "GET" && path.ends_with("/message") {
+        return next_action(
+            &mut shared.sequences.lock().unwrap().messages,
+            Value::Array(vec![]),
+        );
+    }
+    if method == "POST" && path.ends_with("/command") {
+        shared.counters.command.fetch_add(1, Ordering::SeqCst);
+        shared.command_request.notify_waiters();
+        return ResponseAction::json(200, serde_json::json!({}));
+    }
+    if method == "POST" && path.ends_with("/prompt_async") {
+        shared.counters.prompt.fetch_add(1, Ordering::SeqCst);
+        shared.prompt_request.notify_waiters();
+        return ResponseAction::json(204, Value::Null);
+    }
+    if method == "POST" && path.starts_with("/permission/") && path.ends_with("/reply") {
+        shared
+            .counters
+            .permission_response
+            .fetch_add(1, Ordering::SeqCst);
+        shared.permission_response.notify_waiters();
+        let status = shared.permission_response_status.load(Ordering::SeqCst);
+        return ResponseAction::json(status, serde_json::json!(status < 400));
+    }
+    if method == "POST"
+        && path.starts_with("/question/")
+        && (path.ends_with("/reply") || path.ends_with("/reject"))
+    {
+        shared
+            .counters
+            .question_response
+            .fetch_add(1, Ordering::SeqCst);
+        shared.question_response.notify_waiters();
+        let status = shared.question_response_status.load(Ordering::SeqCst);
+        return ResponseAction::json(status, serde_json::json!(status < 400));
+    }
+    ResponseAction::json(404, serde_json::json!({"message": "not found"}))
+}
+
+fn next_action(queue: &mut VecDeque<ResponseAction>, default_body: Value) -> ResponseAction {
+    queue
+        .pop_front()
+        .unwrap_or_else(|| ResponseAction::json(200, default_body))
+}
+
+async fn write_json(stream: &mut TcpStream, status: u16, body: &Value) {
+    let body = if status == 204 {
+        String::new()
+    } else {
+        body.to_string()
+    };
+    let reason = match status {
+        200 => "OK",
+        204 => "No Content",
+        400 => "Bad Request",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Test Response",
+    };
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .expect("JSON response should be writable");
+}
+
+async fn handle_event_stream(
+    mut stream: TcpStream,
+    shared: Arc<Shared>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    shared.counters.event.fetch_add(1, Ordering::SeqCst);
+    stream
+        .write_all(
+            b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncache-control: no-cache\r\nconnection: close\r\n\r\n",
+        )
+        .await
+        .expect("SSE headers should be writable");
+    stream.flush().await.expect("SSE headers should flush");
+    shared.stream_connected.notify_waiters();
+
+    while !shared.sentinel_released.load(Ordering::SeqCst) {
+        tokio::select! {
+            () = shared.release_sentinel.notified() => {}
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    return;
+                }
+            }
+        }
+    }
+    if shared.close_stream_before_ready.load(Ordering::SeqCst) {
+        return;
+    }
+    write_sse_event(
+        &mut stream,
+        &serde_json::json!({"type": "server.connected", "properties": {}}),
+    )
+    .await;
+
+    let mut events = shared
+        .event_rx
+        .lock()
+        .unwrap()
+        .take()
+        .expect("only one active SSE stream is expected");
+    loop {
+        tokio::select! {
+            event = events.recv() => {
+                let Some(event) = event else {
+                    return;
+                };
+                write_sse_event(&mut stream, &event).await;
+            }
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn write_sse_event(stream: &mut TcpStream, event: &Value) {
+    stream
+        .write_all(format!("data: {event}\n\n").as_bytes())
+        .await
+        .expect("SSE event should be writable");
+    stream.flush().await.expect("SSE event should flush");
+}

--- a/apps/opencode-orchestrator-mcp/tests/support/readiness_server.rs
+++ b/apps/opencode-orchestrator-mcp/tests/support/readiness_server.rs
@@ -276,8 +276,12 @@ impl Drop for ReadinessServer {
 
 async fn wait_for_counter(counter: &AtomicUsize, notification: &Notify) {
     timeout(DEADLOCK_GUARD, async {
-        while counter.load(Ordering::SeqCst) == 0 {
-            notification.notified().await;
+        loop {
+            let notified = notification.notified();
+            if counter.load(Ordering::SeqCst) > 0 {
+                return;
+            }
+            notified.await;
         }
     })
     .await

--- a/crates/services/opencode-rs/Cargo.toml
+++ b/crates/services/opencode-rs/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 wiremock = "0.6"
 tokio-test = "0.4"
-tokio = { version = "1", features = ["test-util"] }
+tokio = { version = "1", features = ["io-util", "net", "test-util"] }
 anyhow = "1"
 tracing-subscriber = "0.3"
 

--- a/crates/services/opencode-rs/src/sse.rs
+++ b/crates/services/opencode-rs/src/sse.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 /// Options for SSE subscription.
@@ -43,11 +44,34 @@ impl Default for SseOptions {
 /// Dropping this handle will cancel the subscription.
 pub struct SseSubscription<T> {
     rx: mpsc::Receiver<T>,
+    ready_rx: watch::Receiver<bool>,
     cancel: CancellationToken,
     _task: tokio::task::JoinHandle<()>,
 }
 
 impl<T> SseSubscription<T> {
+    /// Wait until the subscription parses its initial connection sentinel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::OpencodeError::StreamClosed`] if the subscription
+    /// worker stops before observing the sentinel.
+    pub async fn wait_ready(&mut self) -> Result<()> {
+        if *self.ready_rx.borrow() {
+            return Ok(());
+        }
+
+        loop {
+            self.ready_rx
+                .changed()
+                .await
+                .map_err(|_| crate::error::OpencodeError::StreamClosed)?;
+            if *self.ready_rx.borrow_and_update() {
+                return Ok(());
+            }
+        }
+    }
+
     /// Receive the next event.
     ///
     /// Returns `None` if the stream is closed.
@@ -112,7 +136,7 @@ impl SseSubscriber {
     ) -> Result<SseSubscription<Event>> {
         let url = format!("{}/event", self.base_url);
         let session_id = session_id.to_string();
-        self.subscribe_filtered(url, opts, move |event: &Event| {
+        self.subscribe_filtered(url, opts, Event::is_connected, move |event: &Event| {
             event.session_id() == Some(session_id.as_str())
         })
     }
@@ -127,7 +151,7 @@ impl SseSubscriber {
     /// Returns an error if the subscription cannot be created.
     pub fn subscribe(&self, opts: SseOptions) -> Result<SseSubscription<Event>> {
         let url = format!("{}/event", self.base_url);
-        self.subscribe_filtered(url, opts, |_| true)
+        self.subscribe_filtered(url, opts, Event::is_connected, |_| true)
     }
 
     /// Subscribe to global events (all directories).
@@ -141,24 +165,27 @@ impl SseSubscriber {
     /// Returns an error if the subscription cannot be created.
     pub fn subscribe_global(&self, opts: SseOptions) -> Result<SseSubscription<GlobalEvent>> {
         let url = format!("{}/global/event", self.base_url);
-        self.subscribe_filtered(url, opts, |_| true)
+        self.subscribe_filtered(url, opts, GlobalEvent::is_connected, |_| true)
     }
 
     #[expect(
         clippy::unnecessary_wraps,
         reason = "API consistency with public methods"
     )]
-    fn subscribe_filtered<T, F>(
+    fn subscribe_filtered<T, R, F>(
         &self,
         url: String,
         opts: SseOptions,
+        is_ready: R,
         should_send: F,
     ) -> Result<SseSubscription<T>>
     where
         T: serde::de::DeserializeOwned + Send + 'static,
+        R: Fn(&T) -> bool + Send + Sync + 'static,
         F: Fn(&T) -> bool + Send + Sync + 'static,
     {
         let (tx, rx) = mpsc::channel(opts.capacity);
+        let (ready_tx, ready_rx) = watch::channel(false);
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
 
@@ -168,6 +195,7 @@ impl SseSubscriber {
         let lei = Arc::clone(&self.last_event_id);
         let initial = opts.initial_interval;
         let max = opts.max_interval;
+        let is_ready = Arc::new(is_ready);
         let should_send = Arc::new(should_send);
 
         let task = tokio::spawn(async move {
@@ -181,6 +209,7 @@ impl SseSubscriber {
                 .with_jitter();
 
             let mut backoff = backoff_builder.build();
+            let mut readiness_latched = false;
 
             loop {
                 if cancel_clone.is_cancelled() {
@@ -237,6 +266,10 @@ impl SseSubscriber {
                             // Parse event
                             match serde_json::from_str::<T>(&msg.data) {
                                 Ok(ev) => {
+                                    if !readiness_latched && is_ready.as_ref()(&ev) {
+                                        ready_tx.send_replace(true);
+                                        readiness_latched = true;
+                                    }
                                     if should_send.as_ref()(&ev) && tx.send(ev).await.is_err() {
                                         es.close();
                                         return;
@@ -269,6 +302,7 @@ impl SseSubscriber {
 
         Ok(SseSubscription {
             rx,
+            ready_rx,
             cancel,
             _task: task,
         })

--- a/crates/services/opencode-rs/src/types/event.rs
+++ b/crates/services/opencode-rs/src/types/event.rs
@@ -41,6 +41,15 @@ pub enum GlobalEventPayload {
     Event(Box<Event>),
 }
 
+impl GlobalEvent {
+    pub(crate) fn is_connected(&self) -> bool {
+        matches!(
+            &self.payload,
+            GlobalEventPayload::Event(event) if event.is_connected()
+        )
+    }
+}
+
 /// Wrapper for sync payloads emitted on `/global/event`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalSyncEventPayload {

--- a/crates/services/opencode-rs/tests/sse_readiness.rs
+++ b/crates/services/opencode-rs/tests/sse_readiness.rs
@@ -1,0 +1,211 @@
+#![allow(clippy::expect_used)]
+
+use futures::FutureExt;
+use opencode_rs::Client;
+use opencode_rs::OpencodeError;
+use opencode_rs::types::Event;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::time::timeout;
+
+const DEADLOCK_GUARD: Duration = Duration::from_secs(5);
+
+enum StreamCommand {
+    Send {
+        data: String,
+        flushed: oneshot::Sender<()>,
+    },
+    Close {
+        closed: oneshot::Sender<()>,
+    },
+}
+
+struct RawSseServer {
+    base_url: String,
+    connected: watch::Receiver<bool>,
+    commands: mpsc::UnboundedSender<StreamCommand>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RawSseServer {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("raw SSE listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("raw SSE listener should have an address");
+        let (connected_tx, connected) = watch::channel(false);
+        let (commands, mut command_rx) = mpsc::unbounded_channel();
+
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("SSE client should connect");
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream
+                    .read(&mut chunk)
+                    .await
+                    .expect("request headers should be readable");
+                assert!(read > 0, "client closed before sending request headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncache-control: no-cache\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .expect("SSE response headers should be writable");
+            stream.flush().await.expect("SSE headers should flush");
+            connected_tx.send_replace(true);
+
+            while let Some(command) = command_rx.recv().await {
+                match command {
+                    StreamCommand::Send { data, flushed } => {
+                        stream
+                            .write_all(format!("data: {data}\n\n").as_bytes())
+                            .await
+                            .expect("SSE event should be writable");
+                        stream.flush().await.expect("SSE event should flush");
+                        let _ = flushed.send(());
+                    }
+                    StreamCommand::Close { closed } => {
+                        stream.shutdown().await.expect("SSE stream should close");
+                        let _ = closed.send(());
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            connected,
+            commands,
+            task,
+        }
+    }
+
+    fn client(&self) -> Client {
+        Client::builder()
+            .base_url(&self.base_url)
+            .directory("/tmp")
+            .build()
+            .expect("test client should build")
+    }
+
+    async fn wait_connected(&mut self) {
+        timeout(DEADLOCK_GUARD, async {
+            while !*self.connected.borrow() {
+                self.connected
+                    .changed()
+                    .await
+                    .expect("server connection signal should remain open");
+            }
+        })
+        .await
+        .expect("SSE client should establish the HTTP stream");
+    }
+
+    async fn send_raw(&self, data: &str) {
+        let (flushed, flushed_rx) = oneshot::channel();
+        self.commands
+            .send(StreamCommand::Send {
+                data: data.to_string(),
+                flushed,
+            })
+            .expect("SSE server task should remain active");
+        timeout(DEADLOCK_GUARD, flushed_rx)
+            .await
+            .expect("SSE event flush should not deadlock")
+            .expect("SSE event flush acknowledgment should arrive");
+    }
+
+    async fn close_stream(&self) {
+        let (closed, closed_rx) = oneshot::channel();
+        self.commands
+            .send(StreamCommand::Close { closed })
+            .expect("SSE server task should remain active");
+        timeout(DEADLOCK_GUARD, closed_rx)
+            .await
+            .expect("SSE close should not deadlock")
+            .expect("SSE close acknowledgment should arrive");
+    }
+}
+
+impl Drop for RawSseServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[tokio::test]
+async fn readiness_is_parsed_latched_and_precedes_session_filtering() {
+    let mut server = RawSseServer::start().await;
+    let mut subscription = server
+        .client()
+        .subscribe_session("session-1")
+        .expect("session subscription should be created");
+
+    server.wait_connected().await;
+    assert!(
+        subscription.wait_ready().now_or_never().is_none(),
+        "HTTP connection and headers alone must not establish readiness"
+    );
+
+    server.send_raw(r#"{"type":"server.connected""#).await;
+    assert!(
+        subscription.wait_ready().now_or_never().is_none(),
+        "malformed sentinel JSON must not establish readiness"
+    );
+
+    server
+        .send_raw(r#"{"type":"server.connected","properties":{}}"#)
+        .await;
+    timeout(DEADLOCK_GUARD, subscription.wait_ready())
+        .await
+        .expect("parsed sentinel should release readiness")
+        .expect("readiness should succeed");
+    assert!(
+        subscription.wait_ready().now_or_never().is_some(),
+        "repeated readiness waits must complete immediately"
+    );
+    assert!(
+        subscription.recv().now_or_never().is_none(),
+        "session receive must continue filtering server.connected"
+    );
+
+    server
+        .send_raw(r#"{"type":"session.idle","properties":{"sessionID":"session-1"}}"#)
+        .await;
+    let event = timeout(DEADLOCK_GUARD, subscription.recv())
+        .await
+        .expect("session event should be delivered")
+        .expect("session stream should remain open");
+    assert!(matches!(event, Event::SessionIdle { .. }));
+}
+
+#[tokio::test]
+async fn cancellation_before_readiness_returns_stream_closed() {
+    let mut server = RawSseServer::start().await;
+    let mut subscription = server
+        .client()
+        .subscribe_session("session-1")
+        .expect("session subscription should be created");
+
+    server.wait_connected().await;
+    subscription.close();
+    server.close_stream().await;
+
+    let error = timeout(DEADLOCK_GUARD, subscription.wait_ready())
+        .await
+        .expect("cancelled readiness should not deadlock")
+        .expect_err("cancelled worker must fail readiness");
+    assert!(matches!(error, OpencodeError::StreamClosed));
+}


### PR DESCRIPTION
ENG-1263: Prevent OpenCode resume side effects and command dispatch before SSE monitoring is ready. Full description follows.

<!-- BEGIN:describe_pr:autogen pr-description -->
## What problem(s) was I solving?

ENG-1263 fixes an event-loss race in request-scoped OpenCode monitoring. Constructing an `SseSubscription` previously returned as soon as its background worker was spawned, before the instance `/event` stream had parsed OpenCode's authoritative `server.connected` sentinel.

That allowed command dispatch, `prompt_async`, permission replies, or question replies to resume OpenCode before monitoring was ready. OpenCode can synchronously emit another permission or question after a response, and its SSE stream has no reliable replay IDs, so a second blocker could be missed even when polling recovery was present.

## What user-facing changes did I ship?

- OpenCode command and raw-prompt dispatch now fail closed until their request-scoped SSE monitor has parsed `server.connected`.
- Permission and question responses now preserve the original blocker target while readiness is established, reject stale/replaced/wrong-session blockers with actionable errors, and avoid sending a response when authoritative revalidation fails.
- Successful permission and question responses continue with the same server snapshot and already-ready subscription, then immediately reconcile permissions, questions, and session status before steady monitoring.
- Outer-DAG prepared invocations now wait for SSE readiness immediately before initial `/command` dispatch.
- Readiness timeout, stream-closure, and MCP cancellation paths return before the guarded side effect.

## How I implemented it

- Added `SseSubscription::wait_ready()` backed by a private, one-shot `tokio::sync::watch<bool>` latch.
  - Readiness is signaled only after successful deserialization of `server.connected`.
  - The signal occurs before session filtering, so session subscriptions become ready without exposing the server-level sentinel through `recv()`.
  - Repeated waits complete immediately, readiness does not reset during reconnects, and worker termination before readiness maps to the existing `StreamClosed` error.
- Added fixed five-second application-level readiness bounds.
  - MCP races readiness against request-context cancellation and maps cancellation separately from timeout/stream failure.
  - Outer-DAG adds contextual timeout/closure errors before command-task creation.
- Gated MCP `/command` and `/prompt_async` side effects after subscription creation and before dispatch.
- Added a prepared MCP monitoring boundary that carries the exact `Arc<OrchestratorServer>`, resolved session, ready `SseSubscription<Event>`, continuation mode, warning/baseline state, and transcript state into existing monitoring logic.
- Reordered permission and question continuations to:
  1. acquire one server snapshot;
  2. validate the requested blocker;
  3. construct the session subscription;
  4. await parsed readiness;
  5. strictly re-list and revalidate the exact blocker ID/session;
  6. send the response;
  7. continue with the same snapshot and subscription; and
  8. reconcile permissions, questions, then status immediately.
- Made pre-response revalidation fail closed, including permission-list HTTP 400 and transport failures. Missing, replaced, or wrong-session targets return `InvalidInput` without automatically answering a replacement. Question reply/reject HTTP 404 now receives the same actionable classification.
- Kept post-response reconciliation best effort: failures become warnings because the response has already succeeded, while the ready SSE subscription continues buffering events. A single immediate idle observation cannot bypass buffered SSE.
- Added raw Tokio streaming test servers and explicit barriers, notifications, counters, and channels. Tests prove zero guarded POSTs before sentinel release and append immediate second permission/question blockers to the same open stream without sleeps as ordering evidence.

### Explicit non-goals

- No persistent MCP monitor spanning requests.
- No change to the request-scoped MCP monitoring lifecycle.
- No reconnect-aware/current-connection-health readiness model; readiness is intentionally a one-shot initial latch.
- No outer-DAG owner-response readiness gate after initial dispatch.
- No shared MCP/outer-DAG monitoring state machine or broad cross-application refactor.
- No configurable or user-facing readiness timeout.
- No changes to existing SSE retry/backoff behavior.
- No unrelated OpenCode `movePath` fix.

## How to verify it

- [x] `just crate-check opencode_rs`
- [x] `just crate-test opencode_rs` — 333 passed, 45 skipped
- [x] `just crate-check opencode-orchestrator-mcp`
- [x] `just crate-test opencode-orchestrator-mcp` — 205 passed, 11 skipped
- [x] `just crate-check agentic-outer-dag-bin`
- [x] `just crate-test agentic-outer-dag-bin` — 208 passed
- [x] `just fmt-check`
- [x] `just test-ci` — 2,758 Rust tests passed, 100 skipped; 24 frontend tests passed
- [x] `just check`
- [x] `just test` — MCP schema validation passed; 2,758 Rust tests passed, 100 skipped
- [x] Deterministic SDK tests prove headers alone and malformed sentinels do not release readiness, parsed `server.connected` releases before session filtering, repeated waits are immediate, and closure before readiness returns `StreamClosed`.
- [x] Deterministic MCP tests prove command, prompt, permission, and question side effects remain at zero before readiness; immediate second permission/question blockers are surfaced from the same stream; cancellation, timeout/closure, and strict-revalidation failures remain fail closed.
- [x] Deterministic outer-DAG coverage proves initial `/command` remains at zero until sentinel release.
- [x] I ran the "check" and "test" recipes via the Just MCP tools (`tools_just_execute`) and they passed

No manual or live OpenCode validation is required for acceptance; the optional ignored live SSE test was not run.

## Description for the changelog

Prevent OpenCode command, prompt, permission, and question continuations from resuming before authoritative SSE monitoring is ready.
<!-- END:describe_pr:autogen -->
